### PR TITLE
Avoid sending null parameters in the authorize URI

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -433,7 +433,9 @@ public class WebAuthProvider {
 
         final Uri.Builder builder = authorizeUri.buildUpon();
         for (Map.Entry<String, String> entry : queryParameters.entrySet()) {
-            builder.appendQueryParameter(entry.getKey(), entry.getValue());
+            if (entry.getValue() != null) {
+                builder.appendQueryParameter(entry.getKey(), entry.getValue());
+            }
         }
         Uri uri = builder.build();
         Log.d(TAG, "The final Authorize Uri is " + uri.toString());


### PR DESCRIPTION
Gson omits all fields that are null during serialization, but that's not working for map values. This fixes that issue.