### PR TITLE
Migrate loggingEnabled flag to Auth0 class

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -51,6 +51,7 @@ public class Auth0 {
     private final HttpUrl configurationUrl;
     private Telemetry telemetry;
     private boolean oidcConformant;
+    private boolean loggingEnabled;
 
     /**
      * Creates a new Auth0 instance with the 'com_auth0_client_id' and 'com_auth0_domain' values
@@ -130,7 +131,6 @@ public class Auth0 {
         return telemetry;
     }
 
-
     /**
      * Setter for the Telemetry to send in every request to Auth0.
      *
@@ -169,6 +169,23 @@ public class Auth0 {
      */
     public boolean isOIDCConformant() {
         return oidcConformant;
+    }
+
+    /**
+     * @return if every Request, Response and other sensitive information should be logged.
+     */
+    public boolean isLoggingEnabled() {
+        return loggingEnabled;
+    }
+
+    /**
+     * Log every Request, Response and other sensitive information exchanged using the Auth0 APIs.
+     * You shouldn't enable logging in release builds as it may leak sensitive information.
+     *
+     * @param enabled if every Request, Response and other sensitive information should be logged.
+     */
+    public void setLoggingEnabled(boolean enabled) {
+        loggingEnabled = enabled;
     }
 
     private HttpUrl resolveConfiguration(@Nullable String configurationDomain, @NonNull HttpUrl domainUrl) {

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -94,7 +94,6 @@ public class AuthenticationAPIClient {
 
     private final Auth0 auth0;
     private final OkHttpClient client;
-    private final HttpLoggingInterceptor logInterceptor;
     private final Gson gson;
     private final RequestFactory factory;
     private final ErrorBuilder<AuthenticationException> authErrorBuilder;
@@ -127,8 +126,9 @@ public class AuthenticationAPIClient {
     private AuthenticationAPIClient(Auth0 auth0, RequestFactory factory, OkHttpClient client, Gson gson) {
         this.auth0 = auth0;
         this.client = client;
-        this.logInterceptor = new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.NONE);
-        this.client.interceptors().add(logInterceptor);
+        if (auth0.isLoggingEnabled()) {
+            this.client.interceptors().add(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY));
+        }
         this.gson = gson;
         this.factory = factory;
         this.authErrorBuilder = new AuthenticationErrorBuilder();
@@ -137,22 +137,7 @@ public class AuthenticationAPIClient {
             factory.setClientInfo(telemetry.getValue());
         }
     }
-
-    /**
-     * Log every Request and Response made by this client.
-     * You shouldn't enable logging in release builds as it may leak sensitive information.
-     */
-    public void setLoggingEnabled(boolean enabled) {
-        logInterceptor.setLevel(enabled ? HttpLoggingInterceptor.Level.BODY : HttpLoggingInterceptor.Level.NONE);
-    }
-
-    /**
-     * Getter for the current client logger enabled state.
-     */
-    public boolean isLoggingEnabled() {
-        return logInterceptor.getLevel() == HttpLoggingInterceptor.Level.BODY;
-    }
-
+    
     public String getClientId() {
         return auth0.getClientId();
     }

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
@@ -68,7 +68,6 @@ public class UsersAPIClient {
 
     private final Auth0 auth0;
     private final OkHttpClient client;
-    private final HttpLoggingInterceptor logInterceptor;
     private final Gson gson;
     private final RequestFactory factory;
     private final ErrorBuilder<ManagementException> mgmtErrorBuilder;
@@ -102,8 +101,9 @@ public class UsersAPIClient {
     private UsersAPIClient(Auth0 auth0, RequestFactory factory, OkHttpClient client, Gson gson) {
         this.auth0 = auth0;
         this.client = client;
-        this.logInterceptor = new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.NONE);
-        this.client.interceptors().add(logInterceptor);
+        if (auth0.isLoggingEnabled()) {
+            this.client.interceptors().add(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY));
+        }
         this.gson = gson;
         this.factory = factory;
         this.mgmtErrorBuilder = new ManagementErrorBuilder();
@@ -111,14 +111,6 @@ public class UsersAPIClient {
         if (telemetry != null) {
             factory.setClientInfo(telemetry.getValue());
         }
-    }
-
-    /**
-     * Log every Request and Response made by this client.
-     * You shouldn't enable logging in release builds as it may leak sensitive information.
-     */
-    public void enableLogging() {
-        logInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
     }
 
     public String getClientId() {

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -94,7 +94,6 @@ public class WebAuthProvider {
     private Map<String, String> parameters;
 
     private static WebAuthProvider providerInstance;
-    private boolean loggingEnabled;
     private String scheme;
 
     @VisibleForTesting
@@ -109,7 +108,6 @@ public class WebAuthProvider {
         private boolean useBrowser;
         private boolean useFullscreen;
         private PKCE pkce;
-        private boolean loggingEnabled;
         private String scheme;
 
         Builder(Auth0 account) {
@@ -288,15 +286,6 @@ public class WebAuthProvider {
             return this;
         }
 
-        /**
-         * Log every Request and Response made by this provider.
-         * You shouldn't enable logging in release builds as it may leak sensitive information.
-         */
-        public Builder enableLogging() {
-            this.loggingEnabled = true;
-            return this;
-        }
-
         @VisibleForTesting
         Builder withPKCE(PKCE pkce) {
             this.pkce = pkce;
@@ -320,7 +309,6 @@ public class WebAuthProvider {
             webAuth.useFullscreen = useFullscreen;
             webAuth.parameters = values;
             webAuth.pkce = pkce;
-            webAuth.loggingEnabled = loggingEnabled;
             webAuth.scheme = scheme;
 
             providerInstance = webAuth;
@@ -564,13 +552,7 @@ public class WebAuthProvider {
     }
 
     private PKCE createPKCE(String redirectUri) {
-        if (pkce == null) {
-            final AuthenticationAPIClient client = new AuthenticationAPIClient(account);
-            client.setLoggingEnabled(loggingEnabled);
-            return new PKCE(client, redirectUri);
-        } else {
-            return pkce;
-        }
+        return pkce != null ? pkce : new PKCE(new AuthenticationAPIClient(account), redirectUri);
     }
 
     @VisibleForTesting
@@ -586,11 +568,6 @@ public class WebAuthProvider {
     @VisibleForTesting
     Map<String, String> getParameters() {
         return parameters;
-    }
-
-    @VisibleForTesting
-    boolean isLoggingEnabled() {
-        return loggingEnabled;
     }
 
     private String getResponseType() {
@@ -609,7 +586,7 @@ public class WebAuthProvider {
     }
 
     private void logDebug(String message) {
-        if (loggingEnabled) {
+        if (account.isLoggingEnabled()) {
             Log.d(TAG, message);
         }
     }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -156,50 +156,7 @@ public class AuthenticationAPIClientTest {
     @Test
     public void shouldEnableHttpLogging() throws Exception {
         Auth0 account = mock(Auth0.class);
-        RequestFactory factory = mock(RequestFactory.class);
-        OkHttpClient okClient = mock(OkHttpClient.class);
-        List list = mock(List.class);
-        when(okClient.interceptors()).thenReturn(list);
-
-        ArgumentCaptor<Interceptor> interceptorCaptor = ArgumentCaptor.forClass(Interceptor.class);
-        AuthenticationAPIClient client = new AuthenticationAPIClient(account, factory, okClient);
-        client.setLoggingEnabled(true);
-
-        verify(okClient).interceptors();
-        verify(list).add(interceptorCaptor.capture());
-
-        assertThat(interceptorCaptor.getValue(), is(notNullValue()));
-        assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
-        assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.BODY));
-        assertThat(client.isLoggingEnabled(), is(true));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldDisableHttpLogging() throws Exception {
-        Auth0 account = mock(Auth0.class);
-        RequestFactory factory = mock(RequestFactory.class);
-        OkHttpClient okClient = mock(OkHttpClient.class);
-        List list = mock(List.class);
-        when(okClient.interceptors()).thenReturn(list);
-
-        ArgumentCaptor<Interceptor> interceptorCaptor = ArgumentCaptor.forClass(Interceptor.class);
-        AuthenticationAPIClient client = new AuthenticationAPIClient(account, factory, okClient);
-        client.setLoggingEnabled(false);
-
-        verify(okClient).interceptors();
-        verify(list).add(interceptorCaptor.capture());
-
-        assertThat(interceptorCaptor.getValue(), is(notNullValue()));
-        assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
-        assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.NONE));
-        assertThat(client.isLoggingEnabled(), is(false));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldHaveHttpLoggingDisabledByDefault() throws Exception {
-        Auth0 account = mock(Auth0.class);
+        when(account.isLoggingEnabled()).thenReturn(true);
         RequestFactory factory = mock(RequestFactory.class);
         OkHttpClient okClient = mock(OkHttpClient.class);
         List list = mock(List.class);
@@ -213,8 +170,38 @@ public class AuthenticationAPIClientTest {
 
         assertThat(interceptorCaptor.getValue(), is(notNullValue()));
         assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
-        assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.NONE));
-        assertThat(client.isLoggingEnabled(), is(false));
+        assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.BODY));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldDisableHttpLogging() throws Exception {
+        Auth0 account = mock(Auth0.class);
+        when(account.isLoggingEnabled()).thenReturn(false);
+        RequestFactory factory = mock(RequestFactory.class);
+        OkHttpClient okClient = mock(OkHttpClient.class);
+        List list = mock(List.class);
+        when(okClient.interceptors()).thenReturn(list);
+
+        new AuthenticationAPIClient(account, factory, okClient);
+
+        verify(okClient, never()).interceptors();
+        verify(list, never()).add(any(Interceptor.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldHaveHttpLoggingDisabledByDefault() throws Exception {
+        Auth0 account = mock(Auth0.class);
+        RequestFactory factory = mock(RequestFactory.class);
+        OkHttpClient okClient = mock(OkHttpClient.class);
+        List list = mock(List.class);
+        when(okClient.interceptors()).thenReturn(list);
+
+        new AuthenticationAPIClient(account, factory, okClient);
+
+        verify(okClient, never()).interceptors();
+        verify(list, never()).add(any(Interceptor.class));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
@@ -145,27 +145,7 @@ public class UsersAPIClientTest {
     @Test
     public void shouldEnableHttpLogging() throws Exception {
         Auth0 account = mock(Auth0.class);
-        RequestFactory factory = mock(RequestFactory.class);
-        OkHttpClient okClient = mock(OkHttpClient.class);
-        List list = mock(List.class);
-        when(okClient.interceptors()).thenReturn(list);
-
-        ArgumentCaptor<Interceptor> interceptorCaptor = ArgumentCaptor.forClass(Interceptor.class);
-        UsersAPIClient client = new UsersAPIClient(account, factory, okClient);
-        client.enableLogging();
-
-        verify(okClient).interceptors();
-        verify(list).add(interceptorCaptor.capture());
-
-        assertThat(interceptorCaptor.getValue(), is(notNullValue()));
-        assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
-        assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.BODY));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldHaveHttpLoggingDisabledByDefault() throws Exception {
-        Auth0 account = mock(Auth0.class);
+        when(account.isLoggingEnabled()).thenReturn(true);
         RequestFactory factory = mock(RequestFactory.class);
         OkHttpClient okClient = mock(OkHttpClient.class);
         List list = mock(List.class);
@@ -179,7 +159,38 @@ public class UsersAPIClientTest {
 
         assertThat(interceptorCaptor.getValue(), is(notNullValue()));
         assertThat(interceptorCaptor.getValue(), is(instanceOf(HttpLoggingInterceptor.class)));
-        assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.NONE));
+        assertThat(((HttpLoggingInterceptor) interceptorCaptor.getValue()).getLevel(), is(HttpLoggingInterceptor.Level.BODY));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldDisableHttpLogging() throws Exception {
+        Auth0 account = mock(Auth0.class);
+        when(account.isLoggingEnabled()).thenReturn(false);
+        RequestFactory factory = mock(RequestFactory.class);
+        OkHttpClient okClient = mock(OkHttpClient.class);
+        List list = mock(List.class);
+        when(okClient.interceptors()).thenReturn(list);
+
+        new UsersAPIClient(account, factory, okClient);
+
+        verify(okClient, never()).interceptors();
+        verify(list, never()).add(any(Interceptor.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldHaveHttpLoggingDisabledByDefault() throws Exception {
+        Auth0 account = mock(Auth0.class);
+        RequestFactory factory = mock(RequestFactory.class);
+        OkHttpClient okClient = mock(OkHttpClient.class);
+        List list = mock(List.class);
+        when(okClient.interceptors()).thenReturn(list);
+
+        new UsersAPIClient(account, factory, okClient);
+
+        verify(okClient, never()).interceptors();
+        verify(list, never()).add(any(Interceptor.class));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -120,25 +120,6 @@ public class WebAuthProviderTest {
         assertFalse(WebAuthProvider.resume(0, 0, intentMock));
     }
 
-    //logging
-    public void shouldHaveLoggingDisabledByDefault() throws Exception {
-        WebAuthProvider.init(account)
-                .start(activity, callback);
-
-        final WebAuthProvider instance = WebAuthProvider.getInstance();
-        assertFalse(instance.isLoggingEnabled());
-    }
-
-    @Test
-    public void shouldEnableLogging() throws Exception {
-        WebAuthProvider.init(account)
-                .enableLogging()
-                .start(activity, callback);
-
-        final WebAuthProvider instance = WebAuthProvider.getInstance();
-        assertTrue(instance.isLoggingEnabled());
-    }
-
     //scheme
 
     @Test


### PR DESCRIPTION
This is a **breaking change for dev environments**. Previously you had to call `setLoggingEnabled(true)` on the APIClients and the WebAuthProvider. Now this is done on the Auth0 instance. 