### PR TITLE
Fix callback URI bug that included double backslash

### DIFF
--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
@@ -30,6 +30,7 @@ import com.auth0.android.authentication.ParameterBuilder;
 import com.auth0.android.request.ErrorBuilder;
 import com.auth0.android.request.Request;
 import com.auth0.android.request.internal.GsonProvider;
+import com.auth0.android.request.internal.ManagementErrorBuilder;
 import com.auth0.android.request.internal.RequestFactory;
 import com.auth0.android.result.UserIdentity;
 import com.auth0.android.result.UserProfile;

--- a/auth0/src/main/java/com/auth0/android/provider/CallbackHelper.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CallbackHelper.java
@@ -28,13 +28,14 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
+import com.squareup.okhttp.HttpUrl;
+
 import java.util.HashMap;
 import java.util.Map;
 
 class CallbackHelper {
 
     private static final String TAG = CallbackHelper.class.getSimpleName();
-    private static final String REDIRECT_URI_FORMAT = "%s/android/%s/callback";
     private final String packageName;
 
     public CallbackHelper(@NonNull String packageName) {
@@ -47,9 +48,19 @@ class CallbackHelper {
      * @return the callback URI.
      */
     public String getCallbackURI(@NonNull String domain) {
-        String uri = String.format(REDIRECT_URI_FORMAT, domain, packageName);
-        Log.v(TAG, "The Callback URI is: " + uri);
-        return uri;
+        HttpUrl url = HttpUrl.parse(domain);
+        if (url == null) {
+            Log.e(TAG, "The Domain is invalid and the Callback URI will not be set. You used: " + domain);
+            return null;
+        }
+        url = url.newBuilder()
+                .addPathSegment("android")
+                .addPathSegment(packageName)
+                .addPathSegment("callback")
+                .build();
+
+        Log.v(TAG, "The Callback URI is: " + url);
+        return url.toString();
     }
 
     public Map<String, String> getValuesFromUri(@NonNull Uri uri) {

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.java
@@ -24,6 +24,8 @@
 
 package com.auth0.android.request.internal;
 
+import android.support.annotation.VisibleForTesting;
+
 import com.auth0.android.Auth0Exception;
 import com.auth0.android.RequestBodyBuildException;
 import com.auth0.android.authentication.ParameterBuilder;
@@ -53,10 +55,10 @@ abstract class BaseRequest<T, U extends Auth0Exception> implements Parameterizab
     protected final HttpUrl url;
     protected final OkHttpClient client;
     private final TypeAdapter<T> adapter;
-    private final Gson gson;
-    private final ParameterBuilder builder;
     private final ErrorBuilder<U> errorBuilder;
 
+    private final Gson gson;
+    private final ParameterBuilder builder;
     private BaseCallback<T, U> callback;
 
     protected BaseRequest(HttpUrl url, OkHttpClient client, Gson gson, TypeAdapter<T> adapter, ErrorBuilder<U> errorBuilder) {
@@ -64,13 +66,18 @@ abstract class BaseRequest<T, U extends Auth0Exception> implements Parameterizab
     }
 
     public BaseRequest(HttpUrl url, OkHttpClient client, Gson gson, TypeAdapter<T> adapter, ErrorBuilder<U> errorBuilder, BaseCallback<T, U> callback) {
+        this(url, client, gson, adapter, errorBuilder, callback, new HashMap<String, String>(), ParameterBuilder.newBuilder());
+    }
+
+    @VisibleForTesting
+    BaseRequest(HttpUrl url, OkHttpClient client, Gson gson, TypeAdapter<T> adapter, ErrorBuilder<U> errorBuilder, BaseCallback<T, U> callback, Map<String, String> headers, ParameterBuilder parameterBuilder) {
         this.url = url;
         this.client = client;
         this.gson = gson;
         this.adapter = adapter;
         this.callback = callback;
-        this.headers = new HashMap<>();
-        this.builder = ParameterBuilder.newBuilder();
+        this.headers = headers;
+        this.builder = parameterBuilder;
         this.errorBuilder = errorBuilder;
     }
 
@@ -101,6 +108,11 @@ abstract class BaseRequest<T, U extends Auth0Exception> implements Parameterizab
 
     protected ErrorBuilder<U> getErrorBuilder() {
         return errorBuilder;
+    }
+
+    @VisibleForTesting
+    BaseCallback<T, U> getCallback() {
+        return callback;
     }
 
     protected RequestBody buildBody() throws RequestBodyBuildException {

--- a/auth0/src/main/java/com/auth0/android/request/internal/ManagementErrorBuilder.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/ManagementErrorBuilder.java
@@ -1,6 +1,7 @@
-package com.auth0.android.management;
+package com.auth0.android.request.internal;
 
 import com.auth0.android.Auth0Exception;
+import com.auth0.android.management.ManagementException;
 import com.auth0.android.request.ErrorBuilder;
 
 import java.util.Map;

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -26,12 +26,15 @@ package com.auth0.android;
 
 import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.util.Telemetry;
+import com.squareup.okhttp.HttpUrl;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -43,8 +46,6 @@ public class Auth0Test {
     public ExpectedException expectedException = ExpectedException.none();
 
     private static final String CLIENT_ID = "CLIENT_ID";
-    private static final String CLIENT_SECRET = "CLIENT_SECRET";
-    private static final String CONFIGURATION_DOMAIN = "CONFIGURATION_DOMAIN";
     private static final String DOMAIN = "samples.auth0.com";
     private static final String CONFIG_DOMAIN_CUSTOM = "config.mydomain.com";
     private static final String EU_DOMAIN = "samples.eu.auth0.com";
@@ -55,48 +56,48 @@ public class Auth0Test {
     public void shouldBuildWithClientIdAndDomain() throws Exception {
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
-        assertThat(auth0.getDomainUrl(), equalTo("https://samples.auth0.com/"));
-        assertThat(auth0.getConfigurationUrl(), equalTo("https://cdn.auth0.com/"));
+        assertThat(HttpUrl.parse(auth0.getDomainUrl()), equalTo(HttpUrl.parse("https://samples.auth0.com")));
+        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://cdn.auth0.com")));
     }
 
     @Test
     public void shouldBuildWithConfigurationDomainToo() throws Exception {
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN, CONFIG_DOMAIN_CUSTOM);
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
-        assertThat(auth0.getDomainUrl(), equalTo("https://samples.auth0.com/"));
-        assertThat(auth0.getConfigurationUrl(), equalTo("https://config.mydomain.com/"));
+        assertThat(HttpUrl.parse(auth0.getDomainUrl()), equalTo(HttpUrl.parse("https://samples.auth0.com")));
+        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://config.mydomain.com")));
     }
 
     @Test
     public void shouldHandleEUInstance() throws Exception {
         Auth0 auth0 = new Auth0(CLIENT_ID, EU_DOMAIN);
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
-        assertThat(auth0.getDomainUrl(), equalTo("https://samples.eu.auth0.com/"));
-        assertThat(auth0.getConfigurationUrl(), equalTo("https://cdn.eu.auth0.com/"));
+        assertThat(HttpUrl.parse(auth0.getDomainUrl()), equalTo(HttpUrl.parse("https://samples.eu.auth0.com")));
+        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://cdn.eu.auth0.com")));
     }
 
     @Test
     public void shouldHandleAUInstance() throws Exception {
         Auth0 auth0 = new Auth0(CLIENT_ID, AU_DOMAIN);
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
-        assertThat(auth0.getDomainUrl(), equalTo("https://samples.au.auth0.com/"));
-        assertThat(auth0.getConfigurationUrl(), equalTo("https://cdn.au.auth0.com/"));
+        assertThat(HttpUrl.parse(auth0.getDomainUrl()), equalTo(HttpUrl.parse("https://samples.au.auth0.com")));
+        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://cdn.au.auth0.com")));
     }
 
     @Test
     public void shouldHandleOtherInstance() throws Exception {
         Auth0 auth0 = new Auth0(CLIENT_ID, OTHER_DOMAIN);
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
-        assertThat(auth0.getDomainUrl(), equalTo("https://samples-test.other-subdomain.other.auth0.com/"));
-        assertThat(auth0.getConfigurationUrl(), equalTo("https://cdn.other.auth0.com/"));
+        assertThat(HttpUrl.parse(auth0.getDomainUrl()), equalTo(HttpUrl.parse("https://samples-test.other-subdomain.other.auth0.com")));
+        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://cdn.other.auth0.com")));
     }
 
     @Test
     public void shouldHandleNonAuth0Domain() throws Exception {
         Auth0 auth0 = new Auth0(CLIENT_ID, "mydomain.com");
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
-        assertThat(auth0.getDomainUrl(), equalTo("https://mydomain.com/"));
-        assertThat(auth0.getConfigurationUrl(), equalTo("https://mydomain.com/"));
+        assertThat(HttpUrl.parse(auth0.getDomainUrl()), equalTo(HttpUrl.parse("https://mydomain.com")));
+        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://mydomain.com")));
     }
 
     @Test
@@ -110,14 +111,23 @@ public class Auth0Test {
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
         AuthenticationAPIClient client = auth0.newAuthenticationAPIClient();
         assertThat(client, is(notNullValue()));
-        assertThat(client.getBaseURL(), equalTo("https://samples.auth0.com/"));
+        assertThat(HttpUrl.parse(client.getBaseURL()), notNullValue());
+        assertThat(HttpUrl.parse(client.getBaseURL()).scheme(), equalTo("https"));
+        assertThat(HttpUrl.parse(client.getBaseURL()).host(), equalTo(DOMAIN));
+        assertThat(HttpUrl.parse(client.getBaseURL()).pathSize(), is(1));
+        assertThat(HttpUrl.parse(client.getBaseURL()).encodedPath(), is("/"));
         assertThat(client.getClientId(), equalTo(CLIENT_ID));
     }
 
     @Test
     public void shouldReturnAuthorizeUrl() throws Exception {
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        assertThat(auth0.getAuthorizeUrl(), equalTo("https://samples.auth0.com/authorize"));
+
+        assertThat(HttpUrl.parse(auth0.getAuthorizeUrl()), notNullValue());
+        assertThat(HttpUrl.parse(auth0.getAuthorizeUrl()).scheme(), equalTo("https"));
+        assertThat(HttpUrl.parse(auth0.getAuthorizeUrl()).host(), equalTo(DOMAIN));
+        assertThat(HttpUrl.parse(auth0.getAuthorizeUrl()).encodedPathSegments(), hasSize(1));
+        assertThat(HttpUrl.parse(auth0.getAuthorizeUrl()).encodedPathSegments(), contains("authorize"));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -32,9 +32,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.hamcrest.Matchers.contains;
+import static com.auth0.android.util.HttpUrlMatcher.hasHost;
+import static com.auth0.android.util.HttpUrlMatcher.hasPath;
+import static com.auth0.android.util.HttpUrlMatcher.hasScheme;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -110,12 +111,10 @@ public class Auth0Test {
     public void shouldBuildNewClient() throws Exception {
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
         AuthenticationAPIClient client = auth0.newAuthenticationAPIClient();
+        final HttpUrl url = HttpUrl.parse(client.getBaseURL());
         assertThat(client, is(notNullValue()));
-        assertThat(HttpUrl.parse(client.getBaseURL()), notNullValue());
-        assertThat(HttpUrl.parse(client.getBaseURL()).scheme(), equalTo("https"));
-        assertThat(HttpUrl.parse(client.getBaseURL()).host(), equalTo(DOMAIN));
-        assertThat(HttpUrl.parse(client.getBaseURL()).pathSize(), is(1));
-        assertThat(HttpUrl.parse(client.getBaseURL()).encodedPath(), is("/"));
+        assertThat(url, hasScheme("https"));
+        assertThat(url, hasHost(DOMAIN));
         assertThat(client.getClientId(), equalTo(CLIENT_ID));
     }
 
@@ -123,11 +122,10 @@ public class Auth0Test {
     public void shouldReturnAuthorizeUrl() throws Exception {
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
 
-        assertThat(HttpUrl.parse(auth0.getAuthorizeUrl()), notNullValue());
-        assertThat(HttpUrl.parse(auth0.getAuthorizeUrl()).scheme(), equalTo("https"));
-        assertThat(HttpUrl.parse(auth0.getAuthorizeUrl()).host(), equalTo(DOMAIN));
-        assertThat(HttpUrl.parse(auth0.getAuthorizeUrl()).encodedPathSegments(), hasSize(1));
-        assertThat(HttpUrl.parse(auth0.getAuthorizeUrl()).encodedPathSegments(), contains("authorize"));
+        final HttpUrl url = HttpUrl.parse(auth0.getAuthorizeUrl());
+        assertThat(url, hasScheme("https"));
+        assertThat(url, hasHost(DOMAIN));
+        assertThat(url, hasPath("authorize"));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -36,6 +36,7 @@ import com.auth0.android.util.MockAuthenticationCallback;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.junit.After;
@@ -99,7 +100,11 @@ public class AuthenticationAPIClientTest {
         AuthenticationAPIClient client = new AuthenticationAPIClient(new Auth0(CLIENT_ID, DOMAIN));
         assertThat(client, is(notNullValue()));
         assertThat(client.getClientId(), equalTo(CLIENT_ID));
-        assertThat(client.getBaseURL(), equalTo("https://" + DOMAIN + "/"));
+        assertThat(HttpUrl.parse(client.getBaseURL()), notNullValue());
+        assertThat(HttpUrl.parse(client.getBaseURL()).scheme(), equalTo("https"));
+        assertThat(HttpUrl.parse(client.getBaseURL()).host(), equalTo(DOMAIN));
+        assertThat(HttpUrl.parse(client.getBaseURL()).pathSize(), is(1));
+        assertThat(HttpUrl.parse(client.getBaseURL()).encodedPath(), is("/"));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/CallbackHelperTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CallbackHelperTest.java
@@ -32,11 +32,11 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static com.auth0.android.util.HttpUrlMatcher.hasHost;
+import static com.auth0.android.util.HttpUrlMatcher.hasPath;
+import static com.auth0.android.util.HttpUrlMatcher.hasScheme;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
@@ -60,11 +60,9 @@ public class CallbackHelperTest {
         final HttpUrl expected = HttpUrl.parse(DOMAIN + "/android/" + PACKAGE_NAME + "/callback");
         final HttpUrl result = HttpUrl.parse(helper.getCallbackURI(DOMAIN));
 
-        assertThat(result, notNullValue());
-        assertThat(result.scheme(), equalTo("https"));
-        assertThat(result.host(), equalTo("my-domain.auth0.com"));
-        assertThat(result.encodedPathSegments(), hasSize(3));
-        assertThat(result.encodedPathSegments(), contains("android", PACKAGE_NAME, "callback"));
+        assertThat(result, hasScheme("https"));
+        assertThat(result, hasHost("my-domain.auth0.com"));
+        assertThat(result, hasPath("android", PACKAGE_NAME, "callback"));
         assertThat(result, equalTo(expected));
     }
 
@@ -73,11 +71,9 @@ public class CallbackHelperTest {
         final HttpUrl expected = HttpUrl.parse(DOMAIN + "/android/" + PACKAGE_NAME + "/callback");
         final HttpUrl result = HttpUrl.parse(helper.getCallbackURI(DOMAIN_WITH_TRAILING_SLASH));
 
-        assertThat(result, notNullValue());
-        assertThat(result.scheme(), equalTo("https"));
-        assertThat(result.host(), equalTo("my-domain.auth0.com"));
-        assertThat(result.encodedPathSegments(), hasSize(3));
-        assertThat(result.encodedPathSegments(), contains("android", PACKAGE_NAME, "callback"));
+        assertThat(result, hasScheme("https"));
+        assertThat(result, hasHost("my-domain.auth0.com"));
+        assertThat(result, hasPath("android", PACKAGE_NAME, "callback"));
         assertThat(result, equalTo(expected));
     }
 

--- a/auth0/src/test/java/com/auth0/android/request/internal/AuthenticationErrorBuilderTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/AuthenticationErrorBuilderTest.java
@@ -1,0 +1,73 @@
+package com.auth0.android.request.internal;
+
+import com.auth0.android.Auth0Exception;
+import com.auth0.android.authentication.AuthenticationException;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.any;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class AuthenticationErrorBuilderTest {
+
+    private AuthenticationErrorBuilder builder;
+
+    @Before
+    public void setUp() throws Exception {
+        builder = new AuthenticationErrorBuilder();
+    }
+
+    @Test
+    public void shouldCreateFromMessage() throws Exception {
+        final AuthenticationException ex = builder.from("message");
+
+        assertThat(ex.getCause(), is(nullValue()));
+        assertThat(ex.getCode(), is("a0.sdk.internal_error.unknown"));
+        assertThat(ex.getStatusCode(), is(0));
+        assertThat(ex.getDescription(), is(any(String.class)));
+    }
+
+    @Test
+    public void shouldCreateFromMessageAndException() throws Exception {
+        final Auth0Exception auth0Ex = Mockito.mock(Auth0Exception.class);
+        final AuthenticationException ex = builder.from("message", auth0Ex);
+
+        assertThat(ex.getCause(), CoreMatchers.<Throwable>equalTo(auth0Ex));
+        assertThat(ex.getCode(), is("a0.sdk.internal_error.unknown"));
+        assertThat(ex.getStatusCode(), is(0));
+        assertThat(ex.getDescription(), is(any(String.class)));
+    }
+
+    @Test
+    public void shouldCreateFromStringPayloadAndIntCode() throws Exception {
+        final AuthenticationException ex = builder.from("message", 999);
+
+        assertThat(ex.getCause(), is(nullValue()));
+        assertThat(ex.getCode(), is("a0.sdk.internal_error.plain"));
+        assertThat(ex.getStatusCode(), is(999));
+        assertThat(ex.getDescription(), is("message"));
+    }
+
+    @Test
+    public void shouldCreateFromMap() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("key", "value");
+        map.put("asd", "123");
+        final AuthenticationException ex = builder.from(map);
+
+        assertThat(ex.getCause(), is(nullValue()));
+        assertThat(ex.getCode(), is("a0.sdk.internal_error.unknown"));
+        assertThat(ex.getStatusCode(), is(0));
+        assertThat(ex.getDescription(), is(any(String.class)));
+        assertThat(ex.getValue("key"), CoreMatchers.<Object>is("value"));
+        assertThat(ex.getValue("asd"), CoreMatchers.<Object>is("123"));
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.java
@@ -61,6 +61,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class BaseRequestTest {
 
@@ -200,23 +201,18 @@ public class BaseRequestTest {
         final Response response = createJsonResponse(payload, 401);
         baseRequest.parseUnsuccessfulResponse(response);
 
-        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> integerCaptor = ArgumentCaptor.forClass(Integer.class);
-        verify(errorBuilder).from(stringCaptor.capture(), integerCaptor.capture());
+        verify(errorBuilder).from(eq("n=ot_a valid json {{]"), integerCaptor.capture());
         assertThat(integerCaptor.getValue(), is(401));
-        assertThat(stringCaptor.getValue(), is("n=ot_a valid json {{]"));
     }
 
     @Test
     public void shouldParseUnsuccessfulInvalidResponse() throws Exception {
-        byte[] invalidBytes = new byte[]{12,23,2,1,23,3,21,3,12};
+        byte[] invalidBytes = new byte[]{12, 23, 2, 1, 23, 3, 21, 3, 12};
         final Response response = createBytesResponse(invalidBytes, 401);
         response.body().string();    //force a IOException the next time this gets called
         baseRequest.parseUnsuccessfulResponse(response);
-
-        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
-        verify(errorBuilder).from(stringCaptor.capture(), any(Auth0Exception.class));
-        assertThat(stringCaptor.getValue(), is("Request to https://auth0.com/ failed"));
+        verify(errorBuilder).from(eq("Request to https://auth0.com/ failed"), any(Auth0Exception.class));
     }
 
     private Response createJsonResponse(String jsonPayload, int code) {

--- a/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.java
@@ -27,15 +27,22 @@ package com.auth0.android.request.internal;
 
 import com.auth0.android.Auth0Exception;
 import com.auth0.android.RequestBodyBuildException;
+import com.auth0.android.authentication.ParameterBuilder;
 import com.auth0.android.callback.BaseCallback;
 import com.auth0.android.request.ErrorBuilder;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.squareup.okhttp.HttpUrl;
+import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.collection.IsMapWithSize;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -44,9 +51,14 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -64,36 +76,20 @@ public class BaseRequestTest {
     private OkHttpClient client;
     @Mock
     private TypeAdapter<String> adapter;
+    @Mock
+    private Map<String, String> headers;
+    private ParameterBuilder parameterBuilder;
+
     @Captor
-    private ArgumentCaptor<Runnable> captor;
+    private ArgumentCaptor<Map<String, Object>> mapCaptor;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         HttpUrl url = HttpUrl.parse("https://auth0.com");
-        errorBuilder = new ErrorBuilder<Auth0Exception>() {
-            @Override
-            public Auth0Exception from(String message) {
-                return new Auth0Exception(message);
-            }
+        parameterBuilder = ParameterBuilder.newBuilder();
 
-            @Override
-            public Auth0Exception from(String message, Auth0Exception exception) {
-                return exception;
-            }
-
-            @Override
-            public Auth0Exception from(Map<String, Object> values) {
-                return new Auth0Exception("Error");
-            }
-
-            @Override
-            public Auth0Exception from(String payload, int statusCode) {
-                return new Auth0Exception(payload);
-            }
-        };
-
-        baseRequest = new BaseRequest<String, Auth0Exception>(url, client, new Gson(), adapter, errorBuilder, callback) {
+        baseRequest = new BaseRequest<String, Auth0Exception>(url, client, new Gson(), adapter, errorBuilder, callback, headers, parameterBuilder) {
             @Override
             public String execute() throws Auth0Exception {
                 return null;
@@ -112,6 +108,62 @@ public class BaseRequestTest {
     }
 
     @Test
+    public void shouldUpdateTheCallback() throws Exception {
+        BaseCallback<String, Auth0Exception> diffCallback = mock(BaseCallback.class);
+        baseRequest.setCallback(diffCallback);
+        assertThat(baseRequest.getCallback(), CoreMatchers.equalTo(diffCallback));
+    }
+
+    @Test
+    public void shouldGetTheCallback() throws Exception {
+        assertThat(baseRequest.getCallback(), CoreMatchers.equalTo(callback));
+    }
+
+    @Test
+    public void shouldGetTheErrorBuilder() throws Exception {
+        assertThat(baseRequest.getErrorBuilder(), CoreMatchers.equalTo(errorBuilder));
+    }
+
+    @Test
+    public void shouldGetTheAdapter() throws Exception {
+        assertThat(baseRequest.getAdapter(), CoreMatchers.equalTo(adapter));
+    }
+
+    @Test
+    public void shouldAddHeaders() throws Exception {
+        baseRequest.addHeader("name", "value");
+        verify(headers).put("name", "value");
+    }
+
+    @Test
+    public void shouldAddASingleParameter() throws Exception {
+        baseRequest.addParameter("name", "value");
+
+        final Map<String, Object> result = parameterBuilder.asDictionary();
+        assertThat(result, IsMapWithSize.aMapWithSize(1));
+        assertThat(result, IsMapContaining.hasEntry("name", (Object) "value"));
+    }
+
+    @Test
+    public void shouldAddParameters() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("name", "value");
+        params.put("asd", "123");
+        baseRequest.addParameters(params);
+
+        final Map<String, Object> result = parameterBuilder.asDictionary();
+        assertThat(result, IsMapWithSize.aMapWithSize(2));
+        assertThat(result, IsMapContaining.hasEntry("name", (Object) "value"));
+        assertThat(result, IsMapContaining.hasEntry("asd", (Object) "123"));
+    }
+
+    @Test
+    public void shouldSetBearer() throws Exception {
+        baseRequest.setBearer("my-jwt-token");
+        verify(headers).put("Authorization", "Bearer my-jwt-token");
+    }
+
+    @Test
     public void shouldPostOnSuccess() throws Exception {
         baseRequest.postOnSuccess("OK");
         verify(callback).onSuccess(eq("OK"));
@@ -123,5 +175,75 @@ public class BaseRequestTest {
         baseRequest.postOnFailure(throwable);
         verify(callback).onFailure(eq(throwable));
         verifyNoMoreInteractions(callback);
+    }
+
+    @Test
+    public void shouldBuildException() throws Exception {
+        baseRequest.onFailure(null, mock(IOException.class));
+        verify(errorBuilder).from(eq("Request failed"), any(Auth0Exception.class));
+    }
+
+    @Test
+    public void shouldParseUnsuccessfulJsonResponse() throws Exception {
+        String payload = "{key: \"value\", asd: \"123\"}";
+        final Response response = createJsonResponse(payload, 401);
+        baseRequest.parseUnsuccessfulResponse(response);
+
+        verify(errorBuilder).from(mapCaptor.capture());
+        assertThat(mapCaptor.getValue(), IsMapContaining.hasEntry("key", (Object) "value"));
+        assertThat(mapCaptor.getValue(), IsMapContaining.hasEntry("asd", (Object) "123"));
+    }
+
+    @Test
+    public void shouldParseUnsuccessfulNotJsonResponse() throws Exception {
+        String payload = "n=ot_a valid json {{]";
+        final Response response = createJsonResponse(payload, 401);
+        baseRequest.parseUnsuccessfulResponse(response);
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> integerCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(errorBuilder).from(stringCaptor.capture(), integerCaptor.capture());
+        assertThat(integerCaptor.getValue(), is(401));
+        assertThat(stringCaptor.getValue(), is("n=ot_a valid json {{]"));
+    }
+
+    @Test
+    public void shouldParseUnsuccessfulInvalidResponse() throws Exception {
+        byte[] invalidBytes = new byte[]{12,23,2,1,23,3,21,3,12};
+        final Response response = createBytesResponse(invalidBytes, 401);
+        response.body().string();    //force a IOException the next time this gets called
+        baseRequest.parseUnsuccessfulResponse(response);
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        verify(errorBuilder).from(stringCaptor.capture(), any(Auth0Exception.class));
+        assertThat(stringCaptor.getValue(), is("Request to https://auth0.com/ failed"));
+    }
+
+    private Response createJsonResponse(String jsonPayload, int code) {
+        Request request = new Request.Builder()
+                .url("https://someurl.com")
+                .build();
+
+        final ResponseBody responseBody = ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), jsonPayload);
+        return new Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .body(responseBody)
+                .code(code)
+                .build();
+    }
+
+    private Response createBytesResponse(byte[] content, int code) {
+        Request request = new Request.Builder()
+                .url("https://someurl.com")
+                .build();
+
+        final ResponseBody responseBody = ResponseBody.create(MediaType.parse("application/octet-stream; charset=utf-8"), content);
+        return new Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .body(responseBody)
+                .code(code)
+                .build();
     }
 }

--- a/auth0/src/test/java/com/auth0/android/request/internal/ManagementErrorBuilderTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/ManagementErrorBuilderTest.java
@@ -1,0 +1,73 @@
+package com.auth0.android.request.internal;
+
+import com.auth0.android.Auth0Exception;
+import com.auth0.android.management.ManagementException;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.any;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class ManagementErrorBuilderTest {
+
+    private ManagementErrorBuilder builder;
+
+    @Before
+    public void setUp() throws Exception {
+        builder = new ManagementErrorBuilder();
+    }
+
+    @Test
+    public void shouldCreateFromMessage() throws Exception {
+        final ManagementException ex = builder.from("message");
+
+        assertThat(ex.getCause(), is(nullValue()));
+        assertThat(ex.getCode(), is("a0.sdk.internal_error.unknown"));
+        assertThat(ex.getStatusCode(), is(0));
+        assertThat(ex.getDescription(), is(any(String.class)));
+    }
+
+    @Test
+    public void shouldCreateFromMessageAndException() throws Exception {
+        final Auth0Exception auth0Ex = Mockito.mock(Auth0Exception.class);
+        final ManagementException ex = builder.from("message", auth0Ex);
+
+        assertThat(ex.getCause(), CoreMatchers.<Throwable>equalTo(auth0Ex));
+        assertThat(ex.getCode(), is("a0.sdk.internal_error.unknown"));
+        assertThat(ex.getStatusCode(), is(0));
+        assertThat(ex.getDescription(), is(any(String.class)));
+    }
+
+    @Test
+    public void shouldCreateFromStringPayloadAndIntCode() throws Exception {
+        final ManagementException ex = builder.from("message", 999);
+
+        assertThat(ex.getCause(), is(nullValue()));
+        assertThat(ex.getCode(), is("a0.sdk.internal_error.plain"));
+        assertThat(ex.getStatusCode(), is(999));
+        assertThat(ex.getDescription(), is("message"));
+    }
+
+    @Test
+    public void shouldCreateFromMap() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("key", "value");
+        map.put("asd", "123");
+        final ManagementException ex = builder.from(map);
+
+        assertThat(ex.getCause(), is(nullValue()));
+        assertThat(ex.getCode(), is("a0.sdk.internal_error.unknown"));
+        assertThat(ex.getStatusCode(), is(0));
+        assertThat(ex.getDescription(), is(any(String.class)));
+        assertThat(ex.getValue("key"), CoreMatchers.<Object>is("value"));
+        assertThat(ex.getValue("asd"), CoreMatchers.<Object>is("123"));
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/util/HttpUrlMatcher.java
+++ b/auth0/src/test/java/com/auth0/android/util/HttpUrlMatcher.java
@@ -1,0 +1,65 @@
+package com.auth0.android.util;
+
+import com.squareup.okhttp.HttpUrl;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.CoreMatchers.any;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+public class HttpUrlMatcher extends BaseMatcher<HttpUrl> {
+
+    private final Matcher<String> schemeMatcher;
+    private final Matcher<String> hostMatcher;
+    private final Matcher<Iterable<? extends String>> pathMatcher;
+
+    private HttpUrlMatcher(Matcher<String> schemeMatcher, Matcher<String> hostMatcher, Matcher<Iterable<? extends String>> pathMatcher) {
+        this.schemeMatcher = schemeMatcher;
+        this.hostMatcher = hostMatcher;
+        this.pathMatcher = pathMatcher;
+    }
+
+    public static HttpUrlMatcher hasScheme(String scheme) {
+        return new HttpUrlMatcher(is(scheme), any(String.class), null);
+    }
+
+    public static HttpUrlMatcher hasHost(String host) {
+        return new HttpUrlMatcher(any(String.class), is(host), null);
+    }
+
+    public static HttpUrlMatcher hasPath(String... path) {
+        return new HttpUrlMatcher(any(String.class), any(String.class), contains(path));
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a HttpUrl with ")
+                .appendText("scheme: ").appendDescriptionOf(schemeMatcher).appendText(" ")
+                .appendText("host: ").appendDescriptionOf(hostMatcher).appendText(" ");
+        if (pathMatcher != null) {
+            description.appendText("path: ").appendDescriptionOf(pathMatcher);
+        }
+    }
+
+    @Override
+    public boolean matches(Object item) {
+        HttpUrl httpUrl = (HttpUrl) item;
+        return httpUrl != null && hasScheme(httpUrl) && hasHost(httpUrl) && hasPath(httpUrl);
+    }
+
+    private boolean hasScheme(HttpUrl url) {
+        return schemeMatcher.matches(url.scheme());
+    }
+
+    private boolean hasHost(HttpUrl url) {
+        return hostMatcher.matches(url.host());
+    }
+
+    private boolean hasPath(HttpUrl url) {
+        return pathMatcher == null || pathMatcher.matches(url.pathSegments());
+    }
+
+}


### PR DESCRIPTION
**beta.4** was generating Callback URIs like `https://domain.auth0.com//android/package.name/callback` (note the `//`)