### PR TITLE
Login with password grant using /oauth/token endpoint

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
@@ -64,6 +64,7 @@ public class ParameterBuilder {
     public static final String CLIENT_ID_KEY = "client_id";
     public static final String GRANT_TYPE_KEY = "grant_type";
     public static final String DEVICE_KEY = "device";
+    public static final String AUDIENCE_KEY = "audience";
 
     private Map<String, Object> parameters;
 
@@ -110,6 +111,16 @@ public class ParameterBuilder {
      */
     public ParameterBuilder setScope(String scope) {
         return set(SCOPE_KEY, scope);
+    }
+
+    /**
+     * Sets the 'audience' parameter.
+     *
+     * @param audience an audience value
+     * @return itself
+     */
+    public ParameterBuilder setAudience(String audience) {
+        return set(AUDIENCE_KEY, audience);
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.java
@@ -89,6 +89,12 @@ public class SignUpRequest implements Request<Credentials, AuthenticationExcepti
     }
 
     @Override
+    public AuthenticationRequest setAudience(String audience) {
+        authenticationRequest.setAudience(audience);
+        return this;
+    }
+
+    @Override
     public AuthenticationRequest setAccessToken(String accessToken) {
         authenticationRequest.setAccessToken(accessToken);
         return this;

--- a/auth0/src/main/java/com/auth0/android/request/AuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/AuthenticationRequest.java
@@ -43,6 +43,14 @@ public interface AuthenticationRequest extends Request<Credentials, Authenticati
     AuthenticationRequest setDevice(String device);
 
     /**
+     * Sets the 'audience' parameter.
+     *
+     * @param audience an audience value
+     * @return itself
+     */
+    AuthenticationRequest setAudience(String audience);
+
+    /**
      * Sets the 'access_token' parameter
      *
      * @param accessToken a access token

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
@@ -10,6 +10,7 @@ import com.squareup.okhttp.OkHttpClient;
 import java.util.Map;
 
 import static com.auth0.android.authentication.ParameterBuilder.ACCESS_TOKEN_KEY;
+import static com.auth0.android.authentication.ParameterBuilder.AUDIENCE_KEY;
 import static com.auth0.android.authentication.ParameterBuilder.CONNECTION_KEY;
 import static com.auth0.android.authentication.ParameterBuilder.DEVICE_KEY;
 import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_KEY;
@@ -64,6 +65,18 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
      */
     public AuthenticationRequest setDevice(String device) {
         addParameter(DEVICE_KEY, device);
+        return this;
+    }
+
+    /**
+     * Sets the 'audience' parameter.
+     *
+     * @param audience an audience value
+     * @return itself
+     */
+    @Override
+    public AuthenticationRequest setAudience(String audience) {
+        addParameter(AUDIENCE_KEY, audience);
         return this;
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -204,7 +204,7 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin();
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
 
-        client.loginWithToken(SUPPORT_AUTH0_COM, "some-password")
+        client.login(SUPPORT_AUTH0_COM, "some-password")
                 .start(callback);
         assertThat(callback, hasPayloadOfType(Credentials.class));
 
@@ -215,6 +215,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, hasEntry("grant_type", "password"));
         assertThat(body, hasEntry("username", SUPPORT_AUTH0_COM));
         assertThat(body, hasEntry("password", "some-password"));
+        assertThat(body, not(hasKey("connection")));
         assertThat(body, not(hasKey("scope")));
         assertThat(body, not(hasKey("audience")));
     }
@@ -224,7 +225,7 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin();
 
         final Credentials credentials = client
-                .loginWithToken(SUPPORT_AUTH0_COM, "some-password")
+                .login(SUPPORT_AUTH0_COM, "some-password")
                 .execute();
         assertThat(credentials, is(notNullValue()));
 
@@ -235,6 +236,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, hasEntry("grant_type", "password"));
         assertThat(body, hasEntry("username", SUPPORT_AUTH0_COM));
         assertThat(body, hasEntry("password", "some-password"));
+        assertThat(body, not(hasKey("connection")));
         assertThat(body, not(hasKey("scope")));
         assertThat(body, not(hasKey("audience")));
     }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -200,6 +200,46 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
+    public void shouldLoginWithUserAndPasswordUsingOAuthTokenEndpoint() throws Exception {
+        mockAPI.willReturnSuccessfulLogin();
+        final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
+
+        client.loginWithToken(SUPPORT_AUTH0_COM, "some-password")
+                .start(callback);
+        assertThat(callback, hasPayloadOfType(Credentials.class));
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("grant_type", "password"));
+        assertThat(body, hasEntry("username", SUPPORT_AUTH0_COM));
+        assertThat(body, hasEntry("password", "some-password"));
+        assertThat(body, not(hasKey("scope")));
+        assertThat(body, not(hasKey("audience")));
+    }
+
+    @Test
+    public void shouldLoginWithUserAndPasswordSyncUsingOAuthTokenEndpoint() throws Exception {
+        mockAPI.willReturnSuccessfulLogin();
+
+        final Credentials credentials = client
+                .loginWithToken(SUPPORT_AUTH0_COM, "some-password")
+                .execute();
+        assertThat(credentials, is(notNullValue()));
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("grant_type", "password"));
+        assertThat(body, hasEntry("username", SUPPORT_AUTH0_COM));
+        assertThat(body, hasEntry("password", "some-password"));
+        assertThat(body, not(hasKey("scope")));
+        assertThat(body, not(hasKey("audience")));
+    }
+
+    @Test
     public void shouldFetchTokenInfo() throws Exception {
         mockAPI.willReturnTokenInfo();
         final MockAuthenticationCallback<UserProfile> callback = new MockAuthenticationCallback<>();

--- a/auth0/src/test/java/com/auth0/android/authentication/ParameterBuilderTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/ParameterBuilderTest.java
@@ -93,6 +93,12 @@ public class ParameterBuilderTest {
     }
 
     @Test
+    public void shouldSetAudience() throws Exception {
+        Map<String, Object> parameters = builder.setAudience("https://domain.auth0.com/api").asDictionary();
+        assertThat(parameters, hasEntry("audience", "https://domain.auth0.com/api"));
+    }
+
+    @Test
     public void shouldSetDevice() throws Exception {
         Map<String, Object> parameters = builder.setDevice(DEVICE).asDictionary();
         assertThat(parameters, hasEntry("device", DEVICE));

--- a/auth0/src/test/java/com/auth0/android/authentication/request/AuthenticationRequestMock.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/AuthenticationRequestMock.java
@@ -54,6 +54,11 @@ public class AuthenticationRequestMock implements AuthenticationRequest {
     }
 
     @Override
+    public AuthenticationRequest setAudience(String audience) {
+        return this;
+    }
+
+    @Override
     public AuthenticationRequest setAccessToken(String accessToken) {
         return this;
     }

--- a/auth0/src/test/java/com/auth0/android/authentication/request/SignUpRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/SignUpRequestTest.java
@@ -68,6 +68,14 @@ public class SignUpRequestTest {
     }
 
     @Test
+    public void shouldSetAudience() throws Exception {
+        final AuthenticationRequest req = signUpRequest.setAudience("https://domain.auth0.com/api");
+        verify(authenticationMockRequest).setAudience("https://domain.auth0.com/api");
+        Assert.assertThat(req, is(notNullValue()));
+        Assert.assertThat(req, Matchers.<AuthenticationRequest>is(signUpRequest));
+    }
+
+    @Test
     public void shouldSetDevice() throws Exception {
         final AuthenticationRequest req = signUpRequest.setDevice("nexus-5x");
         verify(authenticationMockRequest).setDevice("nexus-5x");

--- a/auth0/src/test/java/com/auth0/android/request/internal/MockAuthenticationRequest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/MockAuthenticationRequest.java
@@ -50,6 +50,11 @@ public class MockAuthenticationRequest implements ParameterizableRequest<Credent
     }
 
     @Override
+    public AuthenticationRequest setAudience(String audience) {
+        return null;
+    }
+
+    @Override
     public AuthenticationRequest setAccessToken(String accessToken) {
         return null;
     }


### PR DESCRIPTION
Allow to log in with Resource Owner using `/oauth/token` endpoint.

Usage:

```java
AuthenticationAPIClient client = new AuthenticationAPIClient(getAccount());
client.login("username", "password")
    .setAudience("https://domain.auth0.com/my/api")
    .setScope("profile friends:email")
    .start(callback);  //Callback will receive `Credentials` on success.
```