### PR TITLE
Log a warning message when using non-OIDC endpoints in OIDC mode

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -89,7 +89,7 @@ public class AuthenticationException extends Auth0Exception {
     }
 
     private void warnIfOIDCError() {
-        if ("invalid_request".equals(getCode()) && getDescription().startsWith("OIDC conformant clients cannot use")) {
+        if ("invalid_request".equals(getCode())) {
             Log.w(AuthenticationAPIClient.class.getSimpleName(), "Your Auth0 Client is configured as 'OIDC Conformant' but this instance it's not. To authenticate you will need to enable the flag by calling Auth0#setOIDCConformant(true) on the Auth0 instance you used in the setup.");
         }
     }

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -24,6 +24,8 @@
 
 package com.auth0.android.authentication;
 
+import android.util.Log;
+
 import com.auth0.android.Auth0Exception;
 
 import java.util.HashMap;
@@ -73,6 +75,7 @@ public class AuthenticationException extends Auth0Exception {
         this.code = codeValue != null ? codeValue : UNKNOWN_ERROR;
         if (!this.values.containsKey(DESCRIPTION_KEY)) {
             this.description = (String) this.values.get(ERROR_DESCRIPTION_KEY);
+            warnIfOIDCError();
             return;
         }
 
@@ -82,6 +85,12 @@ public class AuthenticationException extends Auth0Exception {
         } else if (isPasswordNotStrongEnough()) {
             PasswordStrengthErrorParser pwStrengthParser = new PasswordStrengthErrorParser((Map<String, Object>) description);
             this.description = pwStrengthParser.getDescription();
+        }
+    }
+
+    private void warnIfOIDCError() {
+        if ("invalid_request".equals(getCode()) && getDescription().startsWith("OIDC conformant clients cannot use")) {
+            Log.w(AuthenticationAPIClient.class.getSimpleName(), "Your Auth0 Client is configured as 'OIDC Conformant' but this instance it's not. To authenticate you will need to enable the flag by calling Auth0#setOIDCConformant(true) on the Auth0 instance you used in the setup.");
         }
     }
 


### PR DESCRIPTION
If the account used to create the `AuthenticationAPIClient` has the OIDCConformant flag disabled and the client (dashboard) has the flag enabled, the requests to `/oauth/ro` and `/oauth/access_token` will fail with `invalid_request`. This PR check's that error and logs a warning message so the user can properly setup the android client and authenticate. 