### PR TITLE
Add flag to authenticate with OIDC mode

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -97,7 +97,7 @@ public class AuthenticationAPIClient {
     private final Gson gson;
     private final com.auth0.android.request.internal.RequestFactory factory;
     private final ErrorBuilder<AuthenticationException> authErrorBuilder;
-    private boolean useOAuth2;
+    private boolean oauth2Preferred;
 
 
     /**
@@ -143,10 +143,17 @@ public class AuthenticationAPIClient {
      * This setting affects the methods {@link AuthenticationAPIClient#login(String, String, String)}, {@link AuthenticationAPIClient#tokenInfo(String)}, {@link AuthenticationAPIClient#signUp(String, String, String)} and {@link AuthenticationAPIClient#signUp(String, String, String, String)}.
      * Default is {@code false}.
      *
-     * @param use if Lock will use the OAuth 2.0 API or the legacy one.
+     * @param preferred if Lock will use the OAuth 2.0 API or the legacy one.
      */
-    public void useOAuth2(boolean use) {
-        this.useOAuth2 = use;
+    public void setOAuth2Preferred(boolean preferred) {
+        this.oauth2Preferred = preferred;
+    }
+
+    /**
+     * Getter for the OAuth 2.0 preferred current value.
+     */
+    public boolean isOAuth2Preferred() {
+        return oauth2Preferred;
     }
 
     /**
@@ -184,6 +191,7 @@ public class AuthenticationAPIClient {
 
     /**
      * Log in a user with email/username and password using a DB connection and the /oauth/ro endpoint.
+     * If {@link AuthenticationAPIClient#setOAuth2Preferred} is set to true, the /oauth/token endpoint will be used instead.
      * The default scope used is 'openid'.
      * Example usage:
      * <pre><code>
@@ -204,7 +212,7 @@ public class AuthenticationAPIClient {
      */
     @SuppressWarnings("WeakerAccess")
     public AuthenticationRequest login(@NonNull String usernameOrEmail, @NonNull String password, @NonNull String connection) {
-        if (useOAuth2) {
+        if (oauth2Preferred) {
             AuthenticationRequest login = login(usernameOrEmail, password);
             login.setRealm(connection);
             return login;
@@ -421,7 +429,7 @@ public class AuthenticationAPIClient {
 
     /**
      * Fetch the token information from Auth0.
-     * If {@link AuthenticationAPIClient#useOAuth2} is set to true, userInfo endpoint will be used instead.
+     * If {@link AuthenticationAPIClient#setOAuth2Preferred} is set to true, userInfo endpoint will be used instead.
      * <p>
      * Example usage:
      * <pre><code>
@@ -442,7 +450,7 @@ public class AuthenticationAPIClient {
     @SuppressWarnings("WeakerAccess")
     @Deprecated
     public Request<UserProfile, AuthenticationException> tokenInfo(@NonNull String idToken) {
-        if (useOAuth2) {
+        if (oauth2Preferred) {
             return userInfo(idToken);
         }
 
@@ -521,7 +529,7 @@ public class AuthenticationAPIClient {
 
     /**
      * Creates a user in a DB connection using <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-signup">'/dbconnections/signup' endpoint</a>
-     * and then logs in using the /oauth/ro endpoint. If {@link AuthenticationAPIClient#useOAuth2} is set to true, the /oauth/token endpoint will be used instead.
+     * and then logs in using the /oauth/ro endpoint. If {@link AuthenticationAPIClient#setOAuth2Preferred} is set to true, the /oauth/token endpoint will be used instead.
      * Example usage:
      * <pre><code>
      * client.signUp("{email}", "{password}", "{username}", "{database connection name}")
@@ -544,7 +552,7 @@ public class AuthenticationAPIClient {
     public SignUpRequest signUp(@NonNull String email, @NonNull String password, @NonNull String username, @NonNull String connection) {
         final DatabaseConnectionRequest<DatabaseUser, AuthenticationException> createUserRequest = createUser(email, password, username, connection);
         final AuthenticationRequest authenticationRequest;
-        if (useOAuth2) {
+        if (oauth2Preferred) {
             authenticationRequest = login(email, password);
             authenticationRequest.setRealm(connection);
         } else {
@@ -556,7 +564,7 @@ public class AuthenticationAPIClient {
 
     /**
      * Creates a user in a DB connection using <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-signup">'/dbconnections/signup' endpoint</a>
-     * and then logs in using the /oauth/ro endpoint. If {@link AuthenticationAPIClient#useOAuth2} is set to true, the /oauth/token endpoint will be used instead.
+     * and then logs in using the /oauth/ro endpoint. If {@link AuthenticationAPIClient#setOAuth2Preferred} is set to true, the /oauth/token endpoint will be used instead.
      * Example usage:
      * <pre><code>
      * client.signUp("{email}", "{password}", "{database connection name}")
@@ -578,7 +586,7 @@ public class AuthenticationAPIClient {
     public SignUpRequest signUp(@NonNull String email, @NonNull String password, @NonNull String connection) {
         final DatabaseConnectionRequest<DatabaseUser, AuthenticationException> createUserRequest = createUser(email, password, connection);
         final AuthenticationRequest authenticationRequest;
-        if (useOAuth2) {
+        if (oauth2Preferred) {
             authenticationRequest = login(email, password);
             authenticationRequest.setRealm(connection);
         } else {

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -430,7 +430,6 @@ public class AuthenticationAPIClient {
 
     /**
      * Fetch the token information from Auth0.
-     * If {@link AuthenticationAPIClient#setLegacyModeEnabled} is set to false, userInfo endpoint will be used instead.
      * <p>
      * Example usage:
      * <pre><code>
@@ -451,10 +450,6 @@ public class AuthenticationAPIClient {
     @SuppressWarnings("WeakerAccess")
     @Deprecated
     public Request<UserProfile, AuthenticationException> tokenInfo(@NonNull String idToken) {
-        if (!useLegacyMode) {
-            return userInfo(idToken);
-        }
-
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(TOKEN_INFO_PATH)
                 .build();

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -343,10 +343,11 @@ public class AuthenticationAPIClientTest {
         assertThat(callback, hasPayloadOfType(Credentials.class));
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getPath(), is("/oauth/token"));
         assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         Map<String, String> body = bodyFromRequest(request);
         assertThat(body, hasEntry("client_id", CLIENT_ID));
-        assertThat(body, hasEntry("grant_type", "http://auth0.com/oauth/grant-type/password-realm"));
+        assertThat(body, hasEntry("grant_type", "password"));
         assertThat(body, hasEntry("username", SUPPORT_AUTH0_COM));
         assertThat(body, hasEntry("password", "some-password"));
         assertThat(body, not(hasKey("realm")));
@@ -365,10 +366,11 @@ public class AuthenticationAPIClientTest {
         assertThat(credentials, is(notNullValue()));
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getPath(), is("/oauth/token"));
         assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
         Map<String, String> body = bodyFromRequest(request);
         assertThat(body, hasEntry("client_id", CLIENT_ID));
-        assertThat(body, hasEntry("grant_type", "http://auth0.com/oauth/grant-type/password-realm"));
+        assertThat(body, hasEntry("grant_type", "password"));
         assertThat(body, hasEntry("username", SUPPORT_AUTH0_COM));
         assertThat(body, hasEntry("password", "some-password"));
         assertThat(body, not(hasKey("realm")));

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static android.R.id.list;
 import static com.auth0.android.util.AuthenticationAPI.GENERIC_TOKEN;
 import static com.auth0.android.util.AuthenticationAPI.ID_TOKEN;
 import static com.auth0.android.util.AuthenticationAPI.REFRESH_TOKEN;
@@ -150,6 +151,31 @@ public class AuthenticationAPIClientTest {
         auth0.doNotSendTelemetry();
         new AuthenticationAPIClient(auth0, factory, okClient);
         verify(factory, never()).setClientInfo(any(String.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldPreferOAuth2() throws Exception {
+        AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
+        client.setOAuth2Preferred(true);
+
+        assertThat(client.isOAuth2Preferred(), is(true));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldNotPreferOAuth2() throws Exception {
+        AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
+        client.setOAuth2Preferred(false);
+
+        assertThat(client.isOAuth2Preferred(), is(false));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldNotPreferOAuth2ByDefault() throws Exception {
+        AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
+        assertThat(client.isOAuth2Preferred(), is(false));
     }
 
     @SuppressWarnings("unchecked")
@@ -288,7 +314,7 @@ public class AuthenticationAPIClientTest {
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
 
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.useOAuth2(true);
+        client.setOAuth2Preferred(true);
         client.login(SUPPORT_AUTH0_COM, "some-password", MY_CONNECTION)
                 .start(callback);
         assertThat(callback, hasPayloadOfType(Credentials.class));
@@ -394,7 +420,7 @@ public class AuthenticationAPIClientTest {
         final MockAuthenticationCallback<UserProfile> callback = new MockAuthenticationCallback<>();
 
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.useOAuth2(true);
+        client.setOAuth2Preferred(true);
         client.tokenInfo("ACCESS_TOKEN")
                 .start(callback);
 
@@ -773,7 +799,7 @@ public class AuthenticationAPIClientTest {
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.useOAuth2(true);
+        client.setOAuth2Preferred(true);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, SUPPORT, MY_CONNECTION)
                 .start(callback);
 
@@ -904,7 +930,7 @@ public class AuthenticationAPIClientTest {
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.useOAuth2(true);
+        client.setOAuth2Preferred(true);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, MY_CONNECTION)
                 .start(callback);
 

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -62,7 +62,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static android.R.id.list;
 import static com.auth0.android.util.AuthenticationAPI.GENERIC_TOKEN;
 import static com.auth0.android.util.AuthenticationAPI.ID_TOKEN;
 import static com.auth0.android.util.AuthenticationAPI.REFRESH_TOKEN;
@@ -155,27 +154,27 @@ public class AuthenticationAPIClientTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldPreferOAuth2() throws Exception {
+    public void shouldUseLegacyMode() throws Exception {
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setOAuth2Preferred(true);
+        client.setLegacyModeEnabled(true);
 
-        assertThat(client.isOAuth2Preferred(), is(true));
+        assertThat(client.isLegacyModeEnabled(), is(true));
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldNotPreferOAuth2() throws Exception {
+    public void shouldNotUseLegacyMode() throws Exception {
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setOAuth2Preferred(false);
+        client.setLegacyModeEnabled(false);
 
-        assertThat(client.isOAuth2Preferred(), is(false));
+        assertThat(client.isLegacyModeEnabled(), is(false));
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldNotPreferOAuth2ByDefault() throws Exception {
+    public void shouldUseLegacyModeByDefault() throws Exception {
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        assertThat(client.isOAuth2Preferred(), is(false));
+        assertThat(client.isLegacyModeEnabled(), is(true));
     }
 
     @SuppressWarnings("unchecked")
@@ -309,12 +308,12 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldLoginWithUserAndPasswordUsingOAuthTokenEndpointIfOAuth2IsEnabled() throws Exception {
+    public void shouldLoginWithUserAndPasswordUsingOAuthTokenEndpointIfLegacyModeIsDisabled() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
 
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setOAuth2Preferred(true);
+        client.setLegacyModeEnabled(false);
         client.login(SUPPORT_AUTH0_COM, "some-password", MY_CONNECTION)
                 .start(callback);
         assertThat(callback, hasPayloadOfType(Credentials.class));
@@ -415,12 +414,12 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldFetchUserInfoIfOAuth2IsEnabled() throws Exception {
+    public void shouldFetchUserInfoIfLegacyModeIsDisabled() throws Exception {
         mockAPI.willReturnTokenInfo();
         final MockAuthenticationCallback<UserProfile> callback = new MockAuthenticationCallback<>();
 
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setOAuth2Preferred(true);
+        client.setLegacyModeEnabled(false);
         client.tokenInfo("ACCESS_TOKEN")
                 .start(callback);
 
@@ -793,13 +792,13 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSignUpUserUsingOAuthTokenEndpointIfOAuth2IsEnabled() throws Exception {
+    public void shouldSignUpUserUsingOAuthTokenEndpointIfLegacyModeIsDisabled() throws Exception {
         mockAPI.willReturnSuccessfulSignUp()
                 .willReturnSuccessfulLogin();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setOAuth2Preferred(true);
+        client.setLegacyModeEnabled(false);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, SUPPORT, MY_CONNECTION)
                 .start(callback);
 
@@ -923,14 +922,14 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSignUpUserWithoutUsernameUsingOAuthTokenEndpointIfOAuth2IsEnabled() throws Exception {
+    public void shouldSignUpUserWithoutUsernameUsingOAuthTokenEndpointIfLegacyModeIsDisabled() throws Exception {
         mockAPI.willReturnSuccessfulSignUp()
                 .willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setOAuth2Preferred(true);
+        client.setLegacyModeEnabled(false);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, MY_CONNECTION)
                 .start(callback);
 

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -156,25 +156,25 @@ public class AuthenticationAPIClientTest {
     @Test
     public void shouldUseLegacyMode() throws Exception {
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setLegacyModeEnabled(true);
+        client.setOIDCConformant(true);
 
-        assertThat(client.isLegacyModeEnabled(), is(true));
+        assertThat(client.isOIDCConformant(), is(true));
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void shouldNotUseLegacyMode() throws Exception {
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setLegacyModeEnabled(false);
+        client.setOIDCConformant(false);
 
-        assertThat(client.isLegacyModeEnabled(), is(false));
+        assertThat(client.isOIDCConformant(), is(false));
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void shouldUseLegacyModeByDefault() throws Exception {
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        assertThat(client.isLegacyModeEnabled(), is(true));
+        assertThat(client.isOIDCConformant(), is(false));
     }
 
     @SuppressWarnings("unchecked")
@@ -308,12 +308,12 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldLoginWithUserAndPasswordUsingOAuthTokenEndpointIfLegacyModeIsDisabled() throws Exception {
+    public void shouldLoginWithPasswordReamGrant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
 
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setLegacyModeEnabled(false);
+        client.setOIDCConformant(true);
         client.login(SUPPORT_AUTH0_COM, "some-password", MY_CONNECTION)
                 .start(callback);
         assertThat(callback, hasPayloadOfType(Credentials.class));
@@ -776,13 +776,13 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSignUpUserUsingOAuthTokenEndpointIfLegacyModeIsDisabled() throws Exception {
+    public void shouldLoginWithUsernameSignedUpUserWithPasswordReamGrant() throws Exception {
         mockAPI.willReturnSuccessfulSignUp()
                 .willReturnSuccessfulLogin();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setLegacyModeEnabled(false);
+        client.setOIDCConformant(true);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, SUPPORT, MY_CONNECTION)
                 .start(callback);
 
@@ -906,14 +906,14 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSignUpUserWithoutUsernameUsingOAuthTokenEndpointIfLegacyModeIsDisabled() throws Exception {
+    public void shouldLoginSignedUpUserWithPasswordRealmGrant() throws Exception {
         mockAPI.willReturnSuccessfulSignUp()
                 .willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setLegacyModeEnabled(false);
+        client.setOIDCConformant(true);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, MY_CONNECTION)
                 .start(callback);
 
@@ -946,6 +946,7 @@ public class AuthenticationAPIClientTest {
                 .willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
 
+        client.setOIDCConformant(false);
         final Credentials credentials = client
                 .signUp(SUPPORT_AUTH0_COM, PASSWORD, MY_CONNECTION)
                 .execute();

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -414,24 +414,6 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldFetchUserInfoIfLegacyModeIsDisabled() throws Exception {
-        mockAPI.willReturnTokenInfo();
-        final MockAuthenticationCallback<UserProfile> callback = new MockAuthenticationCallback<>();
-
-        AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setLegacyModeEnabled(false);
-        client.tokenInfo("ACCESS_TOKEN")
-                .start(callback);
-
-        assertThat(callback, hasPayloadOfType(UserProfile.class));
-
-        final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
-        assertThat(request.getHeader("Authorization"), is("Bearer ACCESS_TOKEN"));
-        assertThat(request.getPath(), equalTo("/userinfo"));
-    }
-
-    @Test
     public void shouldFetchUserInfo() throws Exception {
         mockAPI.willReturnTokenInfo();
         final MockAuthenticationCallback<UserProfile> callback = new MockAuthenticationCallback<>();


### PR DESCRIPTION
Make legacy authentication methods use `/oauth/token` endpoint if `client.setOAuth2Preferred(true)` is called. The methods that change it's behavior with the flag are:

* `login(String, String, String)` --> calls `login(String, String)` and sets the connection as realm.
* ~`tokenInfo(String)` --> calls `userInfo(String)`~ 
* `signUp(String, String, String)`  --> replaces the login call with `login(String, String)` and sets the connection as realm.
* `signUp(String, String, String, String)`  --> replaces the login call with `login(String, String)` and sets the connection as realm.

**This PR depends on https://github.com/auth0/Auth0.Android/pull/56** as there was no way to set a `realm` value before that.