### PR TITLE
Allow to set additional Parameters.

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/AuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AuthProvider.java
@@ -36,7 +36,9 @@ import android.util.Log;
 
 import com.auth0.android.auth0.R;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -50,6 +52,7 @@ public abstract class AuthProvider {
     private final PermissionHandler handler;
     private AuthCallback callback;
     private int authenticationRequestCode;
+    private Map<String, Object> parameters;
 
     public AuthProvider() {
         this(new PermissionHandler());
@@ -57,6 +60,7 @@ public abstract class AuthProvider {
 
     AuthProvider(@NonNull PermissionHandler handler) {
         this.handler = handler;
+        this.parameters = new HashMap<>();
     }
 
     /**
@@ -135,11 +139,14 @@ public abstract class AuthProvider {
     /**
      * Finishes the authentication flow by passing the data received in the activity's onNewIntent() callback.
      * The final authentication result will be delivered to the callback specified when calling start().
+     * The default implementation will return false, you need to override it if you want to customize the logic.
      *
      * @param intent the data received on the onNewIntent() call
      * @return true if a result was expected and has a valid format, or false if not.
      */
-    public abstract boolean authorize(@Nullable Intent intent);
+    public boolean authorize(@Nullable Intent intent) {
+        return false;
+    }
 
     /**
      * Defines which Android Manifest Permissions are required by this Identity Provider to work.
@@ -148,6 +155,26 @@ public abstract class AuthProvider {
      * @return the required Android Manifest.permissions
      */
     public abstract String[] getRequiredAndroidPermissions();
+
+    /**
+     * Sets the parameters to send with the authentication request. The user is responsible of calling getParameters() and attaching them in the request.
+     * By default, this is an empty map.
+     *
+     * @param parameters the parameters to use.
+     */
+    public void setParameters(@NonNull Map<String, Object> parameters) {
+        this.parameters = new HashMap<>(parameters);
+    }
+
+    /**
+     * Getter for the parameters to send with the authentication request.
+     *
+     * @return the parameters to use.
+     */
+    @NonNull
+    protected Map<String, Object> getParameters() {
+        return parameters;
+    }
 
     /**
      * Checks if all the required Android Manifest.permissions have already been granted.
@@ -175,7 +202,7 @@ public abstract class AuthProvider {
     }
 
     @VisibleForTesting
-    PermissionHandler getPermissionHandler(){
+    PermissionHandler getPermissionHandler() {
         return handler;
     }
 

--- a/auth0/src/test/java/com/auth0/android/provider/AuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthProviderTest.java
@@ -31,6 +31,8 @@ import android.support.annotation.Nullable;
 import android.support.v4.content.PermissionChecker;
 import android.widget.TextView;
 
+import org.hamcrest.Matcher;
+import org.hamcrest.collection.IsMapContaining;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,14 +46,19 @@ import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = com.auth0.android.auth0.BuildConfig.class, sdk = 21, manifest = Config.NONE)
@@ -75,7 +82,7 @@ public class AuthProviderTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         processAuthenticationCalled = false;
-        provider = new AuthProvider(handler){
+        provider = new AuthProvider(handler) {
 
             @Override
             protected void requestAuth(Activity activity, int requestCode) {
@@ -84,11 +91,6 @@ public class AuthProviderTest {
 
             @Override
             public boolean authorize(int requestCode, int resultCode, @Nullable Intent intent) {
-                return false;
-            }
-
-            @Override
-            public boolean authorize(@Nullable Intent intent) {
                 return false;
             }
 
@@ -108,11 +110,6 @@ public class AuthProviderTest {
 
             @Override
             public boolean authorize(int requestCode, int resultCode, @Nullable Intent intent) {
-                return false;
-            }
-
-            @Override
-            public boolean authorize(@Nullable Intent intent) {
                 return false;
             }
 
@@ -196,7 +193,23 @@ public class AuthProviderTest {
         TextView messageTV = (TextView) dialog.findViewById(android.R.id.message);
         assertThat(messageTV.getText().toString(), containsString("Some permissions required by this provider were not granted. You can try to authenticate again or go to " +
                 "the application's permission screen in the phone settings and grant them. The missing permissions are:\n" + "[some, values]"));
+    }
 
+    @Test
+    public void shouldSetParameters() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("key", "value");
+        provider.setParameters(params);
+
+        final Map<String, Object> parameters = provider.getParameters();
+        assertThat(parameters, is(notNullValue()));
+        assertThat(parameters, hasEntry("key", (Object) "value"));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenCalledWithIntentByDefault() throws Exception {
+        boolean authorizeResult = provider.authorize(new Intent());
+        assertFalse(authorizeResult);
     }
 
     @Test


### PR DESCRIPTION
* The parameters are accesible via a protected getter `getParameters()`. The user is responsible for adding them to the request.
* Make `authorize(Intent)` have a default implementation were it always returns false. This case when the authorize is called from the onNewIntent() is not very common to force the user to override it.