### PR TITLE
Use password-realm grant for /oauth/token endpoint

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -54,6 +54,7 @@ import java.util.Map;
 
 import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_AUTHORIZATION_CODE;
 import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_PASSWORD;
+import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_PASSWORD_REALM;
 import static com.auth0.android.authentication.ParameterBuilder.ID_TOKEN_KEY;
 
 /**
@@ -223,7 +224,7 @@ public class AuthenticationAPIClient {
         Map<String, Object> requestParameters = ParameterBuilder.newBuilder()
                 .set(USERNAME_KEY, usernameOrEmail)
                 .set(PASSWORD_KEY, password)
-                .setGrantType(GRANT_TYPE_PASSWORD)
+                .setGrantType(GRANT_TYPE_PASSWORD_REALM)
                 .asDictionary();
 
         return loginWithToken(requestParameters);
@@ -496,7 +497,7 @@ public class AuthenticationAPIClient {
 
     /**
      * Creates a user in a DB connection using <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-signup">'/dbconnections/signup' endpoint</a>
-     * and then logs in
+     * and then logs in using the /oauth/ro endpoint.
      * Example usage:
      * <pre><code>
      * client.signUp("{email}", "{password}", "{username}", "{database connection name}")
@@ -524,7 +525,7 @@ public class AuthenticationAPIClient {
 
     /**
      * Creates a user in a DB connection using <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-signup">'/dbconnections/signup' endpoint</a>
-     * and then logs in
+     * and then logs in using the /oauth/ro endpoint.
      * Example usage:
      * <pre><code>
      * client.signUp("{email}", "{password}", "{database connection name}")

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
@@ -106,7 +106,7 @@ public class ParameterBuilder {
     }
 
     /**
-     * Sets the 'realm' parameter
+     * Sets the 'realm' parameter. A realm identifies the host against which the authentication will be made, and usually helps to know which username and password to use.
      *
      * @param realm name of the realm
      * @return itself

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
@@ -49,6 +49,7 @@ public class ParameterBuilder {
 
     public static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
     public static final String GRANT_TYPE_PASSWORD = "password";
+    public static final String GRANT_TYPE_PASSWORD_REALM = "http://auth0.com/oauth/grant-type/password-realm";
     public static final String GRANT_TYPE_JWT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
     public static final String GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code";
 
@@ -59,6 +60,7 @@ public class ParameterBuilder {
     public static final String SCOPE_KEY = "scope";
     public static final String REFRESH_TOKEN_KEY = "refresh_token";
     public static final String CONNECTION_KEY = "connection";
+    public static final String REALM_KEY = "realm";
     public static final String ACCESS_TOKEN_KEY = "access_token";
     public static final String SEND_KEY = "send";
     public static final String CLIENT_ID_KEY = "client_id";
@@ -101,6 +103,16 @@ public class ParameterBuilder {
      */
     public ParameterBuilder setConnection(String connection) {
         return set(CONNECTION_KEY, connection);
+    }
+
+    /**
+     * Sets the 'realm' parameter
+     *
+     * @param realm name of the realm
+     * @return itself
+     */
+    public ParameterBuilder setRealm(String realm) {
+        return set(REALM_KEY, realm);
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.java
@@ -41,7 +41,6 @@ import java.util.Map;
  */
 public class ProfileRequest implements Request<Authentication, AuthenticationException> {
 
-    private static final String ACCESS_TOKEN_KEY = "access_token";
     private static final String HEADER_AUTHORIZATION = "Authorization";
 
     private final AuthenticationRequest credentialsRequest;

--- a/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.java
@@ -49,9 +49,10 @@ public class SignUpRequest implements Request<Credentials, AuthenticationExcepti
     }
 
     /**
-     * Add additional parameters sent when creating a using.
+     * Add additional parameters sent when creating a user.
      *
      * @param parameters sent with the request and must be non-null
+     * @see ParameterBuilder
      * @return itself
      */
     public SignUpRequest addSignUpParameters(Map<String, Object> parameters) {
@@ -66,17 +67,13 @@ public class SignUpRequest implements Request<Credentials, AuthenticationExcepti
      * @return itself
      * @see ParameterBuilder
      */
+    @Override
     public SignUpRequest addAuthenticationParameters(Map<String, Object> parameters) {
         authenticationRequest.addAuthenticationParameters(parameters);
         return this;
     }
 
-    /**
-     * Set the scope used to login the user
-     *
-     * @param scope value
-     * @return itself
-     */
+    @Override
     public SignUpRequest setScope(String scope) {
         authenticationRequest.setScope(scope);
         return this;
@@ -106,12 +103,7 @@ public class SignUpRequest implements Request<Credentials, AuthenticationExcepti
         return this;
     }
 
-    /**
-     * Set the connection used to authenticate
-     *
-     * @param connection name
-     * @return itself
-     */
+    @Override
     public SignUpRequest setConnection(String connection) {
         signUpRequest.setConnection(connection);
         authenticationRequest.setConnection(connection);

--- a/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.java
@@ -83,25 +83,25 @@ public class SignUpRequest implements Request<Credentials, AuthenticationExcepti
     }
 
     @Override
-    public AuthenticationRequest setDevice(String device) {
+    public SignUpRequest setDevice(String device) {
         authenticationRequest.setDevice(device);
         return this;
     }
 
     @Override
-    public AuthenticationRequest setAudience(String audience) {
+    public SignUpRequest setAudience(String audience) {
         authenticationRequest.setAudience(audience);
         return this;
     }
 
     @Override
-    public AuthenticationRequest setAccessToken(String accessToken) {
+    public SignUpRequest setAccessToken(String accessToken) {
         authenticationRequest.setAccessToken(accessToken);
         return this;
     }
 
     @Override
-    public AuthenticationRequest setGrantType(String grantType) {
+    public SignUpRequest setGrantType(String grantType) {
         authenticationRequest.setGrantType(grantType);
         return this;
     }
@@ -115,6 +115,13 @@ public class SignUpRequest implements Request<Credentials, AuthenticationExcepti
     public SignUpRequest setConnection(String connection) {
         signUpRequest.setConnection(connection);
         authenticationRequest.setConnection(connection);
+        return this;
+    }
+
+    @Override
+    public SignUpRequest setRealm(String realm) {
+        signUpRequest.setConnection(realm);
+        authenticationRequest.setRealm(realm);
         return this;
     }
 

--- a/auth0/src/main/java/com/auth0/android/request/AuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/AuthenticationRequest.java
@@ -27,7 +27,7 @@ public interface AuthenticationRequest extends Request<Credentials, Authenticati
     AuthenticationRequest setConnection(String connection);
 
     /**
-     * Sets the 'realm' parameter
+     * Sets the 'realm' parameter. A realm identifies the host against which the authentication will be made, and usually helps to know which username and password to use.
      *
      * @param realm name of the realm to use.
      * @return itself

--- a/auth0/src/main/java/com/auth0/android/request/AuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/AuthenticationRequest.java
@@ -27,6 +27,14 @@ public interface AuthenticationRequest extends Request<Credentials, Authenticati
     AuthenticationRequest setConnection(String connection);
 
     /**
+     * Sets the 'realm' parameter
+     *
+     * @param realm name of the realm to use.
+     * @return itself
+     */
+    AuthenticationRequest setRealm(String realm);
+
+    /**
      * Sets the 'scope' parameter.
      *
      * @param scope a scope value

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
@@ -14,6 +14,7 @@ import static com.auth0.android.authentication.ParameterBuilder.AUDIENCE_KEY;
 import static com.auth0.android.authentication.ParameterBuilder.CONNECTION_KEY;
 import static com.auth0.android.authentication.ParameterBuilder.DEVICE_KEY;
 import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_KEY;
+import static com.auth0.android.authentication.ParameterBuilder.REALM_KEY;
 import static com.auth0.android.authentication.ParameterBuilder.SCOPE_KEY;
 
 class BaseAuthenticationRequest extends SimpleRequest<Credentials, AuthenticationException> implements AuthenticationRequest {
@@ -43,6 +44,18 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
     @Override
     public AuthenticationRequest setConnection(String connection) {
         addParameter(CONNECTION_KEY, connection);
+        return this;
+    }
+
+    /**
+     * Sets the 'realm' parameter
+     *
+     * @param realm name of the realm
+     * @return itself
+     */
+    @Override
+    public AuthenticationRequest setRealm(String realm) {
+        addParameter(REALM_KEY, realm);
         return this;
     }
 

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
@@ -1,5 +1,7 @@
 package com.auth0.android.request.internal;
 
+import android.util.Log;
+
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.result.Credentials;
@@ -7,6 +9,7 @@ import com.google.gson.Gson;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.auth0.android.authentication.ParameterBuilder.ACCESS_TOKEN_KEY;
@@ -19,8 +22,14 @@ import static com.auth0.android.authentication.ParameterBuilder.SCOPE_KEY;
 
 class BaseAuthenticationRequest extends SimpleRequest<Credentials, AuthenticationException> implements AuthenticationRequest {
 
+    private static final String TAG = BaseAuthenticationRequest.class.getSimpleName();
+
     public BaseAuthenticationRequest(HttpUrl url, OkHttpClient client, Gson gson, String httpMethod, Class<Credentials> clazz) {
         super(url, client, gson, httpMethod, clazz, new AuthenticationErrorBuilder());
+    }
+
+    private boolean hasLegacyPath() {
+        return url.encodedPath().equals("/oauth/ro");
     }
 
     /**
@@ -36,25 +45,33 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
     }
 
     /**
-     * Sets the 'connection' parameter
+     * Sets the 'connection' parameter.
      *
      * @param connection name of the connection
      * @return itself
      */
     @Override
     public AuthenticationRequest setConnection(String connection) {
+        if (!hasLegacyPath()) {
+            Log.w(TAG, "Not setting the 'connection' parameter as the request is using a OAuth 2.0 API Authorization endpoint that doesn't support it.");
+            return this;
+        }
         addParameter(CONNECTION_KEY, connection);
         return this;
     }
 
     /**
-     * Sets the 'realm' parameter
+     * Sets the 'realm' parameter. A realm identifies the host against which the authentication will be made, and usually helps to know which username and password to use.
      *
      * @param realm name of the realm
      * @return itself
      */
     @Override
     public AuthenticationRequest setRealm(String realm) {
+        if (hasLegacyPath()) {
+            Log.w(TAG, "Not setting the 'realm' parameter as the request is using a Legacy Authorization API endpoint that doesn't support it.");
+            return this;
+        }
         addParameter(REALM_KEY, realm);
         return this;
     }
@@ -106,7 +123,14 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
 
     @Override
     public AuthenticationRequest addAuthenticationParameters(Map<String, Object> parameters) {
-        addParameters(parameters);
+        final HashMap<String, Object> params = new HashMap<>(parameters);
+        if (parameters.containsKey(CONNECTION_KEY)) {
+            setConnection((String) params.remove(CONNECTION_KEY));
+        }
+        if (parameters.containsKey(REALM_KEY)) {
+            setRealm((String) params.remove(REALM_KEY));
+        }
+        addParameters(params);
         return this;
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
@@ -29,7 +29,7 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
     }
 
     private boolean hasLegacyPath() {
-        return url.encodedPath().equals("/oauth/ro");
+        return !url.encodedPath().equals("/oauth/token");
     }
 
     /**

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -50,8 +50,11 @@ import com.squareup.okhttp.mockwebserver.RecordedRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -82,6 +85,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = com.auth0.android.auth0.BuildConfig.class, sdk = 21, manifest = Config.NONE)
 public class AuthenticationAPIClientTest {
 
     private static final String CLIENT_ID = "CLIENTID";

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -287,7 +287,7 @@ public class AuthenticationAPIClientTest {
         assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         Map<String, String> body = bodyFromRequest(request);
         assertThat(body, hasEntry("client_id", CLIENT_ID));
-        assertThat(body, hasEntry("grant_type", "password"));
+        assertThat(body, hasEntry("grant_type", "http://auth0.com/oauth/grant-type/password-realm"));
         assertThat(body, hasEntry("username", SUPPORT_AUTH0_COM));
         assertThat(body, hasEntry("password", "some-password"));
         assertThat(body, not(hasKey("connection")));
@@ -308,7 +308,7 @@ public class AuthenticationAPIClientTest {
         assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         Map<String, String> body = bodyFromRequest(request);
         assertThat(body, hasEntry("client_id", CLIENT_ID));
-        assertThat(body, hasEntry("grant_type", "password"));
+        assertThat(body, hasEntry("grant_type", "http://auth0.com/oauth/grant-type/password-realm"));
         assertThat(body, hasEntry("username", SUPPORT_AUTH0_COM));
         assertThat(body, hasEntry("password", "some-password"));
         assertThat(body, not(hasKey("connection")));

--- a/auth0/src/test/java/com/auth0/android/authentication/ParameterBuilderTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/ParameterBuilderTest.java
@@ -48,6 +48,7 @@ public class ParameterBuilderTest {
     public static final String CLIENT_ID = "CLIENT ID";
     public static final String GRANT_TYPE = "password";
     public static final String CONNECTION = "AD";
+    public static final String REALM = "users";
     public static final String DEVICE = "ANDROID TEST DEVICE";
 
     @Rule
@@ -124,6 +125,11 @@ public class ParameterBuilderTest {
     @Test
     public void shouldSetConnection() throws Exception {
         assertThat(builder.setConnection(CONNECTION).asDictionary(), hasEntry("connection", CONNECTION));
+    }
+
+    @Test
+    public void shouldSetRealm() throws Exception {
+        assertThat(builder.setRealm(REALM).asDictionary(), hasEntry("realm", REALM));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/request/AuthenticationRequestMock.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/AuthenticationRequestMock.java
@@ -44,6 +44,11 @@ public class AuthenticationRequestMock implements AuthenticationRequest {
     }
 
     @Override
+    public AuthenticationRequest setRealm(String realm) {
+        return this;
+    }
+
+    @Override
     public AuthenticationRequest setScope(String scope) {
         return this;
     }

--- a/auth0/src/test/java/com/auth0/android/authentication/request/SignUpRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/SignUpRequestTest.java
@@ -109,6 +109,15 @@ public class SignUpRequestTest {
     }
 
     @Test
+    public void shouldSetRealm() throws Exception {
+        final SignUpRequest req = signUpRequest.setRealm("users");
+        verify(dbMockRequest).setConnection("users");
+        verify(authenticationMockRequest).setRealm("users");
+        Assert.assertThat(req, is(notNullValue()));
+        Assert.assertThat(req, is(signUpRequest));
+    }
+
+    @Test
     public void shouldReturnCredentialsAfterStartingTheRequest() throws Exception {
         final DatabaseUser user = mock(DatabaseUser.class);
         final Credentials credentials = mock(Credentials.class);

--- a/auth0/src/test/java/com/auth0/android/request/internal/BaseAuthenticationRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/BaseAuthenticationRequestTest.java
@@ -1,0 +1,238 @@
+package com.auth0.android.request.internal;
+
+import com.auth0.android.request.AuthenticationRequest;
+import com.auth0.android.result.Credentials;
+import com.auth0.android.util.AuthenticationAPI;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.squareup.okhttp.HttpUrl;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = com.auth0.android.auth0.BuildConfig.class, sdk = 21, manifest = Config.NONE)
+public class BaseAuthenticationRequestTest {
+
+    public static final String OAUTH_PATH = "oauth";
+    public static final String RESOURCE_OWNER_PATH = "ro";
+    public static final String TOKEN_PATH = "token";
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private AuthenticationAPI mockAPI;
+    private BaseAuthenticationRequest request;
+    private Gson gson;
+
+    @Before
+    public void setUp() throws Exception {
+        mockAPI = new AuthenticationAPI();
+        gson = GsonProvider.buildGson();
+        HttpUrl url = HttpUrl.parse(mockAPI.getDomain())
+                .newBuilder()
+                .addPathSegment(OAUTH_PATH)
+                .addPathSegment(RESOURCE_OWNER_PATH)
+                .build();
+        request = createRequest(url);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mockAPI.shutdown();
+    }
+
+    private BaseAuthenticationRequest createRequest(HttpUrl url) {
+        return new BaseAuthenticationRequest(url, new OkHttpClient(), gson, "POST", Credentials.class);
+    }
+
+    private Map<String, String> bodyFromRequest(RecordedRequest request) throws java.io.IOException {
+        final Type mapType = new TypeToken<Map<String, String>>() {
+        }.getType();
+        return gson.fromJson(request.getBody().readUtf8(), mapType);
+    }
+
+    @Test
+    public void shouldSetGrantType() throws Exception {
+        mockAPI.willReturnSuccessfulLogin();
+        request.setGrantType("grantType")
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("grant_type", "grantType"));
+    }
+
+    @Test
+    public void shouldSetConnection() throws Exception {
+        mockAPI.willReturnSuccessfulLogin();
+        request.setConnection("my-connection")
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("connection", "my-connection"));
+    }
+
+    @Test
+    public void shouldNotSetConnectionOnNonLegacyEndpoints() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("method POST must have a request body.");
+        //no body was sent
+
+        HttpUrl url = HttpUrl.parse(mockAPI.getDomain())
+                .newBuilder()
+                .addPathSegment(OAUTH_PATH)
+                .addPathSegment(TOKEN_PATH)
+                .build();
+        AuthenticationRequest req = createRequest(url);
+        req.setConnection("my-connection")
+                .execute();
+    }
+
+    @Test
+    public void shouldSetRealm() throws Exception {
+        HttpUrl url = HttpUrl.parse(mockAPI.getDomain())
+                .newBuilder()
+                .addPathSegment(OAUTH_PATH)
+                .addPathSegment(TOKEN_PATH)
+                .build();
+        AuthenticationRequest req = createRequest(url);
+        mockAPI.willReturnSuccessfulLogin();
+        req.setRealm("users")
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("realm", "users"));
+    }
+
+    @Test
+    public void shouldNotSetRealmOnLegacyEndpoints() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("method POST must have a request body.");
+        //no body was sent
+
+        request.setRealm("users")
+                .execute();
+    }
+
+    @Test
+    public void shouldSetScope() throws Exception {
+        mockAPI.willReturnSuccessfulLogin();
+        request.setScope("profile photos")
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("scope", "profile photos"));
+    }
+
+    @Test
+    public void shouldSetDevice() throws Exception {
+        mockAPI.willReturnSuccessfulLogin();
+        request.setDevice("nexus-5x")
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("device", "nexus-5x"));
+    }
+
+    @Test
+    public void shouldSetAudience() throws Exception {
+        mockAPI.willReturnSuccessfulLogin();
+        request.setAudience("https://domain.auth0.com")
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("audience", "https://domain.auth0.com"));
+    }
+
+    @Test
+    public void shouldSetAccessToken() throws Exception {
+        mockAPI.willReturnSuccessfulLogin();
+        request.setAccessToken("accessToken")
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("access_token", "accessToken"));
+    }
+
+    @Test
+    public void shouldAddAuthenticationParameters() throws Exception {
+        HashMap<String, Object> parameters = new HashMap<>();
+        parameters.put("extra", "value");
+        parameters.put("123", "890");
+        mockAPI.willReturnSuccessfulLogin();
+        request.addAuthenticationParameters(parameters)
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("extra", "value"));
+        assertThat(body, hasEntry("123", "890"));
+    }
+
+    @Test
+    public void shouldWhiteListOAuth2ParametersOnLegacyEndpoints() throws Exception {
+        HashMap<String, Object> parameters = new HashMap<>();
+        parameters.put("extra", "value");
+        parameters.put("realm", "users");
+        HttpUrl url = HttpUrl.parse(mockAPI.getDomain())
+                .newBuilder()
+                .addPathSegment(OAUTH_PATH)
+                .addPathSegment(RESOURCE_OWNER_PATH)
+                .build();
+        AuthenticationRequest req = createRequest(url);
+        mockAPI.willReturnSuccessfulLogin();
+        req.addAuthenticationParameters(parameters)
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("extra", "value"));
+        assertThat(body, not(hasKey("realm")));
+    }
+
+    @Test
+    public void shouldWhiteListLegacyParametersOnNonLegacyEndpoints() throws Exception {
+        HashMap<String, Object> parameters = new HashMap<>();
+        parameters.put("extra", "value");
+        parameters.put("connection", "my-connection");
+        HttpUrl url = HttpUrl.parse(mockAPI.getDomain())
+                .newBuilder()
+                .addPathSegment(OAUTH_PATH)
+                .addPathSegment(TOKEN_PATH)
+                .build();
+        AuthenticationRequest req = createRequest(url);
+        mockAPI.willReturnSuccessfulLogin();
+        req.addAuthenticationParameters(parameters)
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("extra", "value"));
+        assertThat(body, not(hasKey("connection")));
+    }
+
+}

--- a/auth0/src/test/java/com/auth0/android/request/internal/MockAuthenticationRequest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/MockAuthenticationRequest.java
@@ -40,6 +40,11 @@ public class MockAuthenticationRequest implements ParameterizableRequest<Credent
     }
 
     @Override
+    public AuthenticationRequest setRealm(String realm) {
+        return null;
+    }
+
+    @Override
     public AuthenticationRequest setScope(String scope) {
         return null;
     }


### PR DESCRIPTION
Login using `/oauth/token` endpoint was sending `grant_type = 'password'` which was wrong. This PR fixes that and also allows the `AuthenticationRequest` to specify a realm value.