### PR TITLE
Change default WebAuthProvider connection to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,8 +351,6 @@ WebAuthProvider.init(account)
                 .start(MainActivity.this, authCallback, WEB_REQ_CODE);
 ```
 
-> The default connection used is `Username-Password-Authentication`
-
 #### Use Code grant with PKCE
 > Before you can use `Code Grant` in Android, make sure to go to your [client's section](https://manage.auth0.com/#/applications) in dashboard and check in the Settings that `Client Type` is `Native`.
 

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -51,8 +51,6 @@ public class WebAuthProvider {
 
     private static final String TAG = WebAuthProvider.class.getName();
 
-    private static final String DEFAULT_CONNECTION_NAME = "Username-Password-Authentication";
-
     private static final String KEY_ERROR = "error";
     private static final String KEY_ID_TOKEN = "id_token";
     private static final String KEY_ACCESS_TOKEN = "access_token";
@@ -121,7 +119,6 @@ public class WebAuthProvider {
             this.parameters = new HashMap<>();
             this.state = UUID.randomUUID().toString();
             this.scope = SCOPE_TYPE_OPENID;
-            this.connectionName = DEFAULT_CONNECTION_NAME;
         }
 
         /**
@@ -210,7 +207,7 @@ public class WebAuthProvider {
         }
 
         /**
-         * Use the given connection instead of the default 'auth0'.
+         * Use the given connection. By default no connection is specified, so the hosted login page will be displayed.
          *
          * @param connectionName to use
          * @return the current builder instance

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -67,7 +67,6 @@ public class WebAuthProviderTest {
     private static final String SCOPE = "scope";
     private static final String CONNECTION_SCOPE = "connection_scope";
     private static final String STATE = "state";
-    private static final String USERNAME_PASSWORD_AUTHENTICATION_CONNECTION = "Username-Password-Authentication";
     private static final String SCOPE_OPEN_ID = "openid";
 
     @Mock
@@ -120,7 +119,7 @@ public class WebAuthProviderTest {
         assertThat(instance.useBrowser(), is(true));
         assertThat(instance.useCodeGrant(), is(true));
         assertThat(instance.useFullscreen(), is(false));
-        assertThat(instance.getConnection(), is(not(Matchers.isEmptyOrNullString())));
+        assertThat(instance.getConnection(), is(nullValue()));
         assertThat(instance.getScope(), is(not(Matchers.isEmptyOrNullString())));
         assertThat(instance.getConnectionScope(), is(nullValue()));
         assertThat(instance.getState(), is(not(Matchers.isEmptyOrNullString())));
@@ -129,12 +128,12 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldHaveDefaultConnection() throws Exception {
+    public void shouldNotHaveDefaultConnection() throws Exception {
         WebAuthProvider.init(account)
                 .start(activity, callback, REQUEST_CODE);
 
         final WebAuthProvider instance = WebAuthProvider.getInstance();
-        assertThat(instance.getConnection(), is(USERNAME_PASSWORD_AUTHENTICATION_CONNECTION));
+        assertThat(instance.getConnection(), is(nullValue()));
     }
 
     @Test
@@ -262,7 +261,7 @@ public class WebAuthProviderTest {
         final ComponentName expComponent = new ComponentName("package", WebAuthActivity.class.getName());
         assertThat(intentCaptor.getValue(), is(notNullValue()));
         assertThat(intentCaptor.getValue(), hasComponent(expComponent));
-        assertThat(intentCaptor.getValue(), hasExtra(WebAuthActivity.CONNECTION_NAME_EXTRA, "Username-Password-Authentication"));
+        assertThat(intentCaptor.getValue(), hasExtra(WebAuthActivity.CONNECTION_NAME_EXTRA, null));
         assertThat(intentCaptor.getValue(), hasExtra(WebAuthActivity.FULLSCREEN_EXTRA, false));
     }
 


### PR DESCRIPTION
Change the default value for the connection used in the authentication to null, allowing the user to reach Auth0's Web Lock.