### PR TITLE
Add Accept-Language Header

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'com.squareup.okhttp:mockwebserver:2.5.0'
     testCompile 'com.jayway.awaitility:awaitility:1.6.4'
-    testCompile 'org.robolectric:robolectric:3.0'
+    testCompile 'org.robolectric:robolectric:3.1'
 }
 
 def defineVersion() {

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
@@ -38,18 +38,21 @@ import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class RequestFactory {
 
     static final String AUTHORIZATION_HEADER = "Authorization";
     static final String USER_AGENT_HEADER = "User-Agent";
+    static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
     static final String CLIENT_INFO_HEADER = Telemetry.HEADER_NAME;
 
     private final HashMap<String, String> headers;
 
     public RequestFactory() {
         headers = new HashMap<>();
+        headers.put(ACCEPT_LANGUAGE_HEADER, getDefaultLanguage());
     }
 
     public RequestFactory(@NonNull String bearerToken) {
@@ -68,7 +71,7 @@ public class RequestFactory {
 
     public AuthenticationRequest authenticationPOST(HttpUrl url, OkHttpClient client, Gson gson) {
         final AuthenticationRequest request = createAuthenticationRequest(url, client, gson, "POST");
-        addMetrics((ParameterizableRequest)request);
+        addMetrics((ParameterizableRequest) request);
         return request;
     }
 
@@ -136,5 +139,10 @@ public class RequestFactory {
 
     Map<String, String> getHeaders() {
         return headers;
+    }
+
+    static String getDefaultLanguage() {
+        String language = Locale.getDefault().getLanguage();
+        return language != null ? language : "en";
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
@@ -43,10 +43,10 @@ import java.util.Map;
 
 public class RequestFactory {
 
-    static final String AUTHORIZATION_HEADER = "Authorization";
-    static final String USER_AGENT_HEADER = "User-Agent";
-    static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
-    static final String CLIENT_INFO_HEADER = Telemetry.HEADER_NAME;
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String USER_AGENT_HEADER = "User-Agent";
+    private static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
+    private static final String CLIENT_INFO_HEADER = Telemetry.HEADER_NAME;
 
     private final HashMap<String, String> headers;
 
@@ -143,6 +143,6 @@ public class RequestFactory {
 
     static String getDefaultLocale() {
         String language = Locale.getDefault().toString();
-        return language != null ? language : "en";
+        return !language.isEmpty() ? language : "en";
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
@@ -143,6 +143,6 @@ public class RequestFactory {
 
     static String getDefaultLocale() {
         String language = Locale.getDefault().toString();
-        return !language.isEmpty() ? language : "en";
+        return !language.isEmpty() ? language : "en_US";
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
@@ -52,7 +52,7 @@ public class RequestFactory {
 
     public RequestFactory() {
         headers = new HashMap<>();
-        headers.put(ACCEPT_LANGUAGE_HEADER, getDefaultLanguage());
+        headers.put(ACCEPT_LANGUAGE_HEADER, getDefaultLocale());
     }
 
     public RequestFactory(@NonNull String bearerToken) {
@@ -141,8 +141,8 @@ public class RequestFactory {
         return headers;
     }
 
-    static String getDefaultLanguage() {
-        String language = Locale.getDefault().getLanguage();
+    static String getDefaultLocale() {
+        String language = Locale.getDefault().toString();
         return language != null ? language : "en";
     }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static com.auth0.android.util.AuthenticationAPI.GENERIC_TOKEN;
@@ -113,6 +114,7 @@ public class AuthenticationAPIClientTest {
         assertThat(callback, hasPayloadOfType(Credentials.class));
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         Map<String, String> body = bodyFromRequest(request);
         assertThat(body, hasEntry("connection", MY_CONNECTION));
     }
@@ -128,6 +130,7 @@ public class AuthenticationAPIClientTest {
         assertThat(credentials, is(notNullValue()));
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         Map<String, String> body = bodyFromRequest(request);
         assertThat(body, hasEntry("connection", MY_CONNECTION));
     }
@@ -143,6 +146,7 @@ public class AuthenticationAPIClientTest {
         assertThat(callback, hasPayloadOfType(UserProfile.class));
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/tokeninfo"));
     }
 
@@ -157,6 +161,7 @@ public class AuthenticationAPIClientTest {
         assertThat(profile, is(notNullValue()));
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/tokeninfo"));
     }
 
@@ -170,6 +175,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/access_token"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -189,6 +195,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/access_token"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -208,6 +215,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -228,6 +236,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -248,6 +257,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -268,6 +278,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -288,6 +299,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -310,6 +322,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -330,6 +343,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -350,6 +364,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -370,6 +385,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -390,6 +406,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -411,6 +428,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -431,6 +449,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -451,10 +470,11 @@ public class AuthenticationAPIClientTest {
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, SUPPORT, MY_CONNECTION)
                 .start(callback);
 
-        final RecordedRequest createRequest = mockAPI.takeRequest();
-        assertThat(createRequest.getPath(), equalTo("/dbconnections/signup"));
+        final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
-        Map<String, String> body = bodyFromRequest(createRequest);
+        Map<String, String> body = bodyFromRequest(request);
         assertThat(body, hasEntry("email", SUPPORT_AUTH0_COM));
         assertThat(body, hasEntry("username", SUPPORT));
         assertThat(body, hasEntry("password", PASSWORD));
@@ -489,6 +509,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -514,6 +535,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -545,6 +567,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -567,6 +590,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -587,6 +611,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -605,6 +630,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -622,6 +648,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -641,6 +668,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -659,6 +687,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -679,6 +708,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -699,6 +729,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -719,6 +750,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -741,6 +773,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -763,6 +796,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -783,6 +817,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -803,6 +838,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -830,6 +866,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -856,6 +893,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -874,6 +912,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -894,6 +933,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -913,6 +953,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -931,6 +972,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -951,6 +993,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -970,6 +1013,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -988,6 +1032,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1008,6 +1053,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1027,6 +1073,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1045,6 +1092,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1065,6 +1113,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1084,6 +1133,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1102,6 +1152,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1122,6 +1173,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1141,6 +1193,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1159,6 +1212,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1179,6 +1233,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1198,6 +1253,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1282,5 +1338,10 @@ public class AuthenticationAPIClientTest {
         final Type mapType = new TypeToken<Map<String, String>>() {
         }.getType();
         return gson.fromJson(request.getBody().readUtf8(), mapType);
+    }
+
+    private String getDefaultLanguage() {
+        String language = Locale.getDefault().getLanguage();
+        return language != null ? language : "en";
     }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -114,7 +114,7 @@ public class AuthenticationAPIClientTest {
         assertThat(callback, hasPayloadOfType(Credentials.class));
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         Map<String, String> body = bodyFromRequest(request);
         assertThat(body, hasEntry("connection", MY_CONNECTION));
     }
@@ -130,7 +130,7 @@ public class AuthenticationAPIClientTest {
         assertThat(credentials, is(notNullValue()));
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         Map<String, String> body = bodyFromRequest(request);
         assertThat(body, hasEntry("connection", MY_CONNECTION));
     }
@@ -146,7 +146,7 @@ public class AuthenticationAPIClientTest {
         assertThat(callback, hasPayloadOfType(UserProfile.class));
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/tokeninfo"));
     }
 
@@ -161,7 +161,7 @@ public class AuthenticationAPIClientTest {
         assertThat(profile, is(notNullValue()));
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/tokeninfo"));
     }
 
@@ -175,7 +175,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/access_token"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -195,7 +195,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/access_token"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -215,7 +215,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -236,7 +236,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -257,7 +257,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -278,7 +278,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -299,7 +299,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -322,7 +322,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -343,7 +343,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -364,7 +364,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -385,7 +385,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -406,7 +406,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -428,7 +428,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -449,7 +449,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -471,7 +471,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -509,7 +509,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -535,7 +535,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -567,7 +567,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -590,7 +590,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -611,7 +611,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -630,7 +630,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -648,7 +648,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -668,7 +668,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -687,7 +687,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -708,7 +708,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -729,7 +729,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -750,7 +750,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -773,7 +773,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -796,7 +796,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -817,7 +817,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -838,7 +838,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -866,7 +866,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -893,7 +893,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -912,7 +912,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -933,7 +933,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -953,7 +953,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -972,7 +972,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -993,7 +993,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1013,7 +1013,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1032,7 +1032,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1053,7 +1053,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1073,7 +1073,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1092,7 +1092,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1113,7 +1113,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1133,7 +1133,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1152,7 +1152,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1173,7 +1173,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1193,7 +1193,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1212,7 +1212,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1233,7 +1233,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1253,7 +1253,7 @@ public class AuthenticationAPIClientTest {
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -1340,8 +1340,8 @@ public class AuthenticationAPIClientTest {
         return gson.fromJson(request.getBody().readUtf8(), mapType);
     }
 
-    private String getDefaultLanguage() {
-        String language = Locale.getDefault().getLanguage();
+    private String getDefaultLocale() {
+        String language = Locale.getDefault().toString();
         return language != null ? language : "en";
     }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -1342,6 +1342,6 @@ public class AuthenticationAPIClientTest {
 
     private String getDefaultLocale() {
         String language = Locale.getDefault().toString();
-        return language != null ? language : "en";
+        return !language.isEmpty() ? language : "en";
     }
 }

--- a/auth0/src/test/java/com/auth0/android/request/internal/AuthenticationRequestMatcher.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/AuthenticationRequestMatcher.java
@@ -7,6 +7,10 @@ import org.hamcrest.Description;
 
 public class AuthenticationRequestMatcher<T> extends BaseMatcher<MockAuthenticationRequest> {
 
+    private static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
+    private static final String CLIENT_INFO_HEADER = "Auth0-Client";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String USER_AGENT_HEADER = "User-Agent";
     private final boolean checkHeaders;
     private String acceptLanguageValue;
     private String clientInfoValue;
@@ -46,11 +50,11 @@ public class AuthenticationRequestMatcher<T> extends BaseMatcher<MockAuthenticat
     public void describeTo(Description description) {
         if (checkHeaders) {
             description.appendText(String.format("to have headers: (%s) with value (%s), (%s) with value (%s), (%s) with value (%s)",
-                    RequestFactory.ACCEPT_LANGUAGE_HEADER, acceptLanguageValue,
-                    RequestFactory.CLIENT_INFO_HEADER, clientInfoValue,
-                    RequestFactory.USER_AGENT_HEADER, userAgentValue));
+                    ACCEPT_LANGUAGE_HEADER, acceptLanguageValue,
+                    CLIENT_INFO_HEADER, clientInfoValue,
+                    USER_AGENT_HEADER, userAgentValue));
             if (authorizationValue != null) {
-                description.appendText(String.format(", (%s) with value (%s)", RequestFactory.AUTHORIZATION_HEADER, authorizationValue));
+                description.appendText(String.format(", (%s) with value (%s)", AUTHORIZATION_HEADER, authorizationValue));
             }
             return;
         }
@@ -69,12 +73,12 @@ public class AuthenticationRequestMatcher<T> extends BaseMatcher<MockAuthenticat
 
         if (checkHeaders) {
             description.appendText(String.format("header (%s) was (%s), (%s) was (%s), (%s) was (%s)",
-                    RequestFactory.ACCEPT_LANGUAGE_HEADER, getHeaderValue(request, RequestFactory.ACCEPT_LANGUAGE_HEADER),
-                    RequestFactory.CLIENT_INFO_HEADER, getHeaderValue(request, RequestFactory.CLIENT_INFO_HEADER),
-                    RequestFactory.USER_AGENT_HEADER, getHeaderValue(request, RequestFactory.USER_AGENT_HEADER)));
+                    ACCEPT_LANGUAGE_HEADER, getHeaderValue(request, ACCEPT_LANGUAGE_HEADER),
+                    CLIENT_INFO_HEADER, getHeaderValue(request, CLIENT_INFO_HEADER),
+                    USER_AGENT_HEADER, getHeaderValue(request, USER_AGENT_HEADER)));
             if (authorizationValue != null) {
                 description.appendText(String.format(", (%s) was (%s)",
-                        RequestFactory.AUTHORIZATION_HEADER, getHeaderValue(request, RequestFactory.AUTHORIZATION_HEADER)));
+                        AUTHORIZATION_HEADER, getHeaderValue(request, AUTHORIZATION_HEADER)));
             }
             return;
         }
@@ -104,19 +108,19 @@ public class AuthenticationRequestMatcher<T> extends BaseMatcher<MockAuthenticat
     }
 
     private boolean hasAcceptLanguageHeader(MockAuthenticationRequest request) {
-        return objectEquals(acceptLanguageValue, getHeaderValue(request, RequestFactory.ACCEPT_LANGUAGE_HEADER));
+        return objectEquals(acceptLanguageValue, getHeaderValue(request, ACCEPT_LANGUAGE_HEADER));
     }
 
     private boolean hasAuthorizationHeader(MockAuthenticationRequest request) {
-        return objectEquals(authorizationValue, getHeaderValue(request, RequestFactory.AUTHORIZATION_HEADER));
+        return objectEquals(authorizationValue, getHeaderValue(request, AUTHORIZATION_HEADER));
     }
 
     private boolean hasUserAgentHeader(MockAuthenticationRequest request) {
-        return objectEquals(userAgentValue, getHeaderValue(request, RequestFactory.USER_AGENT_HEADER));
+        return objectEquals(userAgentValue, getHeaderValue(request, USER_AGENT_HEADER));
     }
 
     private boolean hasClientInfoHeader(MockAuthenticationRequest request) {
-        return objectEquals(clientInfoValue, getHeaderValue(request, RequestFactory.CLIENT_INFO_HEADER));
+        return objectEquals(clientInfoValue, getHeaderValue(request, CLIENT_INFO_HEADER));
     }
 
     private String getHeaderValue(MockAuthenticationRequest request, String name) {

--- a/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
@@ -5,6 +5,7 @@ import com.auth0.android.Auth0Exception;
 import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.request.ErrorBuilder;
 import com.auth0.android.request.ParameterizableRequest;
+import com.auth0.android.util.Telemetry;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.HttpUrl;
@@ -15,6 +16,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Locale;
 import java.util.Map;
 
 import static com.auth0.android.request.internal.RequestMatcher.hasArguments;
@@ -29,10 +31,10 @@ public class RequestFactoryTest {
     private static final String METHOD_POST = "POST";
     private static final String METHOD_PATCH = "PATCH";
     private static final String METHOD_DELETE = "DELETE";
-    public static final String CLIENT_INFO = "client_info";
-    public static final String USER_AGENT = "user_agent";
-    public static final String TOKEN = "token";
-    public static final String BEARER_PREFIX = "Bearer ";
+    private static final String CLIENT_INFO = "client_info";
+    private static final String USER_AGENT = "user_agent";
+    private static final String TOKEN = "token";
+    private static final String BEARER_PREFIX = "Bearer ";
     private RequestFactory factory;
 
     @Mock
@@ -62,7 +64,7 @@ public class RequestFactoryTest {
         final RequestFactory factory = new RequestFactory();
 
         assertThat(factory.getHeaders().size(), is(1));
-        assertThat(factory.getHeaders().get(RequestFactory.ACCEPT_LANGUAGE_HEADER), is(equalTo(RequestFactory.getDefaultLocale())));
+        assertThat(factory.getHeaders().get("Accept-Language"), is(equalTo(RequestFactory.getDefaultLocale())));
     }
 
     @Test
@@ -71,7 +73,7 @@ public class RequestFactoryTest {
 
         factory.setClientInfo(CLIENT_INFO);
         assertThat(factory.getHeaders().size(), is(2));
-        assertThat(factory.getHeaders().get(RequestFactory.CLIENT_INFO_HEADER), is(equalTo(CLIENT_INFO)));
+        assertThat(factory.getHeaders().get("Auth0-Client"), is(equalTo(CLIENT_INFO)));
     }
 
     @Test
@@ -80,7 +82,7 @@ public class RequestFactoryTest {
 
         factory.setUserAgent(USER_AGENT);
         assertThat(factory.getHeaders().size(), is(2));
-        assertThat(factory.getHeaders().get(RequestFactory.USER_AGENT_HEADER), is(equalTo(USER_AGENT)));
+        assertThat(factory.getHeaders().get("User-Agent"), is(equalTo(USER_AGENT)));
     }
 
     @Test
@@ -88,7 +90,7 @@ public class RequestFactoryTest {
         final RequestFactory factory = new RequestFactory(TOKEN);
 
         assertThat(factory.getHeaders().size(), is(2));
-        assertThat(factory.getHeaders().get(RequestFactory.AUTHORIZATION_HEADER), is(equalTo(BEARER_PREFIX + TOKEN)));
+        assertThat(factory.getHeaders().get("Authorization"), is(equalTo(BEARER_PREFIX + TOKEN)));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
@@ -168,6 +168,13 @@ public class RequestFactoryTest {
         assertThat(RequestFactory.getDefaultLocale(), is("es_CL"));
     }
 
+    @Test
+    public void shouldAlwaysReturnValidLocale() throws Exception {
+        final Locale locale = new Locale("");
+        Locale.setDefault(locale);
+        assertThat(RequestFactory.getDefaultLocale(), is("en_US"));
+    }
+
     private <T> TypeToken<T> createTypeToken() {
         return new TypeToken<T>() {
         };

--- a/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
@@ -5,7 +5,6 @@ import com.auth0.android.Auth0Exception;
 import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.request.ErrorBuilder;
 import com.auth0.android.request.ParameterizableRequest;
-import com.auth0.android.util.Telemetry;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.HttpUrl;
@@ -156,6 +155,17 @@ public class RequestFactoryTest {
         assertThat(request, is(notNullValue()));
         assertThat(request, hasHeaders(RequestFactory.getDefaultLocale(), CLIENT_INFO, USER_AGENT));
         assertThat(request, RequestMatcher.hasArguments(url, METHOD_DELETE, typeToken));
+    }
+
+    @Test
+    public void shouldGetDefaultLocale() throws Exception {
+        final Locale localeJP = new Locale("ja", "JP");
+        Locale.setDefault(localeJP);
+        assertThat(RequestFactory.getDefaultLocale(), is("ja_JP"));
+
+        final Locale localeCL = new Locale("es", "CL");
+        Locale.setDefault(localeCL);
+        assertThat(RequestFactory.getDefaultLocale(), is("es_CL"));
     }
 
     private <T> TypeToken<T> createTypeToken() {

--- a/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
@@ -10,7 +10,6 @@ import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -22,7 +21,6 @@ import static com.auth0.android.request.internal.RequestMatcher.hasArguments;
 import static com.auth0.android.request.internal.RequestMatcher.hasHeaders;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -64,7 +62,7 @@ public class RequestFactoryTest {
         final RequestFactory factory = new RequestFactory();
 
         assertThat(factory.getHeaders().size(), is(1));
-        assertThat(factory.getHeaders().get(RequestFactory.ACCEPT_LANGUAGE_HEADER), is(equalTo(RequestFactory.getDefaultLanguage())));
+        assertThat(factory.getHeaders().get(RequestFactory.ACCEPT_LANGUAGE_HEADER), is(equalTo(RequestFactory.getDefaultLocale())));
     }
 
     @Test
@@ -98,7 +96,7 @@ public class RequestFactoryTest {
         final MockAuthenticationRequest request = (MockAuthenticationRequest) factory.authenticationPOST(url, client, gson);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, AuthenticationRequestMatcher.hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
+        assertThat(request, AuthenticationRequestMatcher.hasHeaders(RequestFactory.getDefaultLocale(), CLIENT_INFO, USER_AGENT));
         assertThat(request, AuthenticationRequestMatcher.hasArguments(url, METHOD_POST));
     }
 
@@ -107,7 +105,7 @@ public class RequestFactoryTest {
         ParameterizableRequest<Auth0, Auth0Exception> request = factory.POST(url, client, gson, Auth0.class, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLocale(), CLIENT_INFO, USER_AGENT));
         assertThat(request, RequestMatcher.hasArguments(url, METHOD_POST, Auth0.class));
     }
 
@@ -117,7 +115,7 @@ public class RequestFactoryTest {
         final ParameterizableRequest<Auth0, Auth0Exception> request = factory.POST(url, client, gson, typeToken, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLocale(), CLIENT_INFO, USER_AGENT));
         assertThat(request, RequestMatcher.hasArguments(url, METHOD_POST, typeToken));
     }
 
@@ -126,7 +124,7 @@ public class RequestFactoryTest {
         final ParameterizableRequest<Void, Auth0Exception> request = factory.POST(url, client, gson, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLocale(), CLIENT_INFO, USER_AGENT));
         assertThat(request, hasArguments(url, METHOD_POST));
     }
 
@@ -135,7 +133,7 @@ public class RequestFactoryTest {
         final ParameterizableRequest<Map<String, Object>, Auth0Exception> request = factory.rawPOST(url, client, gson, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLocale(), CLIENT_INFO, USER_AGENT));
         assertThat(request, hasArguments(url, METHOD_POST));
     }
 
@@ -144,7 +142,7 @@ public class RequestFactoryTest {
         final ParameterizableRequest<Auth0, Auth0Exception> request = factory.PATCH(url, client, gson, Auth0.class, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLocale(), CLIENT_INFO, USER_AGENT));
         assertThat(request, RequestMatcher.hasArguments(url, METHOD_PATCH, Auth0.class));
     }
 
@@ -154,7 +152,7 @@ public class RequestFactoryTest {
         final ParameterizableRequest<Auth0, Auth0Exception> request = factory.DELETE(url, client, gson, typeToken, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLocale(), CLIENT_INFO, USER_AGENT));
         assertThat(request, RequestMatcher.hasArguments(url, METHOD_DELETE, typeToken));
     }
 

--- a/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
@@ -10,6 +10,7 @@ import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -21,6 +22,7 @@ import static com.auth0.android.request.internal.RequestMatcher.hasArguments;
 import static com.auth0.android.request.internal.RequestMatcher.hasHeaders;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -58,11 +60,19 @@ public class RequestFactoryTest {
     }
 
     @Test
+    public void shouldHaveAcceptLanguageHeader() throws Exception {
+        final RequestFactory factory = new RequestFactory();
+
+        assertThat(factory.getHeaders().size(), is(1));
+        assertThat(factory.getHeaders().get(RequestFactory.ACCEPT_LANGUAGE_HEADER), is(equalTo(RequestFactory.getDefaultLanguage())));
+    }
+
+    @Test
     public void shouldHaveClientInfoHeader() throws Exception {
         final RequestFactory factory = new RequestFactory();
 
         factory.setClientInfo(CLIENT_INFO);
-        assertThat(factory.getHeaders().size(), is(1));
+        assertThat(factory.getHeaders().size(), is(2));
         assertThat(factory.getHeaders().get(RequestFactory.CLIENT_INFO_HEADER), is(equalTo(CLIENT_INFO)));
     }
 
@@ -71,7 +81,7 @@ public class RequestFactoryTest {
         final RequestFactory factory = new RequestFactory();
 
         factory.setUserAgent(USER_AGENT);
-        assertThat(factory.getHeaders().size(), is(1));
+        assertThat(factory.getHeaders().size(), is(2));
         assertThat(factory.getHeaders().get(RequestFactory.USER_AGENT_HEADER), is(equalTo(USER_AGENT)));
     }
 
@@ -79,7 +89,7 @@ public class RequestFactoryTest {
     public void shouldHaveAuthorizationHeader() throws Exception {
         final RequestFactory factory = new RequestFactory(TOKEN);
 
-        assertThat(factory.getHeaders().size(), is(1));
+        assertThat(factory.getHeaders().size(), is(2));
         assertThat(factory.getHeaders().get(RequestFactory.AUTHORIZATION_HEADER), is(equalTo(BEARER_PREFIX + TOKEN)));
     }
 
@@ -88,7 +98,7 @@ public class RequestFactoryTest {
         final MockAuthenticationRequest request = (MockAuthenticationRequest) factory.authenticationPOST(url, client, gson);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, AuthenticationRequestMatcher.hasHeaders(CLIENT_INFO, USER_AGENT));
+        assertThat(request, AuthenticationRequestMatcher.hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
         assertThat(request, AuthenticationRequestMatcher.hasArguments(url, METHOD_POST));
     }
 
@@ -97,7 +107,7 @@ public class RequestFactoryTest {
         ParameterizableRequest<Auth0, Auth0Exception> request = factory.POST(url, client, gson, Auth0.class, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
         assertThat(request, RequestMatcher.hasArguments(url, METHOD_POST, Auth0.class));
     }
 
@@ -107,7 +117,7 @@ public class RequestFactoryTest {
         final ParameterizableRequest<Auth0, Auth0Exception> request = factory.POST(url, client, gson, typeToken, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
         assertThat(request, RequestMatcher.hasArguments(url, METHOD_POST, typeToken));
     }
 
@@ -116,7 +126,7 @@ public class RequestFactoryTest {
         final ParameterizableRequest<Void, Auth0Exception> request = factory.POST(url, client, gson, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
         assertThat(request, hasArguments(url, METHOD_POST));
     }
 
@@ -125,7 +135,7 @@ public class RequestFactoryTest {
         final ParameterizableRequest<Map<String, Object>, Auth0Exception> request = factory.rawPOST(url, client, gson, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
         assertThat(request, hasArguments(url, METHOD_POST));
     }
 
@@ -134,7 +144,7 @@ public class RequestFactoryTest {
         final ParameterizableRequest<Auth0, Auth0Exception> request = factory.PATCH(url, client, gson, Auth0.class, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
         assertThat(request, RequestMatcher.hasArguments(url, METHOD_PATCH, Auth0.class));
     }
 
@@ -144,7 +154,7 @@ public class RequestFactoryTest {
         final ParameterizableRequest<Auth0, Auth0Exception> request = factory.DELETE(url, client, gson, typeToken, builder);
 
         assertThat(request, is(notNullValue()));
-        assertThat(request, hasHeaders(CLIENT_INFO, USER_AGENT));
+        assertThat(request, hasHeaders(RequestFactory.getDefaultLanguage(), CLIENT_INFO, USER_AGENT));
         assertThat(request, RequestMatcher.hasArguments(url, METHOD_DELETE, typeToken));
     }
 

--- a/auth0/src/test/java/com/auth0/android/request/internal/RequestMatcher.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/RequestMatcher.java
@@ -8,6 +8,10 @@ import org.hamcrest.Description;
 
 public class RequestMatcher<T> extends BaseMatcher<MockRequest> {
 
+    private static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
+    private static final String CLIENT_INFO_HEADER = "Auth0-Client";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String USER_AGENT_HEADER = "User-Agent";
     private final boolean checkHeaders;
     private String acceptLanguageValue;
     private String clientInfoValue;
@@ -63,11 +67,11 @@ public class RequestMatcher<T> extends BaseMatcher<MockRequest> {
     public void describeTo(Description description) {
         if (checkHeaders) {
             description.appendText(String.format("to have headers: (%s) with value (%s), (%s) with value (%s), (%s) with value (%s)",
-                    RequestFactory.ACCEPT_LANGUAGE_HEADER, acceptLanguageValue,
-                    RequestFactory.CLIENT_INFO_HEADER, clientInfoValue,
-                    RequestFactory.USER_AGENT_HEADER, userAgentValue));
+                    ACCEPT_LANGUAGE_HEADER, acceptLanguageValue,
+                    CLIENT_INFO_HEADER, clientInfoValue,
+                    USER_AGENT_HEADER, userAgentValue));
             if (authorizationValue != null) {
-                description.appendText(String.format(", (%s) with value (%s)", RequestFactory.AUTHORIZATION_HEADER, authorizationValue));
+                description.appendText(String.format(", (%s) with value (%s)", AUTHORIZATION_HEADER, authorizationValue));
             }
             return;
         }
@@ -94,12 +98,12 @@ public class RequestMatcher<T> extends BaseMatcher<MockRequest> {
 
         if (checkHeaders) {
             description.appendText(String.format("header (%s) was (%s), (%s) was (%s), (%s) was (%s)",
-                    RequestFactory.ACCEPT_LANGUAGE_HEADER, getHeaderValue(request, RequestFactory.ACCEPT_LANGUAGE_HEADER),
-                    RequestFactory.CLIENT_INFO_HEADER, getHeaderValue(request, RequestFactory.CLIENT_INFO_HEADER),
-                    RequestFactory.USER_AGENT_HEADER, getHeaderValue(request, RequestFactory.USER_AGENT_HEADER)));
+                    ACCEPT_LANGUAGE_HEADER, getHeaderValue(request, ACCEPT_LANGUAGE_HEADER),
+                    CLIENT_INFO_HEADER, getHeaderValue(request, CLIENT_INFO_HEADER),
+                    USER_AGENT_HEADER, getHeaderValue(request, USER_AGENT_HEADER)));
             if (authorizationValue != null) {
                 description.appendText(String.format(", (%s) was (%s)",
-                        RequestFactory.AUTHORIZATION_HEADER, getHeaderValue(request, RequestFactory.AUTHORIZATION_HEADER)));
+                        AUTHORIZATION_HEADER, getHeaderValue(request, AUTHORIZATION_HEADER)));
             }
             return;
         }
@@ -139,19 +143,19 @@ public class RequestMatcher<T> extends BaseMatcher<MockRequest> {
     }
 
     private boolean hasAcceptLanguageHeader(MockRequest request) {
-        return objectEquals(acceptLanguageValue, getHeaderValue(request, RequestFactory.ACCEPT_LANGUAGE_HEADER));
+        return objectEquals(acceptLanguageValue, getHeaderValue(request, ACCEPT_LANGUAGE_HEADER));
     }
 
     private boolean hasAuthorizationHeader(MockRequest request) {
-        return objectEquals(authorizationValue, getHeaderValue(request, RequestFactory.AUTHORIZATION_HEADER));
+        return objectEquals(authorizationValue, getHeaderValue(request, AUTHORIZATION_HEADER));
     }
 
     private boolean hasUserAgentHeader(MockRequest request) {
-        return objectEquals(userAgentValue, getHeaderValue(request, RequestFactory.USER_AGENT_HEADER));
+        return objectEquals(userAgentValue, getHeaderValue(request, USER_AGENT_HEADER));
     }
 
     private boolean hasClientInfoHeader(MockRequest request) {
-        return objectEquals(clientInfoValue, getHeaderValue(request, RequestFactory.CLIENT_INFO_HEADER));
+        return objectEquals(clientInfoValue, getHeaderValue(request, CLIENT_INFO_HEADER));
     }
 
     private String getHeaderValue(MockRequest request, String name) {


### PR DESCRIPTION
Applies to all AuthenticationAPIClient calls. If the language is not found/available, then it will default to "en".