### PR TITLE
Add Logging for Requests/Responses and Uri's.

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -55,14 +55,15 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.squareup.okhttp:okhttp:2.5.0'
-    compile "com.google.code.gson:gson:2.6.2"
+    compile 'com.squareup.okhttp:okhttp:2.7.5'
+    compile 'com.squareup.okhttp:logging-interceptor:2.7.5'
+    compile 'com.google.code.gson:gson:2.6.2'
     compile 'com.auth0.android:jwtdecode:1.0.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'com.squareup.okhttp:mockwebserver:2.5.0'
+    testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
     testCompile 'com.jayway.awaitility:awaitility:1.6.4'
     testCompile 'org.robolectric:robolectric:3.1.2'
     testCompile 'com.android.support.test.espresso:espresso-intents:2.2.2'

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -140,8 +140,15 @@ public class AuthenticationAPIClient {
      * Log every Request and Response made by this client.
      * You shouldn't enable logging in release builds as it may leak sensitive information.
      */
-    public void enableLogging() {
-        logInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+    public void setLoggingEnabled(boolean enabled) {
+        logInterceptor.setLevel(enabled ? HttpLoggingInterceptor.Level.BODY : HttpLoggingInterceptor.Level.NONE);
+    }
+
+    /**
+     * Getter for the current client logger enabled state.
+     */
+    public boolean isLoggingEnabled() {
+        return logInterceptor.getLevel() == HttpLoggingInterceptor.Level.BODY;
     }
 
     public String getClientId() {

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -137,13 +137,11 @@ public class AuthenticationAPIClient {
     }
 
     /**
-     * Whether to log every Request and Response or not.
+     * Log every Request and Response made by this client.
      * You shouldn't enable logging in release builds as it may leak sensitive information.
-     *
-     * @param enabled whether the logging is enabled or not.
      */
-    public void setLogging(boolean enabled) {
-        logInterceptor.setLevel(enabled ? HttpLoggingInterceptor.Level.BODY : HttpLoggingInterceptor.Level.NONE);
+    public void enableLogging() {
+        logInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
     }
 
     public String getClientId() {

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -48,6 +48,7 @@ import com.auth0.android.util.Telemetry;
 import com.google.gson.Gson;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.logging.HttpLoggingInterceptor;
 
 import java.util.Map;
 
@@ -91,6 +92,7 @@ public class AuthenticationAPIClient {
 
     private final Auth0 auth0;
     private final OkHttpClient client;
+    private final HttpLoggingInterceptor logInterceptor;
     private final Gson gson;
     private final com.auth0.android.request.internal.RequestFactory factory;
     private final ErrorBuilder<AuthenticationException> authErrorBuilder;
@@ -116,13 +118,15 @@ public class AuthenticationAPIClient {
     }
 
     @VisibleForTesting
-    AuthenticationAPIClient(Auth0 auth0, RequestFactory factory) {
-        this(auth0, factory, new OkHttpClient(), GsonProvider.buildGson());
+    AuthenticationAPIClient(Auth0 auth0, RequestFactory factory, OkHttpClient client) {
+        this(auth0, factory, client, GsonProvider.buildGson());
     }
 
     private AuthenticationAPIClient(Auth0 auth0, RequestFactory factory, OkHttpClient client, Gson gson) {
         this.auth0 = auth0;
         this.client = client;
+        this.logInterceptor = new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.NONE);
+        this.client.interceptors().add(logInterceptor);
         this.gson = gson;
         this.factory = factory;
         this.authErrorBuilder = new AuthenticationErrorBuilder();
@@ -130,6 +134,16 @@ public class AuthenticationAPIClient {
         if (telemetry != null) {
             factory.setClientInfo(telemetry.getValue());
         }
+    }
+
+    /**
+     * Whether to log every Request and Response or not.
+     * You shouldn't enable logging in release builds as it may leak sensitive information.
+     *
+     * @param enabled whether the logging is enabled or not.
+     */
+    public void setLogging(boolean enabled) {
+        logInterceptor.setLevel(enabled ? HttpLoggingInterceptor.Level.BODY : HttpLoggingInterceptor.Level.NONE);
     }
 
     public String getClientId() {

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
@@ -114,13 +114,11 @@ public class UsersAPIClient {
     }
 
     /**
-     * Whether to log every Request and Response or not.
+     * Log every Request and Response made by this client.
      * You shouldn't enable logging in release builds as it may leak sensitive information.
-     *
-     * @param enabled whether the logging is enabled or not.
      */
-    public void setLogging(boolean enabled) {
-        logInterceptor.setLevel(enabled ? HttpLoggingInterceptor.Level.BODY : HttpLoggingInterceptor.Level.NONE);
+    public void enableLogging() {
+        logInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
     }
 
     public String getClientId() {

--- a/auth0/src/main/java/com/auth0/android/provider/AlgorithmHelper.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AlgorithmHelper.java
@@ -44,20 +44,16 @@ class AlgorithmHelper {
         return signature;
     }
 
-    public String generateCodeVerifier() {
+    String generateCodeVerifier() {
         SecureRandom sr = new SecureRandom();
         byte[] code = new byte[32];
         sr.nextBytes(code);
-        String verifier = Base64.encodeToString(code, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
-        Log.d(TAG, "Generated code verifier is " + verifier);
-        return verifier;
+        return Base64.encodeToString(code, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
     }
 
-    public String generateCodeChallenge(@NonNull String codeVerifier) {
+    String generateCodeChallenge(@NonNull String codeVerifier) {
         byte[] input = getASCIIBytes(codeVerifier);
         byte[] signature = getSHA256(input);
-        String challenge = getBase64String(signature);
-        Log.d(TAG, "Generated code challenge is " + challenge);
-        return challenge;
+        return getBase64String(signature);
     }
 }

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -531,9 +531,7 @@ public class WebAuthProvider {
     private PKCE createPKCE(String redirectUri) {
         if (pkce == null) {
             final AuthenticationAPIClient client = new AuthenticationAPIClient(account);
-            if (loggingEnabled) {
-                client.enableLogging();
-            }
+            client.setLoggingEnabled(loggingEnabled);
             return new PKCE(client, redirectUri);
         } else {
             return pkce;

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -256,13 +256,11 @@ public class WebAuthProvider {
         }
 
         /**
-         * Whether to log every Request and Response or not.
+         * Log every Request and Response made by this provider.
          * You shouldn't enable logging in release builds as it may leak sensitive information.
-         *
-         * @param enabled whether the logging is enabled or not.
          */
-        public Builder setLogging(boolean enabled) {
-            this.loggingEnabled = enabled;
+        public Builder enableLogging() {
+            this.loggingEnabled = true;
             return this;
         }
 
@@ -533,7 +531,9 @@ public class WebAuthProvider {
     private PKCE createPKCE(String redirectUri) {
         if (pkce == null) {
             final AuthenticationAPIClient client = new AuthenticationAPIClient(account);
-            client.setLogging(loggingEnabled);
+            if (loggingEnabled) {
+                client.enableLogging();
+            }
             return new PKCE(client, redirectUri);
         } else {
             return pkce;

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -380,9 +380,7 @@ public class WebAuthProvider {
             Log.w(TAG, "The response didn't contain any of these values: code, state, id_token, access_token, token_type, refresh_token");
             return false;
         }
-        if (loggingEnabled) {
-            Log.d(TAG, "The parsed CallbackURI contains the following values: " + values);
-        }
+        logDebug("The parsed CallbackURI contains the following values: " + values);
 
         if (values.containsKey(KEY_ERROR)) {
             Log.e(TAG, "Error, access denied. Check that the required Permissions are granted and that the Application has this Connection configured in Auth0 Dashboard.");
@@ -522,9 +520,7 @@ public class WebAuthProvider {
             builder.appendQueryParameter(entry.getKey(), entry.getValue());
         }
         Uri uri = builder.build();
-        if (loggingEnabled) {
-            Log.d(TAG, "Using the following AuthorizeURI: " + uri.toString());
-        }
+        logDebug("The parsed CallbackURI contains the following values: " + "Using the following AuthorizeURI: " + uri.toString());
         return uri;
     }
 
@@ -573,5 +569,11 @@ public class WebAuthProvider {
         final byte[] randomBytes = new byte[32];
         sr.nextBytes(randomBytes);
         return Base64.encodeToString(randomBytes, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
+    }
+
+    private void logDebug(String message) {
+        if (loggingEnabled) {
+            Log.d(TAG, message);
+        }
     }
 }

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -92,6 +92,7 @@ public class WebAuthProvider {
     private Map<String, String> parameters;
 
     private static WebAuthProvider providerInstance;
+    private boolean loggingEnabled;
 
     @VisibleForTesting
     WebAuthProvider(@NonNull Auth0 account) {
@@ -105,6 +106,7 @@ public class WebAuthProvider {
         private boolean useBrowser;
         private boolean useFullscreen;
         private PKCE pkce;
+        private boolean loggingEnabled;
 
         Builder(Auth0 account) {
             this.account = account;
@@ -253,6 +255,17 @@ public class WebAuthProvider {
             return this;
         }
 
+        /**
+         * Whether to log every Request and Response or not.
+         * You shouldn't enable logging in release builds as it may leak sensitive information.
+         *
+         * @param enabled whether the logging is enabled or not.
+         */
+        public Builder setLogging(boolean enabled) {
+            this.loggingEnabled = enabled;
+            return this;
+        }
+
         @VisibleForTesting
         Builder withPKCE(PKCE pkce) {
             this.pkce = pkce;
@@ -276,6 +289,7 @@ public class WebAuthProvider {
             webAuth.useFullscreen = useFullscreen;
             webAuth.parameters = values;
             webAuth.pkce = pkce;
+            webAuth.loggingEnabled = loggingEnabled;
 
             providerInstance = webAuth;
 
@@ -367,6 +381,9 @@ public class WebAuthProvider {
         if (values.isEmpty()) {
             Log.w(TAG, "The response didn't contain any of these values: code, state, id_token, access_token, token_type, refresh_token");
             return false;
+        }
+        if (loggingEnabled) {
+            Log.d(TAG, "The parsed CallbackURI contains the following values: " + values);
         }
 
         if (values.containsKey(KEY_ERROR)) {
@@ -507,12 +524,20 @@ public class WebAuthProvider {
             builder.appendQueryParameter(entry.getKey(), entry.getValue());
         }
         Uri uri = builder.build();
-        Log.d(TAG, "The final Authorize Uri is " + uri.toString());
+        if (loggingEnabled) {
+            Log.d(TAG, "Using the following AuthorizeURI: " + uri.toString());
+        }
         return uri;
     }
 
     private PKCE createPKCE(String redirectUri) {
-        return pkce == null ? new PKCE(new AuthenticationAPIClient(account), redirectUri) : pkce;
+        if (pkce == null) {
+            final AuthenticationAPIClient client = new AuthenticationAPIClient(account);
+            client.setLogging(loggingEnabled);
+            return new PKCE(client, redirectUri);
+        } else {
+            return pkce;
+        }
     }
 
     @VisibleForTesting
@@ -523,6 +548,14 @@ public class WebAuthProvider {
 
     private String getState() {
         return parameters.containsKey(KEY_STATE) ? parameters.get(KEY_STATE) : secureRandomString();
+    }
+
+    String getScope() {
+        return this.parameters.get(KEY_SCOPE) != null ? this.parameters.get(KEY_SCOPE) : SCOPE_TYPE_OPENID;
+    }
+
+    boolean isLoggingEnabled() {
+        return loggingEnabled;
     }
 
     private String getNonce() {

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -157,7 +157,7 @@ public class AuthenticationAPIClientTest {
 
         ArgumentCaptor<Interceptor> interceptorCaptor = ArgumentCaptor.forClass(Interceptor.class);
         AuthenticationAPIClient client = new AuthenticationAPIClient(account, factory, okClient);
-        client.setLogging(true);
+        client.enableLogging();
 
         verify(okClient).interceptors();
         verify(list).add(interceptorCaptor.capture());
@@ -165,27 +165,6 @@ public class AuthenticationAPIClientTest {
         assertThat(interceptorCaptor.getValue(), is(notNullValue()));
         assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
         assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.BODY));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldDisableHttpLogging() throws Exception {
-        Auth0 account = mock(Auth0.class);
-        RequestFactory factory = mock(RequestFactory.class);
-        OkHttpClient okClient = mock(OkHttpClient.class);
-        List list = mock(List.class);
-        when(okClient.interceptors()).thenReturn(list);
-
-        ArgumentCaptor<Interceptor> interceptorCaptor = ArgumentCaptor.forClass(Interceptor.class);
-        AuthenticationAPIClient client = new AuthenticationAPIClient(account, factory, okClient);
-        client.setLogging(false);
-
-        verify(okClient).interceptors();
-        verify(list).add(interceptorCaptor.capture());
-
-        assertThat(interceptorCaptor.getValue(), is(notNullValue()));
-        assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
-        assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.NONE));
     }
 
     @SuppressWarnings("unchecked")

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -157,7 +157,7 @@ public class AuthenticationAPIClientTest {
 
         ArgumentCaptor<Interceptor> interceptorCaptor = ArgumentCaptor.forClass(Interceptor.class);
         AuthenticationAPIClient client = new AuthenticationAPIClient(account, factory, okClient);
-        client.enableLogging();
+        client.setLoggingEnabled(true);
 
         verify(okClient).interceptors();
         verify(list).add(interceptorCaptor.capture());
@@ -165,6 +165,29 @@ public class AuthenticationAPIClientTest {
         assertThat(interceptorCaptor.getValue(), is(notNullValue()));
         assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
         assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.BODY));
+        assertThat(client.isLoggingEnabled(), is(true));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldDisableHttpLogging() throws Exception {
+        Auth0 account = mock(Auth0.class);
+        RequestFactory factory = mock(RequestFactory.class);
+        OkHttpClient okClient = mock(OkHttpClient.class);
+        List list = mock(List.class);
+        when(okClient.interceptors()).thenReturn(list);
+
+        ArgumentCaptor<Interceptor> interceptorCaptor = ArgumentCaptor.forClass(Interceptor.class);
+        AuthenticationAPIClient client = new AuthenticationAPIClient(account, factory, okClient);
+        client.setLoggingEnabled(false);
+
+        verify(okClient).interceptors();
+        verify(list).add(interceptorCaptor.capture());
+
+        assertThat(interceptorCaptor.getValue(), is(notNullValue()));
+        assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
+        assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.NONE));
+        assertThat(client.isLoggingEnabled(), is(false));
     }
 
     @SuppressWarnings("unchecked")
@@ -185,6 +208,7 @@ public class AuthenticationAPIClientTest {
         assertThat(interceptorCaptor.getValue(), is(notNullValue()));
         assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
         assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.NONE));
+        assertThat(client.isLoggingEnabled(), is(false));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
@@ -152,7 +152,7 @@ public class UsersAPIClientTest {
 
         ArgumentCaptor<Interceptor> interceptorCaptor = ArgumentCaptor.forClass(Interceptor.class);
         UsersAPIClient client = new UsersAPIClient(account, factory, okClient);
-        client.setLogging(true);
+        client.enableLogging();
 
         verify(okClient).interceptors();
         verify(list).add(interceptorCaptor.capture());
@@ -160,27 +160,6 @@ public class UsersAPIClientTest {
         assertThat(interceptorCaptor.getValue(), is(notNullValue()));
         assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
         assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.BODY));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldDisableHttpLogging() throws Exception {
-        Auth0 account = mock(Auth0.class);
-        RequestFactory factory = mock(RequestFactory.class);
-        OkHttpClient okClient = mock(OkHttpClient.class);
-        List list = mock(List.class);
-        when(okClient.interceptors()).thenReturn(list);
-
-        ArgumentCaptor<Interceptor> interceptorCaptor = ArgumentCaptor.forClass(Interceptor.class);
-        UsersAPIClient client = new UsersAPIClient(account, factory, okClient);
-        client.setLogging(false);
-
-        verify(okClient).interceptors();
-        verify(list).add(interceptorCaptor.capture());
-
-        assertThat(interceptorCaptor.getValue(), is(notNullValue()));
-        assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
-        assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.NONE));
     }
 
     @SuppressWarnings("unchecked")

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -126,21 +126,11 @@ public class WebAuthProviderTest {
     @Test
     public void shouldEnableLogging() throws Exception {
         WebAuthProvider.init(account)
-                .setLogging(true)
+                .enableLogging()
                 .start(activity, callback);
 
         final WebAuthProvider instance = WebAuthProvider.getInstance();
         assertTrue(instance.isLoggingEnabled());
-    }
-
-    @Test
-    public void shouldDisableLogging() throws Exception {
-        WebAuthProvider.init(account)
-                .setLogging(false)
-                .start(activity, callback);
-
-        final WebAuthProvider instance = WebAuthProvider.getInstance();
-        assertFalse(instance.isLoggingEnabled());
     }
 
     //connection

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -114,6 +114,34 @@ public class WebAuthProviderTest {
         assertFalse(WebAuthProvider.resume(0, 0, intentMock));
     }
 
+    //logging
+    public void shouldHaveLoggingDisabledByDefault() throws Exception {
+        WebAuthProvider.init(account)
+                .start(activity, callback);
+
+        final WebAuthProvider instance = WebAuthProvider.getInstance();
+        assertFalse(instance.isLoggingEnabled());
+    }
+
+    @Test
+    public void shouldEnableLogging() throws Exception {
+        WebAuthProvider.init(account)
+                .setLogging(true)
+                .start(activity, callback);
+
+        final WebAuthProvider instance = WebAuthProvider.getInstance();
+        assertTrue(instance.isLoggingEnabled());
+    }
+
+    @Test
+    public void shouldDisableLogging() throws Exception {
+        WebAuthProvider.init(account)
+                .setLogging(false)
+                .start(activity, callback);
+
+        final WebAuthProvider instance = WebAuthProvider.getInstance();
+        assertFalse(instance.isLoggingEnabled());
+    }
 
     //connection
 


### PR DESCRIPTION
Logging is disabled by default. Usage:

```java
WebAuthProvider.init(account)
    .enableLogging()
    .start(activity, callback);
```

or in the API Clients

```java
AuthenticationAPIClient authClient = new AuthenticationAPIClient(account);
authClient.enableLogging();

UsersAPIClient usersClient = new UsersAPIClient(account);
usersClient.enableLogging();
```
