### PR TITLE
Create APIClients without passing Account

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ First create an instance of `Auth0` with your client information
 Auth0 account = new Auth0("{YOUR_CLIENT_ID}", "{YOUR_DOMAIN}");
 ```
 
-Alternatively, save your client information in the `strings.xml` file using the following names:
+Alternatively, you can save your client information in the `strings.xml` file using the following names:
  
 ```xml
 <resources>
@@ -50,6 +50,13 @@ Alternatively, save your client information in the `strings.xml` file using the 
 </resources>
 
 ```
+
+And then create a new Auth0 instance by passing an Android Context:
+
+```java
+AuthenticationAPIClient authentication = new AuthenticationAPIClient(context);
+```
+  
 
 ### Authentication API
 
@@ -60,14 +67,6 @@ Create a new instance by passing the account:
 ```java
 AuthenticationAPIClient authentication = new AuthenticationAPIClient(account);
 ```
-
-Or create a new instance by passing the context:
-
-```java
-AuthenticationAPIClient authentication = new AuthenticationAPIClient(this);
-```
-  
-> This requires you to add the client information to the `strings.xml` file. See the [usage section](#usage)
 
 #### Login with database connection
 
@@ -176,17 +175,9 @@ Create a new instance by passing the account and the token:
 
 ```java
 Auth0 account = new Auth0("client id", "domain");
-UsersAPIClient apiClient = new UsersAPIClient(account, "user token");
+UsersAPIClient apiClient = new UsersAPIClient(account, "api token");
 ```
  
-Or create a new instance by passing the context and the token:
- 
-```java
-UsersAPIClient apiClient = new UsersAPIClient(this, "user token");
-```
-
-> This requires you to add the client information to the `strings.xml` file. See the [usage section](#usage)
-
 #### Link users
 
 ```java

--- a/README.md
+++ b/README.md
@@ -41,15 +41,33 @@ First create an instance of `Auth0` with your client information
 Auth0 account = new Auth0("{YOUR_CLIENT_ID}", "{YOUR_DOMAIN}");
 ```
 
+Alternatively, save your client information in the `strings.xml` file using the following names:
+ 
+```xml
+<resources>
+    <string name="com_auth0_client_id">YOUR_CLIENT_ID</string>
+    <string name="com_auth0_domain">YOUR_DOMAIN</string>
+</resources>
+
+```
+
 ### Authentication API
 
 The client provides methods to authenticate the user against Auth0 server.
  
- Create a new instance by passing the account:
+Create a new instance by passing the account:
  
- ```java
+```java
 AuthenticationAPIClient authentication = new AuthenticationAPIClient(account);
- ```
+```
+
+Or create a new instance by passing the context:
+
+```java
+AuthenticationAPIClient authentication = new AuthenticationAPIClient(this);
+```
+  
+> This requires you to add the client information to the `strings.xml` file. See the [usage section](#usage)
 
 #### Login with database connection
 
@@ -154,13 +172,20 @@ authentication
 
 The client provides methods to link and unlink users account.
 
-Create a new instance by passing the account:
+Create a new instance by passing the account and the token:
 
 ```java
 Auth0 account = new Auth0("client id", "domain");
 UsersAPIClient apiClient = new UsersAPIClient(account, "user token");
 ```
+ 
+Or create a new instance by passing the context and the token:
+ 
+```java
+UsersAPIClient apiClient = new UsersAPIClient(this, "user token");
+```
 
+> This requires you to add the client information to the `strings.xml` file. See the [usage section](#usage)
 
 #### Link users
 

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -25,6 +25,7 @@
 package com.auth0.android;
 
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -76,6 +77,27 @@ public class Auth0 {
         }
         this.configurationUrl = resolveConfiguration(configurationDomain, this.domainUrl);
         this.telemetry = new Telemetry(BuildConfig.LIBRARY_NAME, BuildConfig.VERSION_NAME);
+    }
+
+    /**
+     * Creates a new Auth0 instance with the 'com_auth0_client_id' and 'com_auth0_domain' values
+     * defined in the project String resources file.
+     * If the values are not found, IllegalArgumentException will raise.
+     *
+     * @param context a valid context
+     * @return a new Auth0 instance.
+     */
+    public static Auth0 createFromResources(@NonNull Context context) {
+        final int clientIdRes = context.getResources().getIdentifier("com_auth0_client_id", "string", context.getPackageName());
+        if (clientIdRes == 0) {
+            throw new IllegalArgumentException("The 'R.string.com_auth0_client_id' value it's not defined in your project's resources file.");
+        }
+        final int domainRes = context.getResources().getIdentifier("com_auth0_domain", "string", context.getPackageName());
+        if (domainRes == 0) {
+            throw new IllegalArgumentException("The 'R.string.com_auth0_domain' value it's not defined in your project's resources file.");
+        }
+
+        return new Auth0(context.getString(clientIdRes), context.getString(domainRes));
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -50,6 +50,18 @@ public class Auth0 {
     private final HttpUrl configurationUrl;
     private Telemetry telemetry;
 
+
+    /**
+     * Creates a new Auth0 instance with the 'com_auth0_client_id' and 'com_auth0_domain' values
+     * defined in the project String resources file.
+     * If the values are not found, IllegalArgumentException will raise.
+     *
+     * @param context a valid context
+     */
+    public Auth0(@NonNull Context context) {
+        this(getResourceFromContext(context, "com_auth0_client_id"), getResourceFromContext(context, "com_auth0_domain"));
+    }
+
     /**
      * Creates a new object using clientId & domain
      *
@@ -77,27 +89,6 @@ public class Auth0 {
         }
         this.configurationUrl = resolveConfiguration(configurationDomain, this.domainUrl);
         this.telemetry = new Telemetry(BuildConfig.LIBRARY_NAME, BuildConfig.VERSION_NAME);
-    }
-
-    /**
-     * Creates a new Auth0 instance with the 'com_auth0_client_id' and 'com_auth0_domain' values
-     * defined in the project String resources file.
-     * If the values are not found, IllegalArgumentException will raise.
-     *
-     * @param context a valid context
-     * @return a new Auth0 instance.
-     */
-    public static Auth0 createFromResources(@NonNull Context context) {
-        final int clientIdRes = context.getResources().getIdentifier("com_auth0_client_id", "string", context.getPackageName());
-        if (clientIdRes == 0) {
-            throw new IllegalArgumentException("The 'R.string.com_auth0_client_id' value it's not defined in your project's resources file.");
-        }
-        final int domainRes = context.getResources().getIdentifier("com_auth0_domain", "string", context.getPackageName());
-        if (domainRes == 0) {
-            throw new IllegalArgumentException("The 'R.string.com_auth0_domain' value it's not defined in your project's resources file.");
-        }
-
-        return new Auth0(context.getString(clientIdRes), context.getString(domainRes));
     }
 
     /**
@@ -179,5 +170,13 @@ public class Auth0 {
         }
         String safeUrl = url.startsWith("http") ? url : "https://" + url;
         return HttpUrl.parse(safeUrl);
+    }
+
+    private static String getResourceFromContext(@NonNull Context context, String resName) {
+        final int stringRes = context.getResources().getIdentifier(resName, "string", context.getPackageName());
+        if (stringRes == 0) {
+            throw new IllegalArgumentException(String.format("The 'R.string.%s' value it's not defined in your project's resources file.", resName));
+        }
+        return context.getString(stringRes);
     }
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -108,7 +108,7 @@ public class AuthenticationAPIClient {
      * @param context a valid Context
      */
     public AuthenticationAPIClient(Context context) {
-        this(Auth0.createFromResources(context));
+        this(new Auth0(context));
     }
 
     private AuthenticationAPIClient(Auth0 auth0, OkHttpClient client, Gson gson) {

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -24,6 +24,7 @@
 
 package com.auth0.android.authentication;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 
 import com.auth0.android.Auth0;
@@ -98,6 +99,16 @@ public class AuthenticationAPIClient {
      */
     public AuthenticationAPIClient(@NonNull Auth0 auth0) {
         this(auth0, new OkHttpClient(), GsonProvider.buildGson());
+    }
+
+    /**
+     * Creates a new API client instance using the 'com_auth0_client_id' and 'com_auth0_domain' values
+     * defined in the project String resources file.
+     *
+     * @param context a valid Context
+     */
+    public AuthenticationAPIClient(Context context) {
+        this(Auth0.createFromResources(context));
     }
 
     private AuthenticationAPIClient(Auth0 auth0, OkHttpClient client, Gson gson) {

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
@@ -88,7 +88,7 @@ public class UsersAPIClient {
      * @param token   of the primary identity
      */
     public UsersAPIClient(Context context, String token) {
-        this(Auth0.createFromResources(context), token);
+        this(new Auth0(context), token);
     }
 
     private UsersAPIClient(Auth0 auth0, String token, OkHttpClient client, Gson gson) {

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
@@ -25,6 +25,8 @@
 package com.auth0.android.management;
 
 
+import android.content.Context;
+
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.ParameterBuilder;
 import com.auth0.android.request.ErrorBuilder;
@@ -45,7 +47,7 @@ import java.util.Map;
 
 /**
  * API client for Auth0 Management API.
- * <p>
+ * <p/>
  * <pre><code>
  * Auth0 auth0 = new Auth0("your_client_id", "your_domain");
  * UsersAPIClient client = new UsersAPIClient(auth0);
@@ -72,9 +74,21 @@ public class UsersAPIClient {
      * Creates a new API client instance providing Auth0 account info.
      *
      * @param auth0 account information
+     * @param token of the primary identity
      */
     public UsersAPIClient(Auth0 auth0, String token) {
         this(auth0, token, new OkHttpClient(), GsonProvider.buildGson());
+    }
+
+    /**
+     * Creates a new API client instance using the 'com_auth0_client_id' and 'com_auth0_domain' values
+     * defined in the project String resources file.
+     *
+     * @param context a valid Context
+     * @param token   of the primary identity
+     */
+    public UsersAPIClient(Context context, String token) {
+        this(Auth0.createFromResources(context), token);
     }
 
     private UsersAPIClient(Auth0 auth0, String token, OkHttpClient client, Gson gson) {

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -26,6 +26,7 @@
 package com.auth0.android.provider;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.NonNull;
@@ -236,6 +237,18 @@ public class WebAuthProvider {
      */
     public static Builder init(@NonNull Auth0 account) {
         return new Builder(account);
+    }
+
+
+    /**
+     * Initialize the WebAuthProvider instance with an Android Context. Additional settings can be configured
+     * in the Builder, like setting the connection name or authentication parameters.
+     *
+     * @param context a valid context.
+     * @return a new Builder instance to customize.
+     */
+    public static Builder init(@NonNull Context context) {
+        return new Builder(new Auth0(context));
     }
 
     /**

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -71,7 +71,7 @@ public class Auth0Test {
         when(context.getString(eq(222))).thenReturn(CLIENT_ID);
         when(context.getString(eq(333))).thenReturn(DOMAIN);
 
-        Auth0 auth0 = Auth0.createFromResources(context);
+        Auth0 auth0 = new Auth0(context);
 
         assertThat(auth0, notNullValue());
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
@@ -90,7 +90,7 @@ public class Auth0Test {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("The 'R.string.com_auth0_client_id' value it's not defined in your project's resources file.");
 
-        Auth0.createFromResources(context);
+        new Auth0(context);
     }
 
     @Test
@@ -104,7 +104,7 @@ public class Auth0Test {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("The 'R.string.com_auth0_domain' value it's not defined in your project's resources file.");
 
-        Auth0.createFromResources(context);
+        new Auth0(context);
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -25,6 +25,9 @@
 package com.auth0.android.authentication;
 
 
+import android.content.Context;
+import android.content.res.Resources;
+
 import com.auth0.android.Auth0;
 import com.auth0.android.result.Authentication;
 import com.auth0.android.result.Credentials;
@@ -42,6 +45,7 @@ import com.squareup.okhttp.mockwebserver.RecordedRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -62,6 +66,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
 
 public class AuthenticationAPIClientTest {
 
@@ -105,6 +112,24 @@ public class AuthenticationAPIClientTest {
         assertThat(HttpUrl.parse(client.getBaseURL()).host(), equalTo(DOMAIN));
         assertThat(HttpUrl.parse(client.getBaseURL()).pathSize(), is(1));
         assertThat(HttpUrl.parse(client.getBaseURL()).encodedPath(), is("/"));
+    }
+
+    @Test
+    public void shouldCreateClientWithContextInfo() throws Exception {
+        Context context = Mockito.mock(Context.class);
+        Resources resources = Mockito.mock(Resources.class);
+        when(context.getResources()).thenReturn(resources);
+        when(resources.getIdentifier(eq("com_auth0_client_id"), eq("string"), anyString())).thenReturn(222);
+        when(resources.getIdentifier(eq("com_auth0_domain"), eq("string"), anyString())).thenReturn(333);
+
+        when(context.getString(eq(222))).thenReturn(CLIENT_ID);
+        when(context.getString(eq(333))).thenReturn(DOMAIN);
+
+        AuthenticationAPIClient client = new AuthenticationAPIClient(context);
+
+        assertThat(client, is(notNullValue()));
+        assertThat(client.getClientId(), is(CLIENT_ID));
+        assertThat(client.getBaseURL(), equalTo("https://" + DOMAIN + "/"));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
@@ -25,6 +25,9 @@
 package com.auth0.android.management;
 
 
+import android.content.Context;
+import android.content.res.Resources;
+
 import com.auth0.android.Auth0;
 import com.auth0.android.result.UserIdentity;
 import com.auth0.android.result.UserProfile;
@@ -39,6 +42,7 @@ import com.squareup.okhttp.mockwebserver.RecordedRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
@@ -55,6 +59,9 @@ import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
 
 public class UsersAPIClientTest {
 
@@ -97,6 +104,24 @@ public class UsersAPIClientTest {
         UsersAPIClient client = new UsersAPIClient(new Auth0(CLIENT_ID, DOMAIN), TOKEN_PRIMARY);
         assertThat(client, is(notNullValue()));
         assertThat(client.getClientId(), equalTo(CLIENT_ID));
+        assertThat(client.getBaseURL(), equalTo("https://" + DOMAIN + "/"));
+    }
+
+    @Test
+    public void shouldCreateClientWithContextInfo() throws Exception {
+        Context context = Mockito.mock(Context.class);
+        Resources resources = Mockito.mock(Resources.class);
+        when(context.getResources()).thenReturn(resources);
+        when(resources.getIdentifier(eq("com_auth0_client_id"), eq("string"), anyString())).thenReturn(222);
+        when(resources.getIdentifier(eq("com_auth0_domain"), eq("string"), anyString())).thenReturn(333);
+
+        when(context.getString(eq(222))).thenReturn(CLIENT_ID);
+        when(context.getString(eq(333))).thenReturn(DOMAIN);
+
+        UsersAPIClient client = new UsersAPIClient(context, TOKEN_PRIMARY);
+
+        assertThat(client, is(notNullValue()));
+        assertThat(client.getClientId(), is(CLIENT_ID));
         assertThat(client.getBaseURL(), equalTo("https://" + DOMAIN + "/"));
     }
 

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 
@@ -48,6 +49,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -84,8 +86,25 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldInit() throws Exception {
+    public void shouldInitWithAccount() throws Exception {
         WebAuthProvider.init(account)
+                .start(activity, callback, REQUEST_CODE);
+
+        assertNotNull(WebAuthProvider.getInstance());
+    }
+
+    @Test
+    public void shouldInitWithContext() throws Exception {
+        Context context = Mockito.mock(Context.class);
+        Resources resources = Mockito.mock(Resources.class);
+        when(context.getResources()).thenReturn(resources);
+        when(resources.getIdentifier(eq("com_auth0_client_id"), eq("string"), anyString())).thenReturn(222);
+        when(resources.getIdentifier(eq("com_auth0_domain"), eq("string"), anyString())).thenReturn(333);
+
+        when(context.getString(eq(222))).thenReturn("clientId");
+        when(context.getString(eq(333))).thenReturn("domain");
+
+        WebAuthProvider.init(context)
                 .start(activity, callback, REQUEST_CODE);
 
         assertNotNull(WebAuthProvider.getInstance());
@@ -517,7 +536,7 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldHavePKCEEnabled() throws Exception{
+    public void shouldHavePKCEEnabled() throws Exception {
         WebAuthProvider.init(account)
                 .useCodeGrant(true)
                 .start(activity, callback, REQUEST_CODE);
@@ -527,7 +546,7 @@ public class WebAuthProviderTest {
 
 
     @Test
-    public void shouldHavePKCEDisabled() throws Exception{
+    public void shouldHavePKCEDisabled() throws Exception {
         WebAuthProvider.init(account)
                 .useCodeGrant(false)
                 .start(activity, callback, REQUEST_CODE);


### PR DESCRIPTION
The PR features the creation of APIClients by giving the Context, which it's used to fetch the client information from the `strings.xml` file. The user needs to define the following keys:

```
<resources>
    <string name="com_auth0_client_id">YOUR_CLIENT_ID</string>
    <string name="com_auth0_domain">YOUR_DOMAIN</string>
</resources>
```