### PR TITLE
Remove unlink method from the AuthenticationAPIClient

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -54,7 +54,7 @@ import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_PASSW
 
 /**
  * API client for Auth0 Authentication API.
- * <p/>
+ * <p>
  * <pre><code>
  * Auth0 auth0 = new Auth0("your_client_id", "your_domain");
  * AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
@@ -70,14 +70,11 @@ public class AuthenticationAPIClient {
     private static final String PASSWORD_KEY = "password";
     private static final String EMAIL_KEY = "email";
     private static final String PHONE_NUMBER_KEY = "phone_number";
-    private static final String USER_ID_KEY = "user_id";
-    private static final String CLIENT_ID_KEY = "clientID";
     private static final String DELEGATION_PATH = "delegation";
     private static final String ACCESS_TOKEN_PATH = "access_token";
     private static final String SIGN_UP_PATH = "signup";
     private static final String DB_CONNECTIONS_PATH = "dbconnections";
     private static final String CHANGE_PASSWORD_PATH = "change_password";
-    private static final String UNLINK_PATH = "unlink";
     private static final String PASSWORDLESS_PATH = "passwordless";
     private static final String START_PATH = "start";
     private static final String OAUTH_PATH = "oauth";
@@ -572,40 +569,6 @@ public class AuthenticationAPIClient {
     }
 
     /**
-     * Unlink a user identity calling <a href="https://auth0.com/docs/auth-api#!#post--unlink">'/unlink'</a> endpoint
-     * Example usage:
-     * <pre><code>
-     * client.unlink("{auth0 user id}", "{user access token}")
-     *      .start(new BaseCallback<Void>() {
-     *          {@literal}Override
-     *          public void onSuccess(Void payload) {}
-     *
-     *          {@literal}Override
-     *          public void onFailure(AuthenticationException error) {}
-     *      });
-     * </code></pre>
-     *
-     * @param userId      of the identity to unlink
-     * @param accessToken of the main identity obtained after login
-     * @return a request to start
-     */
-    @SuppressWarnings("WeakerAccess")
-    public Request<Void, AuthenticationException> unlink(@NonNull String userId, @NonNull String accessToken) {
-        HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
-                .addPathSegment(UNLINK_PATH)
-                .build();
-
-        final Map<String, Object> parameters = ParameterBuilder.newBuilder()
-                .setAccessToken(accessToken)
-                .set(CLIENT_ID_KEY, getClientId())
-                .set(USER_ID_KEY, userId)
-                .asDictionary();
-
-        return factory.POST(url, client, gson, authErrorBuilder)
-                .addParameters(parameters);
-    }
-
-    /**
      * Start a passwordless flow with <a href="https://auth0.com/docs/auth-api#!#post--with_email">Email</a>
      * Example usage:
      * <pre><code>
@@ -793,10 +756,10 @@ public class AuthenticationAPIClient {
 
     /**
      * Fetch the token information from Auth0, using the authorization_code grant type
-     * <p/>
+     * <p>
      * For Public Client, e.g. Android apps ,you need to provide the code_verifier
      * used to generate the challenge sent to Auth0 {@literal /authorize} method like:
-     * <p/>
+     * <p>
      * <pre>{@code
      * AuthenticationAPIClient client = new AuthenticationAPIClient(new Auth0("clientId", "domain"));
      * client
@@ -804,9 +767,9 @@ public class AuthenticationAPIClient {
      *     .setCodeVerifier("code_verifier")
      *     .start(new Callback<Credentials> {...});
      * }</pre>
-     * <p/>
+     * <p>
      * For the rest of clients, clients who can safely keep a {@literal client_secret}, you need to provide it instead like:
-     * <p/>
+     * <p>
      * <pre>{@code
      * AuthenticationAPIClient client = new AuthenticationAPIClient(new Auth0("clientId", "domain"));
      * client


### PR DESCRIPTION
This method is currently implemented in the `UsersAPIClient` class