### PR TITLE
Customize the Scheme used in the redirect_uri parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Also register the intent filters inside your activity's tag, so you can receive 
             android:theme="@style/MyAppTheme"
             android:launchMode="singleTask">
 
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -300,6 +300,20 @@ public class MyActivity extends Activity {
     }
 }
 
+```
+
+##### A note about App Deep Linking:
+
+Currently, the default scheme used in the Callback Uri is `https`. This works best for Android API 23 or newer if you're using [Android App Links](https://developer.android.com/training/app-links/index.html), but in previous Android versions this may show the intent chooser dialog prompting the user to chose either your application or the browser. You can change this behaviour by using a custom unique scheme, so that the OS opens directly the link with your app.
+1) Update the intent filter in the Android Manifest and change the custom scheme.
+2) Update the allowed callback urls in your [Auth0 Dashboard](https://manage.auth0.com/#/applications) client's settings.
+3) Call `withScheme()` passing the scheme you want to use.
+
+
+```java
+WebAuthProvider.init(account)
+                .withScheme("myapp")
+                .start(MainActivity.this, authCallback);
 ```
 
 #### Authenticate with any Auth0 connection

--- a/auth0/src/main/java/com/auth0/android/provider/CallbackHelper.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CallbackHelper.java
@@ -28,8 +28,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
-
-import com.squareup.okhttp.HttpUrl;
+import android.webkit.URLUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,9 +37,11 @@ class CallbackHelper {
 
     private static final String TAG = CallbackHelper.class.getSimpleName();
     private final String packageName;
+    private final String scheme;
 
-    public CallbackHelper(@NonNull String packageName) {
+    public CallbackHelper(@NonNull String packageName, @NonNull String scheme) {
         this.packageName = packageName;
+        this.scheme = scheme;
     }
 
     /**
@@ -49,15 +50,17 @@ class CallbackHelper {
      * @return the callback URI.
      */
     public String getCallbackURI(@NonNull String domain) {
-        HttpUrl url = HttpUrl.parse(domain);
-        if (url == null) {
+        if (!URLUtil.isValidUrl(domain)) {
             Log.e(TAG, "The Domain is invalid and the Callback URI will not be set. You used: " + domain);
             return null;
         }
-        url = url.newBuilder()
-                .addPathSegment("android")
-                .addPathSegment(packageName)
-                .addPathSegment("callback")
+
+        Uri url = Uri.parse(domain);
+        url = url.buildUpon()
+                .scheme(scheme)
+                .appendPath("android")
+                .appendPath(packageName)
+                .appendPath("callback")
                 .build();
 
         Log.v(TAG, "The Callback URI is: " + url);

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -62,6 +62,7 @@ public class WebAuthProvider {
     private static final String KEY_TOKEN_TYPE = "token_type";
     private static final String KEY_REFRESH_TOKEN = "refresh_token";
     private static final String KEY_RESPONSE_TYPE = "response_type";
+    private static final String KEY_SCHEME = "scheme";
     private static final String KEY_STATE = "state";
     private static final String KEY_NONCE = "nonce";
     private static final String KEY_AUDIENCE = "audience";
@@ -94,6 +95,7 @@ public class WebAuthProvider {
 
     private static WebAuthProvider providerInstance;
     private boolean loggingEnabled;
+    private String scheme;
 
     @VisibleForTesting
     WebAuthProvider(@NonNull Auth0 account) {
@@ -108,12 +110,14 @@ public class WebAuthProvider {
         private boolean useFullscreen;
         private PKCE pkce;
         private boolean loggingEnabled;
+        private String scheme;
 
         Builder(Auth0 account) {
             this.account = account;
             this.values = new HashMap<>();
 
             //Default values
+            this.scheme = "https";
             this.useBrowser = true;
             this.useFullscreen = false;
             withResponseType(ResponseType.CODE);
@@ -177,6 +181,17 @@ public class WebAuthProvider {
          */
         public Builder withAudience(@NonNull String audience) {
             this.values.put(KEY_AUDIENCE, audience);
+            return this;
+        }
+
+        /**
+         * Specify a custom Scheme to use on the Callback Uri. Default scheme is 'https'.
+         *
+         * @param scheme to use in the Callback Uri.
+         * @return the current builder instance
+         */
+        public Builder withScheme(@NonNull String scheme) {
+            this.scheme = scheme;
             return this;
         }
 
@@ -302,6 +317,7 @@ public class WebAuthProvider {
             webAuth.parameters = values;
             webAuth.pkce = pkce;
             webAuth.loggingEnabled = loggingEnabled;
+            webAuth.scheme = scheme;
 
             providerInstance = webAuth;
 
@@ -447,7 +463,7 @@ public class WebAuthProvider {
         this.callback = callback;
         this.requestCode = requestCode;
         String pkgName = activity.getApplicationContext().getPackageName();
-        helper = new CallbackHelper(pkgName);
+        helper = new CallbackHelper(pkgName, scheme);
 
         if (account.getAuthorizeUrl() == null) {
             final AuthenticationException ex = new AuthenticationException("a0.invalid_authorize_url", "Auth0 authorize URL not properly set. This can be related to an invalid domain.");

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -139,6 +139,35 @@ public class WebAuthProviderTest {
         assertTrue(instance.isLoggingEnabled());
     }
 
+    //scheme
+
+    @Test
+    public void shouldHaveDefaultScheme() throws Exception {
+        WebAuthProvider.init(account)
+                .start(activity, callback);
+
+        final WebAuthProvider provider = WebAuthProvider.getInstance();
+        Uri uri = provider.buildAuthorizeUri();
+
+        assertThat(uri, hasParamWithName("redirect_uri"));
+        Uri redirectUri = Uri.parse(uri.getQueryParameter("redirect_uri"));
+        assertThat(redirectUri, hasScheme("https"));
+    }
+
+    @Test
+    public void shouldSetScheme() throws Exception {
+        WebAuthProvider.init(account)
+                .withScheme("myapp")
+                .start(activity, callback);
+
+        WebAuthProvider provider = WebAuthProvider.getInstance();
+        Uri uri = provider.buildAuthorizeUri();
+
+        assertThat(uri, hasParamWithName("redirect_uri"));
+        Uri redirectUri = Uri.parse(uri.getQueryParameter("redirect_uri"));
+        assertThat(redirectUri, hasScheme("myapp"));
+    }
+
     //connection
 
     @Test


### PR DESCRIPTION
Customize the Scheme used in the redirect_uri. Default scheme is still `https`.
```java
WebAuthProvider.init(account)
                .withScheme("myapp")
                .start(MainActivity.this, authCallback);
```

Related to https://github.com/auth0/Auth0.Android/issues/52