### PR TITLE
Migrate OIDCConformant flag into Auth0 class

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -30,6 +30,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.auth0.android.auth0.BuildConfig;
+import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.util.Telemetry;
 import com.squareup.okhttp.HttpUrl;
 
@@ -49,7 +50,7 @@ public class Auth0 {
     private final HttpUrl domainUrl;
     private final HttpUrl configurationUrl;
     private Telemetry telemetry;
-
+    private boolean oidcConformant;
 
     /**
      * Creates a new Auth0 instance with the 'com_auth0_client_id' and 'com_auth0_domain' values
@@ -144,6 +145,30 @@ public class Auth0 {
      */
     public void doNotSendTelemetry() {
         this.telemetry = null;
+    }
+
+    /**
+     * Defines if the client uses OIDC conformant authentication endpoints. By default is {@code false}
+     * <p>
+     * You will need to enable this setting in the Auth0 Dashboard first: Go to Account (top right), Account Settings, click Advanced and check the toggle at the bottom.
+     * This setting affects how authentication is performed in the following methods:
+     * <ul>
+     * <li>{@link AuthenticationAPIClient#login(String, String, String)}</li>
+     * <li>{@link AuthenticationAPIClient#signUp(String, String, String)}</li>
+     * <li>{@link AuthenticationAPIClient#signUp(String, String, String, String)}</li>
+     * </ul>
+     *
+     * @param enabled if Lock will use the Legacy Auth API or the new OIDC Conformant Auth API.
+     */
+    public void setOIDCConformant(boolean enabled) {
+        this.oidcConformant = enabled;
+    }
+
+    /**
+     * If the clients works in OIDC conformant mode or not
+     */
+    public boolean isOIDCConformant() {
+        return oidcConformant;
     }
 
     private HttpUrl resolveConfiguration(@Nullable String configurationDomain, @NonNull HttpUrl domainUrl) {

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -96,9 +96,8 @@ public class AuthenticationAPIClient {
     private final OkHttpClient client;
     private final HttpLoggingInterceptor logInterceptor;
     private final Gson gson;
-    private final com.auth0.android.request.internal.RequestFactory factory;
+    private final RequestFactory factory;
     private final ErrorBuilder<AuthenticationException> authErrorBuilder;
-    private boolean oidcConformant;
 
 
     /**
@@ -133,35 +132,10 @@ public class AuthenticationAPIClient {
         this.gson = gson;
         this.factory = factory;
         this.authErrorBuilder = new AuthenticationErrorBuilder();
-        this.oidcConformant = false;
         final Telemetry telemetry = auth0.getTelemetry();
         if (telemetry != null) {
             factory.setClientInfo(telemetry.getValue());
         }
-    }
-
-    /**
-     * Defines if the client uses OIDC conformant authentication endpoints. By default is {@code false}
-     *
-     * You will need to enable this setting in the Auth0 Dashboard first: Go to Account (top right), Account Settings, click Advanced and check the toggle at the bottom.
-     * This setting affects how authentication is performed in the following methods:
-     * <ul>
-     *     <li>{@link AuthenticationAPIClient#login(String, String, String)}</li>
-     *     <li>{@link AuthenticationAPIClient#signUp(String, String, String)}</li>
-     *     <li>{@link AuthenticationAPIClient#signUp(String, String, String, String)}</li>
-     * </ul>
-     *
-     * @param enabled if Lock will use the Legacy Auth API or the new OIDC Conformant Auth API.
-     */
-    public void setOIDCConformant(boolean enabled) {
-        this.oidcConformant = enabled;
-    }
-
-    /**
-     * If the clients works in OIDC conformant mode or not
-     */
-    public boolean isOIDCConformant() {
-        return oidcConformant;
     }
 
     /**
@@ -199,10 +173,10 @@ public class AuthenticationAPIClient {
 
     /**
      * Log in a user with email/username and password for a connection/realm.
-     *
-     * In OIDC conformant mode ({@link AuthenticationAPIClient#isOIDCConformant()}) it will use the password-realm grant type for the {@code /oauth/token} endpoint
+     * <p>
+     * In OIDC conformant mode ({@link Auth0#isOIDCConformant()}) it will use the password-realm grant type for the {@code /oauth/token} endpoint
      * otherwise it will use {@code /oauth/ro}
-     *
+     * <p>
      * Example:
      * <pre><code>
      * client
@@ -228,12 +202,12 @@ public class AuthenticationAPIClient {
                 .set(USERNAME_KEY, usernameOrEmail)
                 .set(PASSWORD_KEY, password);
 
-        if (oidcConformant) {
+        if (auth0.isOIDCConformant()) {
             final Map<String, Object> parameters = builder
                     .setGrantType(GRANT_TYPE_PASSWORD_REALM)
                     .setRealm(realmOrConnection)
                     .asDictionary();
-            return  loginWithToken(parameters);
+            return loginWithToken(parameters);
         } else {
             final Map<String, Object> parameters = builder
                     .setGrantType(GRANT_TYPE_PASSWORD)
@@ -541,7 +515,7 @@ public class AuthenticationAPIClient {
 
     /**
      * Creates a user in a DB connection using <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-signup">'/dbconnections/signup' endpoint</a>
-     * and then logs in the user. How the user is logged in depends on the {@link AuthenticationAPIClient#isOIDCConformant()} flag.
+     * and then logs in the user. How the user is logged in depends on the {@link Auth0#isOIDCConformant()} flag.
      * Example usage:
      * <pre><code>
      * client.signUp("{email}", "{password}", "{username}", "{database connection name}")
@@ -570,7 +544,7 @@ public class AuthenticationAPIClient {
 
     /**
      * Creates a user in a DB connection using <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-signup">'/dbconnections/signup' endpoint</a>
-     * and then logs in the user. How the user is logged in depends on the {@link AuthenticationAPIClient#isOIDCConformant()} flag.
+     * and then logs in the user. How the user is logged in depends on the {@link Auth0#isOIDCConformant()} flag.
      * Example usage:
      * <pre><code>
      * client.signUp("{email}", "{password}", "{database connection name}")

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -30,10 +30,13 @@ import android.content.res.Resources;
 import com.auth0.android.util.Telemetry;
 import com.squareup.okhttp.HttpUrl;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import static com.auth0.android.util.HttpUrlMatcher.hasHost;
 import static com.auth0.android.util.HttpUrlMatcher.hasPath;
@@ -51,6 +54,8 @@ public class Auth0Test {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+    @Mock
+    public Context context;
 
     private static final String CLIENT_ID = "CLIENT_ID";
     private static final String DOMAIN = "samples.auth0.com";
@@ -59,10 +64,35 @@ public class Auth0Test {
     private static final String AU_DOMAIN = "samples.au.auth0.com";
     private static final String OTHER_DOMAIN = "samples-test.other-subdomain.other.auth0.com";
 
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldBeOIDCConformant() throws Exception {
+        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
+        auth0.setOIDCConformant(true);
+
+        assertThat(auth0.isOIDCConformant(), is(true));
+    }
+
+    @Test
+    public void shouldNotBeOIDCConformant() throws Exception {
+        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
+        auth0.setOIDCConformant(false);
+
+        assertThat(auth0.isOIDCConformant(), is(false));
+    }
+
+    @Test
+    public void shouldNotBeOIDCConformantByDefault() throws Exception {
+        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
+        assertThat(auth0.isOIDCConformant(), is(false));
+    }
 
     @Test
     public void shouldBuildFromResources() throws Exception {
-        Context context = Mockito.mock(Context.class);
         Resources resources = Mockito.mock(Resources.class);
         when(context.getResources()).thenReturn(resources);
         when(resources.getIdentifier(eq("com_auth0_client_id"), eq("string"), anyString())).thenReturn(222);
@@ -81,7 +111,6 @@ public class Auth0Test {
 
     @Test
     public void shouldFailToBuildFromResourcesWithoutClientID() throws Exception {
-        Context context = Mockito.mock(Context.class);
         Resources resources = Mockito.mock(Resources.class);
         when(context.getResources()).thenReturn(resources);
         when(resources.getIdentifier(eq("com_auth0_client_id"), eq("string"), anyString())).thenReturn(0);
@@ -95,7 +124,6 @@ public class Auth0Test {
 
     @Test
     public void shouldFailToBuildFromResourcesWithoutDomain() throws Exception {
-        Context context = Mockito.mock(Context.class);
         Resources resources = Mockito.mock(Resources.class);
         when(context.getResources()).thenReturn(resources);
         when(resources.getIdentifier(eq("com_auth0_client_id"), eq("string"), anyString())).thenReturn(222);

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -154,31 +154,6 @@ public class AuthenticationAPIClientTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldUseLegacyMode() throws Exception {
-        AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setOIDCConformant(true);
-
-        assertThat(client.isOIDCConformant(), is(true));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldNotUseLegacyMode() throws Exception {
-        AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setOIDCConformant(false);
-
-        assertThat(client.isOIDCConformant(), is(false));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldUseLegacyModeByDefault() throws Exception {
-        AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        assertThat(client.isOIDCConformant(), is(false));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
     public void shouldEnableHttpLogging() throws Exception {
         Auth0 account = mock(Auth0.class);
         RequestFactory factory = mock(RequestFactory.class);
@@ -312,8 +287,9 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin();
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
 
+        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        auth0.setOIDCConformant(true);
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setOIDCConformant(true);
         client.login(SUPPORT_AUTH0_COM, "some-password", MY_CONNECTION)
                 .start(callback);
         assertThat(callback, hasPayloadOfType(Credentials.class));
@@ -781,8 +757,9 @@ public class AuthenticationAPIClientTest {
                 .willReturnSuccessfulLogin();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
+        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        auth0.setOIDCConformant(true);
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setOIDCConformant(true);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, SUPPORT, MY_CONNECTION)
                 .start(callback);
 
@@ -912,8 +889,9 @@ public class AuthenticationAPIClientTest {
                 .willReturnTokenInfo();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
+        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        auth0.setOIDCConformant(true);
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.setOIDCConformant(true);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, MY_CONNECTION)
                 .start(callback);
 
@@ -946,7 +924,9 @@ public class AuthenticationAPIClientTest {
                 .willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
 
-        client.setOIDCConformant(false);
+        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        auth0.setOIDCConformant(false);
+        AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
         final Credentials credentials = client
                 .signUp(SUPPORT_AUTH0_COM, PASSWORD, MY_CONNECTION)
                 .execute();


### PR DESCRIPTION
Instead of setting the flag on the `AuthenticationAPIClient` the flag is now set on the `Auth0` class. Default value is still _false_.

```java
Auth0 account = new Auth0("clientId", "domain");
account.setOIDCConformant(true);
```
