### PR TITLE
Get new Credentials using a Refresh Token

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -506,6 +506,41 @@ public class AuthenticationAPIClient {
     }
 
     /**
+     * Requests new Credentials using a valid Refresh Token.
+     * Example usage:
+     * <pre><code>
+     * client.renewAuth("{refresh_token}")
+     *      .addParameter("scope", "openid profile email")
+     *      .start(new BaseCallback<Credentials>() {
+     *          {@literal}Override
+     *          public void onSuccess(Credentials payload) { }
+     *
+     *          {@literal}@Override
+     *          public void onFailure(AuthenticationException error) { }
+     *      });
+     * </code></pre>
+     *
+     * @param refreshToken used to fetch the new Credentials.
+     * @return a request to start
+     */
+    @SuppressWarnings("WeakerAccess")
+    public ParameterizableRequest<Credentials, AuthenticationException> renewAuth(@NonNull String refreshToken) {
+        final Map<String, Object> parameters = ParameterBuilder.newBuilder()
+                .setClientId(getClientId())
+                .setRefreshToken(refreshToken)
+                .setGrantType(ParameterBuilder.GRANT_TYPE_REFRESH_TOKEN)
+                .asDictionary();
+
+        HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
+                .addPathSegment(OAUTH_PATH)
+                .addPathSegment(TOKEN_PATH)
+                .build();
+
+        return factory.POST(url, client, gson, Credentials.class, authErrorBuilder)
+                .addParameters(parameters);
+    }
+
+    /**
      * Performs a <a href="https://auth0.com/docs/auth-api#!#post--delegation">delegation</a> request that will yield a new Auth0 'id_token'
      * Example usage:
      * <pre><code>

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
@@ -47,6 +47,7 @@ import java.util.Map;
  */
 public class ParameterBuilder {
 
+    public static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
     public static final String GRANT_TYPE_PASSWORD = "password";
     public static final String GRANT_TYPE_JWT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
     public static final String GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code";
@@ -129,6 +130,16 @@ public class ParameterBuilder {
      */
     public ParameterBuilder setAccessToken(String accessToken) {
         return set(ACCESS_TOKEN_KEY, accessToken);
+    }
+
+    /**
+     * Sets the 'refresh_token' parameter
+     *
+     * @param refreshToken a access token
+     * @return itself
+     */
+    public ParameterBuilder setRefreshToken(String refreshToken) {
+        return set(REFRESH_TOKEN_KEY, refreshToken);
     }
 
     /**

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -1298,6 +1298,45 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
+    public void shouldRenewAuth() throws Exception {
+        mockAPI.willReturnSuccessfulLogin();
+
+        final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
+        client.renewAuth("refreshToken")
+                .start(callback);
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
+        assertThat(request.getPath(), equalTo("/oauth/token"));
+
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("refresh_token", "refreshToken"));
+        assertThat(body, hasEntry("grant_type", "refresh_token"));
+
+        assertThat(callback, hasPayloadOfType(Credentials.class));
+    }
+
+    @Test
+    public void shouldRenewAuthSync() throws Exception {
+        mockAPI.willReturnSuccessfulLogin();
+
+        Credentials credentials = client.renewAuth("refreshToken")
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
+        assertThat(request.getPath(), equalTo("/oauth/token"));
+
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("refresh_token", "refreshToken"));
+        assertThat(body, hasEntry("grant_type", "refresh_token"));
+
+        assertThat(credentials, is(notNullValue()));
+    }
+
+    @Test
     public void shouldGetOAuthTokensUsingCodeVerifier() throws Exception {
         mockAPI.willReturnTokens()
                 .willReturnTokenInfo();

--- a/auth0/src/test/java/com/auth0/android/authentication/ParameterBuilderTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/ParameterBuilderTest.java
@@ -99,6 +99,12 @@ public class ParameterBuilderTest {
     }
 
     @Test
+    public void shouldSetRefreshToken() throws Exception {
+        Map<String, Object> parameters = builder.setRefreshToken(DEVICE).asDictionary();
+        assertThat(parameters, hasEntry("refresh_token", DEVICE));
+    }
+
+    @Test
     public void shouldSetScopeWithOfflineAccess() throws Exception {
         Map<String, Object> parameters = builder.setScope(ParameterBuilder.SCOPE_OFFLINE_ACCESS).asDictionary();
         assertThat(parameters, hasEntry("scope", ParameterBuilder.SCOPE_OFFLINE_ACCESS));


### PR DESCRIPTION
Use the `/oauth/token` endpoint to get new Credentials given a valid refresh token.

Usage: 

```java
AuthenticationAPIClient client = new AuthenticationAPIClient(getAccount())
client.renewAuth("{refresh_token}")
   .addParameter("scope", "openid profile email") //Can specify more parameters
   .start(new BaseCallback<Credentials>() {
       @Override
       public void onSuccess(Credentials payload) { }

       @Override
       public void onFailure(AuthenticationException error) { }
   });
```