### PR TITLE
Make AuthHandler callback protected again

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -54,7 +54,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.squareup.okhttp:okhttp:2.5.0'
     compile "com.google.code.gson:gson:2.6.2"
 
@@ -63,7 +63,7 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'com.squareup.okhttp:mockwebserver:2.5.0'
     testCompile 'com.jayway.awaitility:awaitility:1.6.4'
-    testCompile 'org.robolectric:robolectric:3.1'
+    testCompile 'org.robolectric:robolectric:3.1.2'
     testCompile 'com.android.support.test.espresso:espresso-intents:2.2.2'
 }
 

--- a/auth0/src/main/java/com/auth0/android/provider/AuthHandler.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AuthHandler.java
@@ -14,5 +14,5 @@ public interface AuthHandler {
      * @return an AuthProvider to handle the authentication or null.
      */
     @Nullable
-    AuthProvider providerFor(@NonNull String strategy, @NonNull String connection);
+    AuthProvider providerFor(@Nullable String strategy, @NonNull String connection);
 }

--- a/auth0/src/main/java/com/auth0/android/provider/AuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AuthProvider.java
@@ -28,6 +28,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Intent;
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -83,6 +84,18 @@ public abstract class AuthProvider {
     }
 
     /**
+     * Returns the Authentication callback received in the start method to notify success and failures.
+     * The callback will be null if start was never called or if clearSession was called.
+     *
+     * @return the callback received in the start method or null if missing.
+     */
+    @Nullable
+    protected AuthCallback getCallback() {
+        return callback;
+    }
+
+
+    /**
      * Starts the authentication flow on the Identity Provider. The connection name is specified
      * by the getConnectionName method.
      * All the required Android permissions had already been granted when Start was called, so
@@ -102,6 +115,7 @@ public abstract class AuthProvider {
     /**
      * Removes any session information stored in the object.
      */
+    @CallSuper
     public void clearSession() {
         callback = null;
     }

--- a/auth0/src/test/java/com/auth0/android/provider/AuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthProviderTest.java
@@ -41,6 +41,7 @@ import org.robolectric.annotation.Config;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
@@ -65,19 +66,11 @@ public class AuthProviderTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         processAuthenticationCalled = false;
-        provider = new AuthProvider(handler) {
+        provider = new AuthProvider(handler){
 
             @Override
             protected void requestAuth(Activity activity, int requestCode) {
                 processAuthenticationCalled = true;
-            }
-
-            @Override
-            public void stop() {
-            }
-
-            @Override
-            public void clearSession() {
             }
 
             @Override
@@ -136,4 +129,29 @@ public class AuthProviderTest {
 
         Mockito.verify(handler).parseRequestResult(PERMISSION_REQUEST_CODE, PROVIDER_PERMISSIONS, PERMISSIONS_GRANTED);
     }
+
+    @Test
+    public void shouldReturnCallback() throws Exception {
+        Mockito.when(handler.areAllPermissionsGranted(activity, PROVIDER_PERMISSIONS)).thenReturn(true);
+        provider.start(activity, callback, PERMISSION_REQUEST_CODE, AUTHENTICATION_REQUEST_CODE);
+
+        assertThat(provider.getCallback(), is(callback));
+    }
+
+    @Test
+    public void shouldReturnNullCallbackIfNotStarted() throws Exception {
+        Mockito.when(handler.areAllPermissionsGranted(activity, PROVIDER_PERMISSIONS)).thenReturn(true);
+
+        assertThat(provider.getCallback(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnNullCallbackIfSessionCleared() throws Exception {
+        Mockito.when(handler.areAllPermissionsGranted(activity, PROVIDER_PERMISSIONS)).thenReturn(true);
+        provider.start(activity, callback, PERMISSION_REQUEST_CODE, AUTHENTICATION_REQUEST_CODE);
+        provider.clearSession();
+
+        assertThat(provider.getCallback(), is(nullValue()));
+    }
+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
     }
     dependencies {
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
     }
 }
 


### PR DESCRIPTION
* Callback is again visible from a subclass using the `getCallback` method. 
* Also force the user to call super when overriding `clearSession` so we can clear the saved callback instance.