### PR TITLE
Strictly compare the OIDC invalid_request message

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -41,6 +41,9 @@ public class AuthenticationException extends Auth0Exception {
 
     private static final String DEFAULT_MESSAGE = "An error occurred when trying to authenticate with the server.";
 
+    private static final String ERROR_OIDC_ACCESS_TOKEN = "OIDC conformant clients cannot use /oauth/access_token";
+    private static final String ERROR_OIDC_RO = "OIDC conformant clients cannot use /oauth/ro";
+
     private String code;
     private String description;
     private int statusCode;
@@ -89,7 +92,7 @@ public class AuthenticationException extends Auth0Exception {
     }
 
     private void warnIfOIDCError() {
-        if ("invalid_request".equals(getCode())) {
+        if ("invalid_request".equals(getCode()) && (ERROR_OIDC_ACCESS_TOKEN.equals(getDescription()) || ERROR_OIDC_RO.equals(getDescription()))) {
             Log.w(AuthenticationAPIClient.class.getSimpleName(), "Your Auth0 Client is configured as 'OIDC Conformant' but this instance it's not. To authenticate you will need to enable the flag by calling Auth0#setOIDCConformant(true) on the Auth0 instance you used in the setup.");
         }
     }


### PR DESCRIPTION
To avoid false positive OIDC error matches, include the description in the comparison. 