### PR TITLE
Change return type of AuthenticationAPIClient#userInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Step 1: Request the code
 ```java
 authentication
     .passwordlessWithEmail("info@auth0.com", PasswordlessType.CODE, "my-passwordless-connection")
-    .start(new BaseCallback<Credentials>() {
+    .start(new BaseCallback<Void>() {
         @Override
         public void onSuccess(Void payload) {
             //Code sent!
@@ -153,10 +153,10 @@ authentication
 ```java
 authentication
    .userInfo("user access_token")
-   .start(new BaseCallback<Credentials>() {
+   .start(new BaseCallback<UserInfo>() {
        @Override
-       public void onSuccess(UserProfile payload) {
-           //Got the profile!
+       public void onSuccess(UserInfo payload) {
+           //Got the info!
        }
 
        @Override
@@ -304,11 +304,11 @@ public class MyActivity extends Activity {
 
 ##### A note about App Deep Linking:
 
-Currently, the default scheme used in the Callback Uri is `https`. This works best for Android API 23 or newer if you're using [Android App Links](https://developer.android.com/training/app-links/index.html), but in previous Android versions this may show the intent chooser dialog prompting the user to chose either your application or the browser. You can change this behaviour by using a custom unique scheme, so that the OS opens directly the link with your app.
+Currently, the default scheme used in the Callback Uri is `https`. This works best for Android Marshmallow (API 23) or newer if you're using [Android App Links](https://developer.android.com/training/app-links/index.html), but in previous Android versions this may show the intent chooser dialog prompting the user to chose either your application or the browser. You can change this behaviour by using a custom unique scheme, so that the OS opens the link directly with your app.
 
-1. Update the intent filter in the Android Manifest and change the custom scheme.
+1. Update the intent filter in the `AndroidManifest.xml` file and change the current scheme to the custom one.
 2. Update the allowed callback urls in your [Auth0 Dashboard](https://manage.auth0.com/#/applications) client's settings.
-3. Call `withScheme()` passing the scheme you want to use.
+3. Call `withScheme()` on the WebAuthProvider.Builder instance passing the scheme you want to use.
 
 
 ```java
@@ -326,7 +326,7 @@ WebAuthProvider.init(account)
 ```
 
 #### Use Code grant with PKCE
-> Before you can use `Code Grant` in Android, make sure to go to your [client's section](https://manage.auth0.com/#/applications) in dashboard and check in the Settings that `Client Type` is `Native`.
+> Before you can use `Code Grant` in Android, make sure to go to your [client's section](https://manage.auth0.com/#/clients) in dashboard and check in the Settings that the `Client Type` is set to `Native`.
 
 
 ```java
@@ -408,7 +408,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com)
 
 ## License
 

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -44,6 +44,7 @@ import com.auth0.android.request.internal.RequestFactory;
 import com.auth0.android.result.Credentials;
 import com.auth0.android.result.DatabaseUser;
 import com.auth0.android.result.Delegation;
+import com.auth0.android.result.UserInfo;
 import com.auth0.android.result.UserProfile;
 import com.auth0.android.util.Telemetry;
 import com.google.gson.Gson;
@@ -386,9 +387,9 @@ public class AuthenticationAPIClient {
      * Example usage:
      * <pre><code>
      * client.userInfo("{access_token}")
-     *      .start(new BaseCallback<UserProfile>() {
+     *      .start(new BaseCallback<UserInfo>() {
      *          {@literal}Override
-     *          public void onSuccess(UserProfile payload) { }
+     *          public void onSuccess(UserInfo payload) { }
      *
      *          {@literal}@Override
      *          public void onFailure(AuthenticationException error) { }
@@ -399,7 +400,7 @@ public class AuthenticationAPIClient {
      * @return a request to start
      */
     @SuppressWarnings("WeakerAccess")
-    public Request<UserProfile, AuthenticationException> userInfo(@NonNull String accessToken) {
+    public Request<UserInfo, AuthenticationException> userInfo(@NonNull String accessToken) {
         return profileRequest()
                 .addHeader(HEADER_AUTHORIZATION, "Bearer " + accessToken);
     }
@@ -898,7 +899,7 @@ public class AuthenticationAPIClient {
      * @return a {@link ProfileRequest} that first logins and the fetches the profile
      */
     public ProfileRequest getProfileAfter(@NonNull AuthenticationRequest authenticationRequest) {
-        final ParameterizableRequest<UserProfile, AuthenticationException> profileRequest = profileRequest();
+        final ParameterizableRequest<UserInfo, AuthenticationException> profileRequest = profileRequest();
         return new ProfileRequest(authenticationRequest, profileRequest);
     }
 
@@ -976,12 +977,12 @@ public class AuthenticationAPIClient {
                 .addAuthenticationParameters(requestParameters);
     }
 
-    private ParameterizableRequest<UserProfile, AuthenticationException> profileRequest() {
+    private ParameterizableRequest<UserInfo, AuthenticationException> profileRequest() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(USER_INFO_PATH)
                 .build();
 
-        return factory.GET(url, client, gson, UserProfile.class, authErrorBuilder);
+        return factory.GET(url, client, gson, UserInfo.class, authErrorBuilder);
     }
 
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -401,8 +401,12 @@ public class AuthenticationAPIClient {
      */
     @SuppressWarnings("WeakerAccess")
     public Request<UserInfo, AuthenticationException> userInfo(@NonNull String accessToken) {
-        return profileRequest()
-                .addHeader(HEADER_AUTHORIZATION, "Bearer " + accessToken);
+        HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
+                .addPathSegment(USER_INFO_PATH)
+                .build();
+
+        ParameterizableRequest<UserInfo, AuthenticationException> request = factory.GET(url, client, gson, UserInfo.class, authErrorBuilder);
+        return request.addHeader(HEADER_AUTHORIZATION, "Bearer " + accessToken);
     }
 
     /**
@@ -899,7 +903,11 @@ public class AuthenticationAPIClient {
      * @return a {@link ProfileRequest} that first logins and the fetches the profile
      */
     public ProfileRequest getProfileAfter(@NonNull AuthenticationRequest authenticationRequest) {
-        final ParameterizableRequest<UserInfo, AuthenticationException> profileRequest = profileRequest();
+        HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
+                .addPathSegment(USER_INFO_PATH)
+                .build();
+
+        ParameterizableRequest<UserProfile, AuthenticationException> profileRequest = factory.GET(url, client, gson, UserProfile.class, authErrorBuilder);
         return new ProfileRequest(authenticationRequest, profileRequest);
     }
 
@@ -975,14 +983,6 @@ public class AuthenticationAPIClient {
                 .asDictionary();
         return factory.authenticationPOST(url, client, gson)
                 .addAuthenticationParameters(requestParameters);
-    }
-
-    private ParameterizableRequest<UserInfo, AuthenticationException> profileRequest() {
-        HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
-                .addPathSegment(USER_INFO_PATH)
-                .build();
-
-        return factory.GET(url, client, gson, UserInfo.class, authErrorBuilder);
     }
 
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.java
@@ -32,7 +32,7 @@ import com.auth0.android.request.ParameterizableRequest;
 import com.auth0.android.request.Request;
 import com.auth0.android.result.Authentication;
 import com.auth0.android.result.Credentials;
-import com.auth0.android.result.UserProfile;
+import com.auth0.android.result.UserInfo;
 
 import java.util.Map;
 
@@ -44,9 +44,9 @@ public class ProfileRequest implements Request<Authentication, AuthenticationExc
     private static final String HEADER_AUTHORIZATION = "Authorization";
 
     private final AuthenticationRequest credentialsRequest;
-    private final ParameterizableRequest<UserProfile, AuthenticationException> userInfoRequest;
+    private final ParameterizableRequest<UserInfo, AuthenticationException> userInfoRequest;
 
-    public ProfileRequest(AuthenticationRequest credentialsRequest, ParameterizableRequest<UserProfile, AuthenticationException> userInfoRequest) {
+    public ProfileRequest(AuthenticationRequest credentialsRequest, ParameterizableRequest<UserInfo, AuthenticationException> userInfoRequest) {
         this.credentialsRequest = credentialsRequest;
         this.userInfoRequest = userInfoRequest;
     }
@@ -96,10 +96,10 @@ public class ProfileRequest implements Request<Authentication, AuthenticationExc
             public void onSuccess(final Credentials credentials) {
                 userInfoRequest
                         .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials.getAccessToken())
-                        .start(new BaseCallback<UserProfile, AuthenticationException>() {
+                        .start(new BaseCallback<UserInfo, AuthenticationException>() {
                             @Override
-                            public void onSuccess(UserProfile profile) {
-                                callback.onSuccess(new Authentication(profile, credentials));
+                            public void onSuccess(UserInfo info) {
+                                callback.onSuccess(new Authentication(info, credentials));
                             }
 
                             @Override
@@ -125,9 +125,9 @@ public class ProfileRequest implements Request<Authentication, AuthenticationExc
     @Override
     public Authentication execute() throws Auth0Exception {
         Credentials credentials = credentialsRequest.execute();
-        UserProfile profile = userInfoRequest
+        UserInfo info = userInfoRequest
                 .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials.getAccessToken())
                 .execute();
-        return new Authentication(profile, credentials);
+        return new Authentication(info, credentials);
     }
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.java
@@ -32,7 +32,7 @@ import com.auth0.android.request.ParameterizableRequest;
 import com.auth0.android.request.Request;
 import com.auth0.android.result.Authentication;
 import com.auth0.android.result.Credentials;
-import com.auth0.android.result.UserInfo;
+import com.auth0.android.result.UserProfile;
 
 import java.util.Map;
 
@@ -44,11 +44,11 @@ public class ProfileRequest implements Request<Authentication, AuthenticationExc
     private static final String HEADER_AUTHORIZATION = "Authorization";
 
     private final AuthenticationRequest credentialsRequest;
-    private final ParameterizableRequest<UserInfo, AuthenticationException> userInfoRequest;
+    private final ParameterizableRequest<UserProfile, AuthenticationException> userProfileRequest;
 
-    public ProfileRequest(AuthenticationRequest credentialsRequest, ParameterizableRequest<UserInfo, AuthenticationException> userInfoRequest) {
+    public ProfileRequest(AuthenticationRequest credentialsRequest, ParameterizableRequest<UserProfile, AuthenticationException> userProfileRequest) {
         this.credentialsRequest = credentialsRequest;
-        this.userInfoRequest = userInfoRequest;
+        this.userProfileRequest = userProfileRequest;
     }
 
     /**
@@ -94,12 +94,12 @@ public class ProfileRequest implements Request<Authentication, AuthenticationExc
         credentialsRequest.start(new BaseCallback<Credentials, AuthenticationException>() {
             @Override
             public void onSuccess(final Credentials credentials) {
-                userInfoRequest
+                userProfileRequest
                         .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials.getAccessToken())
-                        .start(new BaseCallback<UserInfo, AuthenticationException>() {
+                        .start(new BaseCallback<UserProfile, AuthenticationException>() {
                             @Override
-                            public void onSuccess(UserInfo info) {
-                                callback.onSuccess(new Authentication(info, credentials));
+                            public void onSuccess(UserProfile profile) {
+                                callback.onSuccess(new Authentication(profile, credentials));
                             }
 
                             @Override
@@ -125,9 +125,9 @@ public class ProfileRequest implements Request<Authentication, AuthenticationExc
     @Override
     public Authentication execute() throws Auth0Exception {
         Credentials credentials = credentialsRequest.execute();
-        UserInfo info = userInfoRequest
+        UserProfile profile = userProfileRequest
                 .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials.getAccessToken())
                 .execute();
-        return new Authentication(info, credentials);
+        return new Authentication(profile, credentials);
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/UserInfoDeserializer.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/UserInfoDeserializer.java
@@ -1,0 +1,26 @@
+package com.auth0.android.request.internal;
+
+import com.auth0.android.result.UserInfo;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+class UserInfoDeserializer implements JsonDeserializer<UserInfo> {
+    @Override
+    public UserInfo deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        if (!json.isJsonObject() || json.isJsonNull() || json.getAsJsonObject().entrySet().isEmpty()) {
+            throw new JsonParseException("user info json is not a valid json object");
+        }
+
+        JsonObject object = json.getAsJsonObject();
+        final Type mapType = new TypeToken<Map<String, Object>>() {}.getType();
+        Map<String, Object> values = context.deserialize(object, mapType);
+        return new UserInfo(values);
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/result/Authentication.java
+++ b/auth0/src/main/java/com/auth0/android/result/Authentication.java
@@ -38,18 +38,18 @@ import static com.auth0.android.util.CheckHelper.checkArgument;
  */
 public class Authentication {
 
-    private final UserInfo info;
+    private final UserProfile profile;
     private final Credentials credentials;
 
-    public Authentication(UserInfo info, Credentials credentials) {
-        checkArgument(info != null, "info must be non-null");
+    public Authentication(UserProfile profile, Credentials credentials) {
+        checkArgument(profile != null, "profile must be non-null");
         checkArgument(credentials != null, "credentials must be non-null");
-        this.info = info;
+        this.profile = profile;
         this.credentials = credentials;
     }
 
-    public UserInfo getUserInfo() {
-        return info;
+    public UserProfile getUserProfile() {
+        return profile;
     }
 
     public Credentials getCredentials() {

--- a/auth0/src/main/java/com/auth0/android/result/UserInfo.java
+++ b/auth0/src/main/java/com/auth0/android/result/UserInfo.java
@@ -1,7 +1,7 @@
 /*
- * Authentication.java
+ * UserProfile.java
  *
- * Copyright (c) 2016 Auth0 (http://auth0.com)
+ * Copyright (c) 2015 Auth0 (http://auth0.com)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,35 +24,29 @@
 
 package com.auth0.android.result;
 
-
-import com.auth0.android.authentication.AuthenticationAPIClient;
-import com.auth0.android.request.AuthenticationRequest;
-
-import static com.auth0.android.util.CheckHelper.checkArgument;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * The result of a successful authentication against Auth0
- * Contains the logged in user's {@link Credentials} and {@link UserInfo}.
- *
- * @see AuthenticationAPIClient#getProfileAfter(AuthenticationRequest)
+ * Class that holds the information of an Auth0 User
  */
-public class Authentication {
+public class UserInfo implements Serializable {
 
-    private final UserInfo info;
-    private final Credentials credentials;
+    private Map<String, Object> values;
 
-    public Authentication(UserInfo info, Credentials credentials) {
-        checkArgument(info != null, "info must be non-null");
-        checkArgument(credentials != null, "credentials must be non-null");
-        this.info = info;
-        this.credentials = credentials;
+    public UserInfo(Map<String, Object> values) {
+        this.values = values;
     }
 
-    public UserInfo getUserInfo() {
-        return info;
+    /**
+     * Returns information contained in the user
+     *
+     * @return a map with user's information
+     */
+    public Map<String, Object> getValues() {
+        return values != null ? new HashMap<>(values) : Collections.<String, Object>emptyMap();
     }
 
-    public Credentials getCredentials() {
-        return credentials;
-    }
 }

--- a/auth0/src/main/java/com/auth0/android/result/UserInfo.java
+++ b/auth0/src/main/java/com/auth0/android/result/UserInfo.java
@@ -37,7 +37,7 @@ public class UserInfo implements Serializable {
     private Map<String, Object> values;
 
     public UserInfo(Map<String, Object> values) {
-        this.values = values;
+        this.values = values != null ? new HashMap<>(values) : Collections.<String, Object>emptyMap();
     }
 
     /**
@@ -46,7 +46,7 @@ public class UserInfo implements Serializable {
      * @return a map with user's information
      */
     public Map<String, Object> getValues() {
-        return values != null ? new HashMap<>(values) : Collections.<String, Object>emptyMap();
+        return values;
     }
 
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -34,6 +34,7 @@ import com.auth0.android.result.Authentication;
 import com.auth0.android.result.Credentials;
 import com.auth0.android.result.DatabaseUser;
 import com.auth0.android.result.Delegation;
+import com.auth0.android.result.UserInfo;
 import com.auth0.android.result.UserProfile;
 import com.auth0.android.util.AuthenticationAPI;
 import com.auth0.android.util.MockAuthenticationCallback;
@@ -381,12 +382,12 @@ public class AuthenticationAPIClientTest {
     @Test
     public void shouldFetchUserInfo() throws Exception {
         mockAPI.willReturnTokenInfo();
-        final MockAuthenticationCallback<UserProfile> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<UserInfo> callback = new MockAuthenticationCallback<>();
 
         client.userInfo("ACCESS_TOKEN")
                 .start(callback);
 
-        assertThat(callback, hasPayloadOfType(UserProfile.class));
+        assertThat(callback, hasPayloadOfType(UserInfo.class));
 
         final RecordedRequest request = mockAPI.takeRequest();
         assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
@@ -398,7 +399,7 @@ public class AuthenticationAPIClientTest {
     public void shouldFetchUserInfoSync() throws Exception {
         mockAPI.willReturnTokenInfo();
 
-        final UserProfile profile = client
+        final UserInfo profile = client
                 .userInfo("ACCESS_TOKEN")
                 .execute();
 

--- a/auth0/src/test/java/com/auth0/android/authentication/request/ProfileRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/ProfileRequestTest.java
@@ -6,6 +6,7 @@ import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.request.ParameterizableRequest;
 import com.auth0.android.result.Authentication;
 import com.auth0.android.result.Credentials;
+import com.auth0.android.result.UserInfo;
 import com.auth0.android.result.UserProfile;
 
 import org.hamcrest.CoreMatchers;
@@ -75,11 +76,11 @@ public class ProfileRequestTest {
 
     @Test
     public void shouldReturnAuthenticationAfterStartingTheRequest() throws Exception {
-        final UserProfile userProfile = mock(UserProfile.class);
+        final UserInfo userInfo = mock(UserInfo.class);
         final Credentials credentials = mock(Credentials.class);
 
         final AuthenticationRequestMock authenticationRequestMock = new AuthenticationRequestMock(credentials, null);
-        final ParameterizableRequestMock tokenInfoRequestMock = new ParameterizableRequestMock(userProfile, null);
+        final ParameterizableRequestMock tokenInfoRequestMock = new ParameterizableRequestMock(userInfo, null);
         final BaseCallback callback = mock(BaseCallback.class);
 
         profileRequest = new ProfileRequest(authenticationRequestMock, tokenInfoRequestMock);
@@ -95,8 +96,8 @@ public class ProfileRequestTest {
         assertThat(authenticationCaptor.getValue(), is(instanceOf(Authentication.class)));
         assertThat(authenticationCaptor.getValue().getCredentials(), is(notNullValue()));
         assertThat(authenticationCaptor.getValue().getCredentials(), is(credentials));
-        assertThat(authenticationCaptor.getValue().getProfile(), is(notNullValue()));
-        assertThat(authenticationCaptor.getValue().getProfile(), is(userProfile));
+        assertThat(authenticationCaptor.getValue().getUserInfo(), is(notNullValue()));
+        assertThat(authenticationCaptor.getValue().getUserInfo(), is(userInfo));
     }
 
     @Test
@@ -144,13 +145,13 @@ public class ProfileRequestTest {
                 return credentials;
             }
         });
-        final UserProfile userProfile = mock(UserProfile.class);
+        final UserInfo userInfo = mock(UserInfo.class);
         when(userInfoMockRequest.addParameter(anyString(), anyObject())).thenReturn(userInfoMockRequest);
         when(userInfoMockRequest.addHeader(anyString(), anyString())).thenReturn(userInfoMockRequest);
         when(userInfoMockRequest.execute()).thenAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-                return userProfile;
+                return userInfo;
             }
         });
         final Authentication executeResult = profileRequest.execute();
@@ -161,8 +162,8 @@ public class ProfileRequestTest {
         assertThat(executeResult, is(instanceOf(Authentication.class)));
         assertThat(executeResult.getCredentials(), is(notNullValue()));
         assertThat(executeResult.getCredentials(), is(credentials));
-        assertThat(executeResult.getProfile(), is(notNullValue()));
-        assertThat(executeResult.getProfile(), is(userProfile));
+        assertThat(executeResult.getUserInfo(), is(notNullValue()));
+        assertThat(executeResult.getUserInfo(), is(userInfo));
     }
 
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/request/ProfileRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/ProfileRequestTest.java
@@ -6,7 +6,6 @@ import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.request.ParameterizableRequest;
 import com.auth0.android.result.Authentication;
 import com.auth0.android.result.Credentials;
-import com.auth0.android.result.UserInfo;
 import com.auth0.android.result.UserProfile;
 
 import org.hamcrest.CoreMatchers;
@@ -76,11 +75,11 @@ public class ProfileRequestTest {
 
     @Test
     public void shouldReturnAuthenticationAfterStartingTheRequest() throws Exception {
-        final UserInfo userInfo = mock(UserInfo.class);
+        final UserProfile userProfile = mock(UserProfile.class);
         final Credentials credentials = mock(Credentials.class);
 
         final AuthenticationRequestMock authenticationRequestMock = new AuthenticationRequestMock(credentials, null);
-        final ParameterizableRequestMock tokenInfoRequestMock = new ParameterizableRequestMock(userInfo, null);
+        final ParameterizableRequestMock tokenInfoRequestMock = new ParameterizableRequestMock(userProfile, null);
         final BaseCallback callback = mock(BaseCallback.class);
 
         profileRequest = new ProfileRequest(authenticationRequestMock, tokenInfoRequestMock);
@@ -96,8 +95,8 @@ public class ProfileRequestTest {
         assertThat(authenticationCaptor.getValue(), is(instanceOf(Authentication.class)));
         assertThat(authenticationCaptor.getValue().getCredentials(), is(notNullValue()));
         assertThat(authenticationCaptor.getValue().getCredentials(), is(credentials));
-        assertThat(authenticationCaptor.getValue().getUserInfo(), is(notNullValue()));
-        assertThat(authenticationCaptor.getValue().getUserInfo(), is(userInfo));
+        assertThat(authenticationCaptor.getValue().getUserProfile(), is(notNullValue()));
+        assertThat(authenticationCaptor.getValue().getUserProfile(), is(userProfile));
     }
 
     @Test
@@ -145,13 +144,13 @@ public class ProfileRequestTest {
                 return credentials;
             }
         });
-        final UserInfo userInfo = mock(UserInfo.class);
+        final UserProfile userProfile = mock(UserProfile.class);
         when(userInfoMockRequest.addParameter(anyString(), anyObject())).thenReturn(userInfoMockRequest);
         when(userInfoMockRequest.addHeader(anyString(), anyString())).thenReturn(userInfoMockRequest);
         when(userInfoMockRequest.execute()).thenAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-                return userInfo;
+                return userProfile;
             }
         });
         final Authentication executeResult = profileRequest.execute();
@@ -162,8 +161,8 @@ public class ProfileRequestTest {
         assertThat(executeResult, is(instanceOf(Authentication.class)));
         assertThat(executeResult.getCredentials(), is(notNullValue()));
         assertThat(executeResult.getCredentials(), is(credentials));
-        assertThat(executeResult.getUserInfo(), is(notNullValue()));
-        assertThat(executeResult.getUserInfo(), is(userInfo));
+        assertThat(executeResult.getUserProfile(), is(notNullValue()));
+        assertThat(executeResult.getUserProfile(), is(userProfile));
     }
 
 }

--- a/auth0/src/test/java/com/auth0/android/result/AuthenticationTest.java
+++ b/auth0/src/test/java/com/auth0/android/result/AuthenticationTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertThat;
 
 public class AuthenticationTest {
 
-    private UserProfile profile;
+    private UserInfo info;
     private Credentials credentials;
 
     private Authentication authentication;
@@ -17,13 +17,13 @@ public class AuthenticationTest {
     @Before
     public void setUp() throws Exception {
         credentials = Mockito.mock(Credentials.class);
-        profile = Mockito.mock(UserProfile.class);
-        authentication = new Authentication(profile, credentials);
+        info = Mockito.mock(UserInfo.class);
+        authentication = new Authentication(info, credentials);
     }
 
     @Test
-    public void getProfile() throws Exception {
-        assertThat(authentication.getProfile(), is(profile));
+    public void getUserInfo() throws Exception {
+        assertThat(authentication.getUserInfo(), is(info));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/result/AuthenticationTest.java
+++ b/auth0/src/test/java/com/auth0/android/result/AuthenticationTest.java
@@ -1,7 +1,9 @@
 package com.auth0.android.result;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import static org.hamcrest.core.Is.is;
@@ -9,26 +11,42 @@ import static org.junit.Assert.assertThat;
 
 public class AuthenticationTest {
 
-    private UserInfo info;
-    private Credentials credentials;
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
+    private UserProfile profile;
+    private Credentials credentials;
     private Authentication authentication;
 
     @Before
     public void setUp() throws Exception {
         credentials = Mockito.mock(Credentials.class);
-        info = Mockito.mock(UserInfo.class);
-        authentication = new Authentication(info, credentials);
+        profile = Mockito.mock(UserProfile.class);
+        authentication = new Authentication(profile, credentials);
     }
 
     @Test
     public void getUserInfo() throws Exception {
-        assertThat(authentication.getUserInfo(), is(info));
+        assertThat(authentication.getUserProfile(), is(profile));
     }
 
     @Test
     public void getCredentials() throws Exception {
         assertThat(authentication.getCredentials(), is(credentials));
+    }
+
+    @Test
+    public void shouldThrowOnNullInfo() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("profile must be non-null");
+        new Authentication(null, credentials);
+    }
+
+    @Test
+    public void shouldThrowOnNullCredentials() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("credentials must be non-null");
+        new Authentication(profile, null);
     }
 
 }

--- a/auth0/src/test/java/com/auth0/android/result/UserInfoTest.java
+++ b/auth0/src/test/java/com/auth0/android/result/UserInfoTest.java
@@ -1,0 +1,27 @@
+package com.auth0.android.result;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class UserInfoTest {
+
+    private Map<String, Object> values;
+    private UserInfo userInfo;
+
+    @Before
+    public void setUp() throws Exception {
+        values = Mockito.mock(Map.class);
+        userInfo = new UserInfo(values);
+    }
+
+    @Test
+    public void getValues() throws Exception {
+        assertThat(userInfo.getValues(), is(values));
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/result/UserInfoTest.java
+++ b/auth0/src/test/java/com/auth0/android/result/UserInfoTest.java
@@ -1,6 +1,6 @@
 package com.auth0.android.result;
 
-import org.junit.Before;
+import org.hamcrest.collection.IsMapWithSize;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -11,17 +11,16 @@ import static org.junit.Assert.assertThat;
 
 public class UserInfoTest {
 
-    private Map<String, Object> values;
-    private UserInfo userInfo;
-
-    @Before
-    public void setUp() throws Exception {
-        values = Mockito.mock(Map.class);
-        userInfo = new UserInfo(values);
+    @Test
+    public void getValues() throws Exception {
+        Map<String, Object> values = Mockito.mock(Map.class);
+        UserInfo userInfo = new UserInfo(values);
+        assertThat(userInfo.getValues(), is(values));
     }
 
     @Test
-    public void getValues() throws Exception {
-        assertThat(userInfo.getValues(), is(values));
+    public void getEmptyValues() throws Exception {
+        UserInfo userInfo = new UserInfo(null);
+        assertThat(userInfo.getValues(), IsMapWithSize.anEmptyMap());
     }
 }


### PR DESCRIPTION
Make `userInfo` return a `UserInfo` instance instead of a `UserProfile`. UserInfo will only contain a map with values. The `UserProfile` is kept to be returned by the `tokenInfo` endpoint and the `getProfileAfter` call.

**This is a breaking change.**