### PR TITLE
Handle different response_type values

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -70,14 +70,11 @@ public class AuthenticationAPIClient {
     private static final String PASSWORD_KEY = "password";
     private static final String EMAIL_KEY = "email";
     private static final String PHONE_NUMBER_KEY = "phone_number";
-    private static final String USER_ID_KEY = "user_id";
-    private static final String CLIENT_ID_KEY = "clientID";
     private static final String DELEGATION_PATH = "delegation";
     private static final String ACCESS_TOKEN_PATH = "access_token";
     private static final String SIGN_UP_PATH = "signup";
     private static final String DB_CONNECTIONS_PATH = "dbconnections";
     private static final String CHANGE_PASSWORD_PATH = "change_password";
-    private static final String UNLINK_PATH = "unlink";
     private static final String PASSWORDLESS_PATH = "passwordless";
     private static final String START_PATH = "start";
     private static final String OAUTH_PATH = "oauth";
@@ -569,40 +566,6 @@ public class AuthenticationAPIClient {
 
         return new DelegationRequest<>(request)
                 .setApiType(apiType);
-    }
-
-    /**
-     * Unlink a user identity calling <a href="https://auth0.com/docs/auth-api#!#post--unlink">'/unlink'</a> endpoint
-     * Example usage:
-     * <pre><code>
-     * client.unlink("{auth0 user id}", "{user access token}")
-     *      .start(new BaseCallback<Void>() {
-     *          {@literal}Override
-     *          public void onSuccess(Void payload) {}
-     *
-     *          {@literal}Override
-     *          public void onFailure(AuthenticationException error) {}
-     *      });
-     * </code></pre>
-     *
-     * @param userId      of the identity to unlink
-     * @param accessToken of the main identity obtained after login
-     * @return a request to start
-     */
-    @SuppressWarnings("WeakerAccess")
-    public Request<Void, AuthenticationException> unlink(@NonNull String userId, @NonNull String accessToken) {
-        HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
-                .addPathSegment(UNLINK_PATH)
-                .build();
-
-        final Map<String, Object> parameters = ParameterBuilder.newBuilder()
-                .setAccessToken(accessToken)
-                .set(CLIENT_ID_KEY, getClientId())
-                .set(USER_ID_KEY, userId)
-                .asDictionary();
-
-        return factory.POST(url, client, gson, authErrorBuilder)
-                .addParameters(parameters);
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthActivity.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthActivity.java
@@ -24,6 +24,7 @@
 
 package com.auth0.android.provider;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
@@ -111,6 +112,7 @@ public class WebAuthActivity extends AppCompatActivity {
         }
     }
 
+    @SuppressLint("SetJavaScriptEnabled")
     private void startUrlLoading() {
         if (!isNetworkAvailable()) {
             renderLoadError(getString(R.string.com_auth0_lock_network_error));

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -5,8 +5,6 @@ import android.content.Intent;
 import android.net.Uri;
 
 import com.auth0.android.Auth0;
-import com.auth0.android.provider.AuthCallback;
-import com.auth0.android.provider.WebAuthProvider;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -73,7 +71,7 @@ public class WebAuthProviderTest {
 
         final WebAuthProvider instance = WebAuthProvider.getInstance();
         assertThat(instance.useBrowser(), is(true));
-        assertThat(instance.useCodeGrant(), is(true));
+        assertThat(instance.getResponseType(), is(WebAuthProvider.ResponseType.CODE));
         assertThat(instance.useFullscreen(), is(false));
         assertThat(instance.getConnection(), is(not(Matchers.isEmptyOrNullString())));
         assertThat(instance.getScope(), is(not(Matchers.isEmptyOrNullString())));
@@ -107,7 +105,7 @@ public class WebAuthProviderTest {
 
         WebAuthProvider.init(account)
                 .useBrowser(true)
-                .useCodeGrant(true)
+                .withResponseType(WebAuthProvider.ResponseType.ID_TOKEN)
                 .useFullscreen(true)
                 .withConnection(CONNECTION_NAME)
                 .withScope(SCOPE)
@@ -117,7 +115,7 @@ public class WebAuthProviderTest {
 
         final WebAuthProvider instance = WebAuthProvider.getInstance();
         assertThat(instance.useBrowser(), is(true));
-        assertThat(instance.useCodeGrant(), is(true));
+        assertThat(instance.getResponseType(), is(WebAuthProvider.ResponseType.ID_TOKEN));
         assertThat(instance.useFullscreen(), is(true));
         assertThat(instance.getConnection(), is(CONNECTION_NAME));
         assertThat(instance.getScope(), is(SCOPE));
@@ -146,7 +144,7 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldCleatInstanceAfterSuccessAuthentication() throws Exception {
+    public void shouldClearInstanceAfterSuccessAuthentication() throws Exception {
         WebAuthProvider.init(account)
                 .start(activity, callback, REQUEST_CODE);
 


### PR DESCRIPTION
The `WebAuthProvider` class already handles **code** and **token** `response_type`. This PR adds support for **id_token**. When an id_token comes, the access_token, refresh_token are empty, and the token_type can be any value.

**[WIP]: Don't require access_token & token_type when building a new `Credentials`**