### PR TITLE
Deprecate WebView authentication flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Step 2: Input the code
 
 ```java
 authentication
-    .loginWithEmail("info@auth0.com", "a secret password", "my-passwordless-connection")
+    .loginWithEmail("info@auth0.com", "123456", "my-passwordless-connection")
     .start(new BaseCallback<Credentials>() {
         @Override
         public void onSuccess(Credentials payload) {
@@ -171,7 +171,7 @@ authentication
 
 The client provides methods to link and unlink users account.
 
-Create a new instance by passing the account and the token:
+Create a new instance by passing the account and the primary user token:
 
 ```java
 Auth0 account = new Auth0("client id", "domain");
@@ -236,6 +236,9 @@ users
     });
 ```
 
+> In all the cases, the `User ID` parameter is the unique identifier of the auth0 account instance. i.e. in `google-oauth2|123456789081523216417` it would be the part after the '|' pipe: `123456789081523216417`.
+
+
 ### Web-based Auth
 
 First go to [Auth0 Dashboard](https://manage.auth0.com/#/applications) and go to your application's settings. Make sure you have in *Allowed Callback URLs* a URL with the following format:
@@ -283,24 +286,10 @@ Also register the intent filters inside your activity's tag, so you can receive 
 
 Make sure the Activity's **launchMode** is declared as "singleTask" or the result won't come back after the authentication.
 
-In your `Activity` class define a constant like `WEB_REQ_CODE` that holds the request code (an `int`), that will be sent back with the intent once the auth is finished in the browser/webview. To capture the response, override the `OnActivityResult` and the `onNewIntent` methods and call `WebAuthProvider.resume()` with the received parameters:
+When you launch the WebAuthProvider you'll expect a result back. To capture the response override the `onNewIntent` method and call `WebAuthProvider.resume()` with the received parameters:
 
 ```java
 public class MyActivity extends Activity {
-
-    private static final int WEB_REQ_CODE = 110;
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        switch (requestCode) {
-            case WEB_REQ_CODE:
-                lockView.showProgress(false);
-                WebAuthProvider.resume(requestCode, resultCode, data);
-                break;
-            default:
-                super.onActivityResult(requestCode, resultCode, data);
-        }
-    }
 
     @Override
     protected void onNewIntent(Intent intent) {
@@ -318,7 +307,7 @@ public class MyActivity extends Activity {
 ```java
 WebAuthProvider.init(account)
                 .withConnection("twitter")
-                .start(MainActivity.this, authCallback, WEB_REQ_CODE);
+                .start(MainActivity.this, authCallback);
 ```
 
 #### Use Code grant with PKCE
@@ -328,7 +317,7 @@ WebAuthProvider.init(account)
 ```java
 WebAuthProvider.init(account)
                 .useCodeGrant(true)
-                .start(MainActivity.this, authCallback, WEB_REQ_CODE);
+                .start(MainActivity.this, authCallback);
 ```
 
 #### Specify scope
@@ -336,7 +325,7 @@ WebAuthProvider.init(account)
 ```java
 WebAuthProvider.init(account)
                 .withScope("user openid")
-                .start(MainActivity.this, authCallback, WEB_REQ_CODE);
+                .start(MainActivity.this, authCallback);
 ```
 
 > The default scope used is `openid`
@@ -346,14 +335,15 @@ WebAuthProvider.init(account)
 ```java
 WebAuthProvider.init(account)
                 .withConnectionScope("email", "profile", "calendar:read")
-                .start(MainActivity.this, authCallback, WEB_REQ_CODE);
+                .start(MainActivity.this, authCallback);
 ```
 
 #### Authenticate with Auth0 hosted login page
+Simply don't specify any custom connection and the Lock web widget will show.
 
 ```java
 WebAuthProvider.init(account)
-                .start(MainActivity.this, authCallback, WEB_REQ_CODE);
+                .start(MainActivity.this, authCallback);
 ```
 
 

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -179,7 +179,7 @@ public class WebAuthProvider {
         public Builder withConnectionScope(@NonNull String... connectionScope) {
             StringBuilder sb = new StringBuilder();
             for (String s : connectionScope) {
-                sb.append(s.trim()).append(",");
+                sb.append(s.trim()).append(" ");
             }
             if (sb.length() > 0) {
                 sb.deleteCharAt(sb.length() - 1);
@@ -412,7 +412,6 @@ public class WebAuthProvider {
         String redirectUri = helper.getCallbackURI(account.getDomainUrl());
 
         final Map<String, String> queryParameters = new HashMap<>();
-        queryParameters.put(KEY_SCOPE, scope);
         queryParameters.put(KEY_CONNECTION_SCOPE, connectionScope);
         queryParameters.put(KEY_RESPONSE_TYPE, RESPONSE_TYPE_TOKEN);
 
@@ -439,6 +438,9 @@ public class WebAuthProvider {
 
         if (account.getTelemetry() != null) {
             queryParameters.put(KEY_TELEMETRY, account.getTelemetry().getValue());
+        }
+        if (scope != null) {
+            queryParameters.put(KEY_SCOPE, scope);
         }
 
         queryParameters.put(KEY_STATE, state);

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -44,7 +44,7 @@ import java.util.UUID;
 
 /**
  * OAuth2 Web Authentication Provider.
- * It can use an external browser by sending the {@link android.content.Intent#ACTION_VIEW} intent, or also the {@link WebAuthActivity}.
+ * It can use an external browser by sending the {@link android.content.Intent#ACTION_VIEW} intent or also the {@link WebAuthActivity}.
  * This behaviour is changed using {@link WebAuthProvider#useBrowser()}, and defaults to use browser.
  */
 public class WebAuthProvider {
@@ -126,7 +126,7 @@ public class WebAuthProvider {
          *
          * @param useBrowser if the authentication is handled in a Browser.
          * @return the current builder instance
-         * @deprecated This method has been deprecated since Google is no longer supporting WebViews to perform login.
+         * @deprecated This method has been deprecated since it only applied to WebView authentication and Google is no longer supporting it. You should use the default value (use browser).
          */
         @Deprecated
         public Builder useBrowser(boolean useBrowser) {
@@ -140,7 +140,7 @@ public class WebAuthProvider {
          *
          * @param useFullscreen if the activity should be fullscreen or not.
          * @return the current builder instance
-         * @deprecated This method has been deprecated since it's only applied to WebView authentication and Google is no longer supporting them to perform login.
+         * @deprecated This method has been deprecated since it only applied to WebView authentication and Google is no longer supporting it.
          */
         @Deprecated
         public Builder useFullscreen(boolean useFullscreen) {
@@ -229,13 +229,15 @@ public class WebAuthProvider {
 
         /**
          * Begins the authentication flow.
-         * Make sure to override your activity's onActivityResult() method,
+         * Make sure to override your activity's onNewIntent() and onActivityResult() methods,
          * and call this provider's resume() method with the received parameters.
          *
          * @param activity    context to run the authentication
          * @param callback    to receive the parsed results
          * @param requestCode to use in the authentication request
+         * @deprecated This method has been deprecated since it only applied to WebView authentication and Google is no longer supporting it. Please use {@link WebAuthProvider.Builder#start(Activity, AuthCallback)}
          */
+        @Deprecated
         public void start(@NonNull Activity activity, @NonNull AuthCallback callback, int requestCode) {
             WebAuthProvider webAuth = new WebAuthProvider(account);
             webAuth.useBrowser = useBrowser;
@@ -251,6 +253,17 @@ public class WebAuthProvider {
             providerInstance = webAuth;
 
             webAuth.requestAuth(activity, callback, requestCode);
+        }
+
+        /**
+         * Begins the authentication flow.
+         * Make sure to override your activity's onNewIntent() method and call this provider's resume() method with the received parameters.
+         *
+         * @param activity context to run the authentication
+         * @param callback to receive the parsed results
+         */
+        public void start(@NonNull Activity activity, @NonNull AuthCallback callback) {
+            this.start(activity, callback, 110);
         }
     }
 
@@ -287,7 +300,9 @@ public class WebAuthProvider {
      * @param resultCode  the result code received on the onActivityResult() call
      * @param intent      the data received on the onActivityResult() call
      * @return true if a result was expected and has a valid format, or false if not.
+     * @deprecated This method has been deprecated since it only applied to WebView authentication and Google is no longer supporting it. Please use {@link WebAuthProvider#requestAuth(Activity, AuthCallback, int)}
      */
+    @Deprecated
     public static boolean resume(int requestCode, int resultCode, @Nullable Intent intent) {
         if (providerInstance == null) {
             Log.w(TAG, "There is no previous instance of this provider.");

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -106,7 +106,7 @@ public class WebAuthProviderTest {
         when(context.getString(eq(333))).thenReturn("domain");
 
         WebAuthProvider.init(context)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         assertNotNull(WebAuthProvider.getInstance());
     }
@@ -114,7 +114,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldHaveDefaultsOnInit() throws Exception {
         WebAuthProvider.init(account)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         final WebAuthProvider instance = WebAuthProvider.getInstance();
         assertThat(instance.useBrowser(), is(true));
@@ -131,7 +131,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldNotHaveDefaultConnection() throws Exception {
         WebAuthProvider.init(account)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         final WebAuthProvider instance = WebAuthProvider.getInstance();
         assertThat(instance.getConnection(), is(nullValue()));
@@ -140,7 +140,16 @@ public class WebAuthProviderTest {
     @Test
     public void shouldHaveDefaultScope() throws Exception {
         WebAuthProvider.init(account)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
+
+        final WebAuthProvider instance = WebAuthProvider.getInstance();
+        assertThat(instance.getScope(), is(SCOPE_OPEN_ID));
+    }
+
+    @Test
+    public void shouldCallStartWithRequestCode() throws Exception {
+        WebAuthProvider.init(account)
+                .start(activity, callback);
 
         final WebAuthProvider instance = WebAuthProvider.getInstance();
         assertThat(instance.getScope(), is(SCOPE_OPEN_ID));
@@ -160,7 +169,7 @@ public class WebAuthProviderTest {
                 .withConnectionScope(CONNECTION_SCOPE)
                 .withState(STATE)
                 .withParameters(parameters)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         final WebAuthProvider instance = WebAuthProvider.getInstance();
         assertThat(instance.useBrowser(), is(true));
@@ -190,7 +199,7 @@ public class WebAuthProviderTest {
         when(activity.getPackageName()).thenReturn("package");
         when(appContext.getPackageName()).thenReturn("package");
         WebAuthProvider.init(account)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         final ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
         verify(activity).startActivity(intentCaptor.capture());
@@ -218,7 +227,7 @@ public class WebAuthProviderTest {
         when(activity.getPackageName()).thenReturn("package");
         when(appContext.getPackageName()).thenReturn("package");
         WebAuthProvider.init(account)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         final ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
         verify(activity).startActivity(intentCaptor.capture());
@@ -265,7 +274,7 @@ public class WebAuthProviderTest {
                 .withScope("super_scope")
                 .withConnectionScope("first_connection_scope", "second_connection_scope")
                 .withParameters(parameters)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         final ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
         verify(activity).startActivity(intentCaptor.capture());
@@ -304,7 +313,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .useBrowser(true)
                 .useCodeGrant(false)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         final ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
         verify(activity).startActivity(intentCaptor.capture());
@@ -349,7 +358,7 @@ public class WebAuthProviderTest {
                 .withConnection("my-connection")
                 .useCodeGrant(false)
                 .useFullscreen(true)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         final ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
         verify(activity).startActivityForResult(intentCaptor.capture(), any(Integer.class));
@@ -369,7 +378,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .withState("abcdefghijk")
                 .useCodeGrant(false)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         verify(callback).onFailure(authExceptionCaptor.capture());
 
@@ -377,6 +386,28 @@ public class WebAuthProviderTest {
         assertThat(authExceptionCaptor.getValue().getCode(), is("a0.invalid_authorize_url"));
         assertThat(authExceptionCaptor.getValue().getDescription(), is("Auth0 authorize URL not properly set. This can be related to an invalid domain."));
         assertThat(WebAuthProvider.getInstance(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldStartWithValidRequestCode() throws Exception {
+        final Credentials credentials = Mockito.mock(Credentials.class);
+        final PKCE pkce = Mockito.mock(PKCE.class);
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                callback.onSuccess(credentials);
+                return null;
+            }
+        }).when(pkce).getToken(any(String.class), eq(callback));
+
+        WebAuthProvider.init(account)
+                .withState("1234567890")
+                .useCodeGrant(true)
+                .withPKCE(pkce)
+                .start(activity, callback);
+        final Intent intent = createAuthIntent(createHash("aToken", "iToken", "refresh_token", "1234567890", null));
+        final int DEFAULT_REQUEST_CODE = 110;
+        assertTrue(WebAuthProvider.resume(DEFAULT_REQUEST_CODE, Activity.RESULT_OK, intent));
     }
 
     @Test
@@ -395,7 +426,7 @@ public class WebAuthProviderTest {
                 .withState("1234567890")
                 .useCodeGrant(true)
                 .withPKCE(pkce)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
         final Intent intent = createAuthIntent(createHash("aToken", "iToken", "refresh_token", "1234567890", null));
         assertTrue(WebAuthProvider.resume(intent));
 
@@ -452,7 +483,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .withState("1234567890")
                 .useCodeGrant(false)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
         final Intent intent = createAuthIntent(createHash("aToken", "iToken", "refresh_token", "1234567890", null));
         assertTrue(WebAuthProvider.resume(intent));
 
@@ -476,7 +507,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .withState("1234567890")
                 .useCodeGrant(false)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
         final Intent intent = createAuthIntent(createHash("aToken", "iToken", "refresh_token", "1234567890", "access_denied"));
         assertTrue(WebAuthProvider.resume(intent));
 
@@ -508,7 +539,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .withState("1234567890")
                 .useCodeGrant(false)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
         final Intent intent = createAuthIntent(createHash("aToken", "iToken", "refresh_token", "1234567890", "some other error"));
         assertTrue(WebAuthProvider.resume(intent));
 
@@ -540,7 +571,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .withState("abcdefghijk")
                 .useCodeGrant(false)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
         final Intent intent = createAuthIntent(createHash("aToken", "iToken", "refresh_token", "1234567890", null));
         assertTrue(WebAuthProvider.resume(intent));
 
@@ -572,7 +603,7 @@ public class WebAuthProviderTest {
         verifyNoMoreInteractions(callback);
         WebAuthProvider.init(account)
                 .useCodeGrant(false)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         final Intent intent = createAuthIntent(createHash("aToken", "iToken", "refresh_token", "1234567890", null));
         assertFalse(WebAuthProvider.resume(999, Activity.RESULT_OK, intent));
@@ -606,7 +637,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .withState("abcdefghijk")
                 .useCodeGrant(false)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         final Intent intent = createAuthIntent("");
         assertFalse(WebAuthProvider.resume(intent));
@@ -616,17 +647,16 @@ public class WebAuthProviderTest {
     public void shouldHavePKCEEnabled() throws Exception {
         WebAuthProvider.init(account)
                 .useCodeGrant(true)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         assertTrue(WebAuthProvider.getInstance().shouldUsePKCE());
     }
-
 
     @Test
     public void shouldHavePKCEDisabled() throws Exception {
         WebAuthProvider.init(account)
                 .useCodeGrant(false)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         assertFalse(WebAuthProvider.getInstance().shouldUsePKCE());
     }
@@ -659,7 +689,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .withState("abcdefghijk")
                 .useCodeGrant(false)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
         assertFalse(WebAuthProvider.resume(null));
     }
 
@@ -675,7 +705,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldClearInstanceAfterSuccessAuthenticationWithIntent() throws Exception {
         WebAuthProvider.init(account)
-                .start(activity, callback, REQUEST_CODE);
+                .start(activity, callback);
 
         assertThat(WebAuthProvider.getInstance(), is(notNullValue()));
         final Intent intent = createAuthIntent(createHash("aToken", "iToken", "refresh_token", "1234567890", null));


### PR DESCRIPTION
Methods that receive a REQUEST_CODE are now deprecated. Users should avoid calling `builder.useBrowser(false)`.

```java
//Start the authentication
public void doAuth(){
   WebAuthProvider.init(account)
      .start(activity, callback);
}

//Capture the result and resume the authentication
@Override
protected void onNewIntent(Intent intent) {
   if (WebAuthProvider.resume(intent)) {
      return;   //Handled
   }
   super.onNewIntent(intent);
}
```