### PR TITLE
Extract the user id from the 'sub' claim if present

### DIFF
--- a/auth0/src/main/java/com/auth0/android/result/UserProfile.java
+++ b/auth0/src/main/java/com/auth0/android/result/UserProfile.java
@@ -25,10 +25,15 @@
 package com.auth0.android.result;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
- * Class that holds the information of a user's profile in Auth0
+ * Class that holds the information of a user's profile in Auth0.
+ * Used both in {@link com.auth0.android.management.UsersAPIClient} and {@link com.auth0.android.authentication.AuthenticationAPIClient}.
  */
 public class UserProfile implements Serializable {
     private String id;
@@ -63,8 +68,17 @@ public class UserProfile implements Serializable {
         this.extraInfo = extraInfo;
     }
 
+    /**
+     * Getter for the unique Identifier of the user. If this represents a Full User Profile (Management API) the 'id' field will be returned.
+     * If the value is not present, it will be considered a User Information and the id will be obtained from the 'sub' claim.
+     *
+     * @return the unique identifier of the user.
+     */
     public String getId() {
-        return id;
+        if (id != null) {
+            return id;
+        }
+        return getExtraInfo().containsKey("sub") ? (String) getExtraInfo().get("sub") : null;
     }
 
     public String getName() {

--- a/auth0/src/test/java/com/auth0/android/request/internal/UserProfileGsonTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/UserProfileGsonTest.java
@@ -141,7 +141,7 @@ public class UserProfileGsonTest extends GsonBaseTest {
     @Test
     public void shouldReturnOAuthProfile() throws Exception {
         UserProfile profile = pojoFrom(json(PROFILE_OAUTH), UserProfile.class);
-        assertThat(profile.getId(), is(nullValue()));
+        assertThat(profile.getId(), is("google-oauth2|9883254263433883220"));
         assertThat(profile.getName(), is(nullValue()));
         assertThat(profile.getNickname(), is(nullValue()));
         assertThat(profile.getPictureURL(), is(nullValue()));

--- a/auth0/src/test/java/com/auth0/android/result/UserProfileTest.java
+++ b/auth0/src/test/java/com/auth0/android/result/UserProfileTest.java
@@ -8,6 +8,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import edu.emory.mathcs.backport.java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -33,6 +36,21 @@ public class UserProfileTest {
     @Test
     public void getId() throws Exception {
         assertThat(userProfile.getId(), is("id"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldReturnSubIfMissingId() throws Exception {
+        Map<String, Object> extraInfo = Collections.singletonMap("sub", "fromSub");
+        userProfile = new UserProfile(null, null, null, null, null, false, null, null, null, extraInfo, null, null, null);
+        assertThat(userProfile.getId(), is("fromSub"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldGetNullIdIfMissing() throws Exception {
+        userProfile = new UserProfile(null, null, null, null, null, false, null, null, null, null, null, null, null);
+        assertThat(userProfile.getId(), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
As the `UsersAPIClient` and `AuthenticationAPIClient` return a `UserProfile` object on `getProfile` or `userInfo`, we need to ensure the instance can handle both id scenarios. The `userProfile.getId()` will return:
1. The id value if present.
2. The 'sub' claim if present 
3. Null in any other case.