### PR TITLE
Small changes in the public API (Breaking Change)

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -29,7 +29,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.auth0.android.auth0.BuildConfig;
-import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.util.Telemetry;
 import com.squareup.okhttp.HttpUrl;
 
@@ -98,13 +97,6 @@ public class Auth0 {
      */
     public String getConfigurationUrl() {
         return configurationUrl.toString();
-    }
-
-    /**
-     * @return a new Authentication API client using your account credentials
-     */
-    public AuthenticationAPIClient newAuthenticationAPIClient() {
-        return new AuthenticationAPIClient(this);
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -54,7 +54,7 @@ import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_PASSW
 
 /**
  * API client for Auth0 Authentication API.
- * <p>
+ * <p/>
  * <pre><code>
  * Auth0 auth0 = new Auth0("your_client_id", "your_domain");
  * AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
@@ -453,10 +453,10 @@ public class AuthenticationAPIClient {
     }
 
     /**
-     * Request a change password using <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-change_password">'/dbconnections/change_password'</a>
+     * Request a reset password using <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-change_password">'/dbconnections/change_password'</a>
      * Example usage:
      * <pre><code>
-     * client.requestChangePassword("{email}", "{database connection name}")
+     * client.resetPassword("{email}", "{database connection name}")
      *      .start(new BaseCallback<Void>() {
      *          {@literal}Override
      *          public void onSuccess(Void payload) {}
@@ -466,12 +466,12 @@ public class AuthenticationAPIClient {
      *      });
      * </code></pre>
      *
-     * @param email      of the user that changes the password. It's also where the email will be sent with the link to perform the change password.
-     * @param connection of the database to request the change password on
+     * @param email      of the user to request the password reset. An email will be sent with the reset instructions.
+     * @param connection of the database to request the reset password on
      * @return a request to configure and start
      */
     @SuppressWarnings("WeakerAccess")
-    public DatabaseConnectionRequest<Void, AuthenticationException> requestChangePassword(@NonNull String email, @NonNull String connection) {
+    public DatabaseConnectionRequest<Void, AuthenticationException> resetPassword(@NonNull String email, @NonNull String connection) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(DB_CONNECTIONS_PATH)
                 .addPathSegment(CHANGE_PASSWORD_PATH)
@@ -728,7 +728,7 @@ public class AuthenticationAPIClient {
      * @return a request to configure and start
      */
     @SuppressWarnings("WeakerAccess")
-    public ParameterizableRequest<Void, AuthenticationException> passwordless() {
+    private ParameterizableRequest<Void, AuthenticationException> passwordless() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(PASSWORDLESS_PATH)
                 .addPathSegment(START_PATH)
@@ -756,10 +756,10 @@ public class AuthenticationAPIClient {
 
     /**
      * Fetch the token information from Auth0, using the authorization_code grant type
-     * <p>
+     * <p/>
      * For Public Client, e.g. Android apps ,you need to provide the code_verifier
      * used to generate the challenge sent to Auth0 {@literal /authorize} method like:
-     * <p>
+     * <p/>
      * <pre>{@code
      * AuthenticationAPIClient client = new AuthenticationAPIClient(new Auth0("clientId", "domain"));
      * client
@@ -767,9 +767,9 @@ public class AuthenticationAPIClient {
      *     .setCodeVerifier("code_verifier")
      *     .start(new Callback<Credentials> {...});
      * }</pre>
-     * <p>
+     * <p/>
      * For the rest of clients, clients who can safely keep a {@literal client_secret}, you need to provide it instead like:
-     * <p>
+     * <p/>
      * <pre>{@code
      * AuthenticationAPIClient client = new AuthenticationAPIClient(new Auth0("clientId", "domain"));
      * client

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -32,8 +32,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
-import com.auth0.android.auth0.R;
 import com.auth0.android.Auth0;
+import com.auth0.android.auth0.R;
 import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.result.Credentials;
 
@@ -298,7 +298,7 @@ public class WebAuthProvider {
     private void requestAuth(@NonNull Activity activity, @NonNull AuthCallback callback, int requestCode) {
         this.callback = callback;
         this.requestCode = requestCode;
-        this.client = useCodeGrant && PKCE.isAvailable() ? account.newAuthenticationAPIClient() : null;
+        this.client = useCodeGrant && PKCE.isAvailable() ? new AuthenticationAPIClient(account) : null;
         String pkgName = activity.getApplicationContext().getPackageName();
         helper = new CallbackHelper(pkgName);
 

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -30,6 +30,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 
 import com.auth0.android.Auth0;
@@ -78,7 +79,6 @@ public class WebAuthProvider {
     private final Auth0 account;
     private AuthCallback callback;
     private int requestCode;
-    private AuthenticationAPIClient client;
     private PKCE pkce;
 
     private boolean useFullscreen;
@@ -298,7 +298,6 @@ public class WebAuthProvider {
     private void requestAuth(@NonNull Activity activity, @NonNull AuthCallback callback, int requestCode) {
         this.callback = callback;
         this.requestCode = requestCode;
-        this.client = useCodeGrant && PKCE.isAvailable() ? new AuthenticationAPIClient(account) : null;
         String pkgName = activity.getApplicationContext().getPackageName();
         helper = new CallbackHelper(pkgName);
 
@@ -327,8 +326,9 @@ public class WebAuthProvider {
         }
     }
 
-    private boolean shouldUsePKCE() {
-        return client != null;
+    @VisibleForTesting
+    boolean shouldUsePKCE() {
+        return useCodeGrant && PKCE.isAvailable();
     }
 
     private Uri buildAuthorizeUri() {
@@ -341,7 +341,7 @@ public class WebAuthProvider {
 
         if (shouldUsePKCE()) {
             try {
-                pkce = new PKCE(client, redirectUri);
+                pkce = new PKCE(new AuthenticationAPIClient(account), redirectUri);
                 String codeChallenge = pkce.getCodeChallenge();
                 queryParameters.put(KEY_RESPONSE_TYPE, RESPONSE_TYPE_CODE);
                 queryParameters.put(KEY_CODE_CHALLENGE, codeChallenge);

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -24,7 +24,6 @@
 
 package com.auth0.android;
 
-import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.util.Telemetry;
 import com.squareup.okhttp.HttpUrl;
 
@@ -37,7 +36,6 @@ import static com.auth0.android.util.HttpUrlMatcher.hasPath;
 import static com.auth0.android.util.HttpUrlMatcher.hasScheme;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
@@ -105,17 +103,6 @@ public class Auth0Test {
     public void shouldThrowWhenInvalidDomain() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         new Auth0(CLIENT_ID, "some invalid domain.com");
-    }
-
-    @Test
-    public void shouldBuildNewClient() throws Exception {
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        AuthenticationAPIClient client = auth0.newAuthenticationAPIClient();
-        final HttpUrl url = HttpUrl.parse(client.getBaseURL());
-        assertThat(client, is(notNullValue()));
-        assertThat(url, hasScheme("https"));
-        assertThat(url, hasHost(DOMAIN));
-        assertThat(client.getClientId(), equalTo(CLIENT_ID));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -612,7 +612,7 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulChangePassword();
 
         final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
-        client.requestChangePassword(SUPPORT_AUTH0_COM, MY_CONNECTION)
+        client.resetPassword(SUPPORT_AUTH0_COM, MY_CONNECTION)
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
@@ -631,7 +631,7 @@ public class AuthenticationAPIClientTest {
     public void shouldChangePasswordSync() throws Exception {
         mockAPI.willReturnSuccessfulChangePassword();
 
-        client.requestChangePassword(SUPPORT_AUTH0_COM, MY_CONNECTION)
+        client.resetPassword(SUPPORT_AUTH0_COM, MY_CONNECTION)
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
@@ -649,7 +649,7 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulChangePassword();
 
         final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
-        client.requestChangePassword(SUPPORT_AUTH0_COM, MY_CONNECTION)
+        client.resetPassword(SUPPORT_AUTH0_COM, MY_CONNECTION)
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
@@ -669,7 +669,7 @@ public class AuthenticationAPIClientTest {
     public void shouldRequestChangePasswordSync() throws Exception {
         mockAPI.willReturnSuccessfulChangePassword();
 
-        client.requestChangePassword(SUPPORT_AUTH0_COM, MY_CONNECTION)
+        client.resetPassword(SUPPORT_AUTH0_COM, MY_CONNECTION)
                 .execute();
 
         final RecordedRequest request = mockAPI.takeRequest();
@@ -853,59 +853,6 @@ public class AuthenticationAPIClientTest {
         assertThat(body, hasEntry("refresh_token", REFRESH_TOKEN));
 
         assertThat(delegation, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldStartPasswordless() throws Exception {
-        mockAPI.willReturnSuccessfulPasswordlessStart();
-
-        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
-        final Map<String, Object> parameters = ParameterBuilder.newBuilder()
-                .setConnection("email")
-                .set("send", "code")
-                .set("email", SUPPORT_AUTH0_COM)
-                .asDictionary();
-
-        client.passwordless()
-                .addParameters(parameters)
-                .start(callback);
-
-        final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
-        assertThat(request.getPath(), equalTo("/passwordless/start"));
-
-        Map<String, String> body = bodyFromRequest(request);
-        assertThat(body, hasEntry("client_id", CLIENT_ID));
-        assertThat(body, hasEntry("email", SUPPORT_AUTH0_COM));
-        assertThat(body, hasEntry("send", "code"));
-        assertThat(body, hasEntry("connection", "email"));
-
-        assertThat(callback, hasNoError());
-    }
-
-    @Test
-    public void shouldStartPasswordlessSync() throws Exception {
-        mockAPI.willReturnSuccessfulPasswordlessStart();
-
-        final Map<String, Object> parameters = ParameterBuilder.newBuilder()
-                .setConnection("email")
-                .set("send", "code")
-                .set("email", SUPPORT_AUTH0_COM)
-                .asDictionary();
-
-        client.passwordless()
-                .addParameters(parameters)
-                .execute();
-
-        final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
-        assertThat(request.getPath(), equalTo("/passwordless/start"));
-
-        Map<String, String> body = bodyFromRequest(request);
-        assertThat(body, hasEntry("client_id", CLIENT_ID));
-        assertThat(body, hasEntry("email", SUPPORT_AUTH0_COM));
-        assertThat(body, hasEntry("send", "code"));
-        assertThat(body, hasEntry("connection", "email"));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/CallbackHelperTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CallbackHelperTest.java
@@ -24,19 +24,28 @@
 
 package com.auth0.android.provider;
 
+import android.net.Uri;
+
 import com.squareup.okhttp.HttpUrl;
 
+import org.hamcrest.collection.IsMapWithSize;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.Map;
+
 import static com.auth0.android.util.HttpUrlMatcher.hasHost;
 import static com.auth0.android.util.HttpUrlMatcher.hasPath;
 import static com.auth0.android.util.HttpUrlMatcher.hasScheme;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
@@ -83,4 +92,47 @@ public class CallbackHelperTest {
         assertThat(uri, nullValue());
     }
 
+    @Test
+    public void shouldParseQueryValues() throws Exception {
+        String uriString = "https://lbalmaceda.auth0.com/android/com.auth0.android.lock.app/callback?code=soMec0d3ML8B&state=810132b-486aa-4aa8-1768-a1dcd3368fae";
+        Uri uri = Uri.parse(uriString);
+        final Map<String, String> values = helper.getValuesFromUri(uri);
+
+        assertThat(values, is(notNullValue()));
+        assertThat(values, aMapWithSize(2));
+        assertThat(values, hasEntry("code", "soMec0d3ML8B"));
+        assertThat(values, hasEntry("state", "810132b-486aa-4aa8-1768-a1dcd3368fae"));
+    }
+
+    @Test
+    public void shouldParseFragmentValues() throws Exception {
+        String uriString = "https://lbalmaceda.auth0.com/android/com.auth0.android.lock.app/callback#code=soMec0d3ML8B&state=810132b-486aa-4aa8-1768-a1dcd3368fae";
+        Uri uri = Uri.parse(uriString);
+        final Map<String, String> values = helper.getValuesFromUri(uri);
+
+        assertThat(values, is(notNullValue()));
+        assertThat(values, aMapWithSize(2));
+        assertThat(values, hasEntry("code", "soMec0d3ML8B"));
+        assertThat(values, hasEntry("state", "810132b-486aa-4aa8-1768-a1dcd3368fae"));
+    }
+
+    @Test
+    public void shouldReturnEmptyQueryValues() throws Exception {
+        String uriString = "https://lbalmaceda.auth0.com/android/com.auth0.android.lock.app/callback?";
+        Uri uri = Uri.parse(uriString);
+        final Map<String, String> values = helper.getValuesFromUri(uri);
+
+        assertThat(values, is(notNullValue()));
+        assertThat(values, IsMapWithSize.<String, String>anEmptyMap());
+    }
+
+    @Test
+    public void shouldReturnEmptyFragmentValues() throws Exception {
+        String uriString = "https://lbalmaceda.auth0.com/android/com.auth0.android.lock.app/callback#";
+        Uri uri = Uri.parse(uriString);
+        final Map<String, String> values = helper.getValuesFromUri(uri);
+
+        assertThat(values, is(notNullValue()));
+        assertThat(values, IsMapWithSize.<String, String>anEmptyMap());
+    }
 }

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -146,7 +146,7 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldCleatInstanceAfterSuccessAuthentication() throws Exception {
+    public void shouldClearInstanceAfterSuccessAuthentication() throws Exception {
         WebAuthProvider.init(account)
                 .start(activity, callback, REQUEST_CODE);
 
@@ -155,11 +155,31 @@ public class WebAuthProviderTest {
         assertNull(WebAuthProvider.getInstance());
     }
 
+    @Test
+    public void shouldHavePKCEEnabled() throws Exception{
+        WebAuthProvider.init(account)
+                .useCodeGrant(true)
+                .start(activity, callback, REQUEST_CODE);
+
+        assertTrue(WebAuthProvider.getInstance().shouldUsePKCE());
+    }
+
+
+    @Test
+    public void shouldHavePKCEDisabled() throws Exception{
+        WebAuthProvider.init(account)
+                .useCodeGrant(false)
+                .start(activity, callback, REQUEST_CODE);
+
+        assertFalse(WebAuthProvider.getInstance().shouldUsePKCE());
+    }
+
+
+
     private Intent createValidAuthIntent() {
         Uri validUri = Uri.parse(CALLBACK_URL + SAMPLE_HASH);
         Intent intent = new Intent();
         intent.setData(validUri);
         return intent;
     }
-
 }


### PR DESCRIPTION
[Breaking]
* Remove `newAuthenticationAPIClient()` from the `Auth0` class.
* Rename `requestChangePassword()` to `resetPassword()`.
* Make `passwordless()` private.

[Other]
* Test the query/hash parse on the `CallbackHelper` class.