### PR TITLE
Refresh auth using /oauth/token refresh_token grant (OIDC mode)

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -156,6 +156,7 @@ public class Auth0 {
      * <li>{@link AuthenticationAPIClient#login(String, String, String)}</li>
      * <li>{@link AuthenticationAPIClient#signUp(String, String, String)}</li>
      * <li>{@link AuthenticationAPIClient#signUp(String, String, String, String)}</li>
+     * <li>{@link AuthenticationAPIClient#renewAuth(String)}</li>
      * </ul>
      *
      * @param enabled if Lock will use the Legacy Auth API or the new OIDC Conformant Auth API.

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -592,7 +592,9 @@ public class AuthenticationAPIClient {
     }
 
     /**
-     * Requests new Credentials using a valid Refresh Token. How the new Credentials are requested depends on the {@link Auth0#isOIDCConformant()} flag.
+     * Requests new Credentials using a valid Refresh Token. The received token will have the same audience and scope as first requested. How the new Credentials are requested depends on the {@link Auth0#isOIDCConformant()} flag.
+     * - If the instance is OIDC Conformant the endpoint will be /oauth/token with 'refresh_token' grant, and the response will include an id_token and an access_token if 'openid' scope was requested when the refresh_token was obtained.
+     * - If the instance is not OIDC Conformant the endpoint will be /delegation with 'urn:ietf:params:oauth:grant-type:jwt-bearer' grant, and the response will include an id_token.
      * <p>
      * Example usage:
      * <pre><code>


### PR DESCRIPTION
Use either `/delegation` or `/oauth/token` endpoints depending on the OIDC flag.