### PR TITLE
Ensure closing the response body after it was parsed

### DIFF
--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.java
@@ -131,7 +131,7 @@ abstract class BaseRequest<T, U extends Auth0Exception> implements Parameterizab
             stringPayload = body.string();
             Type mapType = new TypeToken<Map<String, Object>>() {
             }.getType();
-            Map<String, Object> mapPayload = gson.fromJson(body.charStream(), mapType);
+            Map<String, Object> mapPayload = gson.fromJson(stringPayload, mapType);
             return errorBuilder.from(mapPayload);
         } catch (JsonSyntaxException e) {
             return errorBuilder.from(stringPayload, response.code());

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.java
@@ -50,6 +50,8 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.auth0.android.request.internal.ResponseUtils.closeStream;
+
 abstract class BaseRequest<T, U extends Auth0Exception> implements ParameterizableRequest<T, U>, AuthorizableRequest<T, U>, Callback {
 
     private final Map<String, String> headers;
@@ -139,10 +141,7 @@ abstract class BaseRequest<T, U extends Auth0Exception> implements Parameterizab
             final Auth0Exception auth0Exception = new Auth0Exception("Error parsing the server response", e);
             return errorBuilder.from("Request to " + url.toString() + " failed", auth0Exception);
         } finally {
-            try {
-                body.close();
-            } catch (IOException ignored) {
-            }
+            closeStream(body);
         }
     }
 

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.java
@@ -131,7 +131,7 @@ abstract class BaseRequest<T, U extends Auth0Exception> implements Parameterizab
             stringPayload = body.string();
             Type mapType = new TypeToken<Map<String, Object>>() {
             }.getType();
-            Map<String, Object> mapPayload = gson.fromJson(stringPayload, mapType);
+            Map<String, Object> mapPayload = gson.fromJson(body.charStream(), mapType);
             return errorBuilder.from(mapPayload);
         } catch (JsonSyntaxException e) {
             return errorBuilder.from(stringPayload, response.code());
@@ -141,7 +141,7 @@ abstract class BaseRequest<T, U extends Auth0Exception> implements Parameterizab
         } finally {
             try {
                 body.close();
-            } catch (Exception ignored) {
+            } catch (IOException ignored) {
             }
         }
     }

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.java
@@ -43,6 +43,7 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -125,8 +126,9 @@ abstract class BaseRequest<T, U extends Auth0Exception> implements Parameterizab
 
     protected U parseUnsuccessfulResponse(Response response) {
         String stringPayload = null;
+        ResponseBody body = response.body();
         try {
-            stringPayload = response.body().string();
+            stringPayload = body.string();
             Type mapType = new TypeToken<Map<String, Object>>() {
             }.getType();
             Map<String, Object> mapPayload = gson.fromJson(stringPayload, mapType);
@@ -136,6 +138,11 @@ abstract class BaseRequest<T, U extends Auth0Exception> implements Parameterizab
         } catch (IOException e) {
             final Auth0Exception auth0Exception = new Auth0Exception("Error parsing the server response", e);
             return errorBuilder.from("Request to " + url.toString() + " failed", auth0Exception);
+        } finally {
+            try {
+                body.close();
+            } catch (Exception ignored) {
+            }
         }
     }
 

--- a/auth0/src/main/java/com/auth0/android/request/internal/ResponseUtils.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/ResponseUtils.java
@@ -1,0 +1,19 @@
+package com.auth0.android.request.internal;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+class ResponseUtils {
+
+    /**
+     * Attempts to close a stream. No exception will be thrown if an IOException was raised.
+     *
+     * @param closeable the stream to close
+     */
+    static void closeStream(Closeable closeable) {
+        try {
+            closeable.close();
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/request/internal/SimpleRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/SimpleRequest.java
@@ -40,6 +40,8 @@ import com.squareup.okhttp.ResponseBody;
 import java.io.IOException;
 import java.io.Reader;
 
+import static com.auth0.android.request.internal.ResponseUtils.closeStream;
+
 class SimpleRequest<T, U extends Auth0Exception> extends BaseRequest<T, U> implements ParameterizableRequest<T, U>, Callback {
 
     private final String method;
@@ -76,10 +78,7 @@ class SimpleRequest<T, U extends Auth0Exception> extends BaseRequest<T, U> imple
             final Auth0Exception auth0Exception = new Auth0Exception("Failed to parse response to request to " + url, e);
             postOnFailure(getErrorBuilder().from("Failed to parse a successful response", auth0Exception));
         } finally {
-            try {
-                body.close();
-            } catch (Exception ignored) {
-            }
+            closeStream(body);
         }
     }
 
@@ -113,10 +112,7 @@ class SimpleRequest<T, U extends Auth0Exception> extends BaseRequest<T, U> imple
         } catch (IOException e) {
             throw new Auth0Exception("Failed to parse response to request to " + url, e);
         } finally {
-            try {
-                body.close();
-            } catch (Exception ignored) {
-            }
+            closeStream(body);
         }
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/SimpleRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/SimpleRequest.java
@@ -35,6 +35,7 @@ import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -66,13 +67,19 @@ class SimpleRequest<T, U extends Auth0Exception> extends BaseRequest<T, U> imple
             return;
         }
 
+        ResponseBody body = response.body();
         try {
-            Reader charStream = response.body().charStream();
+            Reader charStream = body.charStream();
             T payload = getAdapter().fromJson(charStream);
             postOnSuccess(payload);
         } catch (IOException e) {
             final Auth0Exception auth0Exception = new Auth0Exception("Failed to parse response to request to " + url, e);
             postOnFailure(getErrorBuilder().from("Failed to parse a successful response", auth0Exception));
+        } finally {
+            try {
+                body.close();
+            } catch (Exception ignored) {
+            }
         }
     }
 
@@ -99,11 +106,17 @@ class SimpleRequest<T, U extends Auth0Exception> extends BaseRequest<T, U> imple
             throw parseUnsuccessfulResponse(response);
         }
 
+        ResponseBody body = response.body();
         try {
-            Reader charStream = response.body().charStream();
+            Reader charStream = body.charStream();
             return getAdapter().fromJson(charStream);
         } catch (IOException e) {
             throw new Auth0Exception("Failed to parse response to request to " + url, e);
+        } finally {
+            try {
+                body.close();
+            } catch (Exception ignored) {
+            }
         }
     }
 }

--- a/auth0/src/test/java/com/auth0/android/request/internal/ResponseUtilsTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/ResponseUtilsTest.java
@@ -1,0 +1,24 @@
+package com.auth0.android.request.internal;
+
+import com.squareup.okhttp.ResponseBody;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ResponseUtilsTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldCloseBody() throws Exception {
+        ResponseBody body = mock(ResponseBody.class);
+        ResponseUtils.closeStream(body);
+
+        verify(body).close();
+    }
+}


### PR DESCRIPTION
Body should be closed after we finish parsing the response. There are some methods like `body.string()` that close the body internally, but if the call throws an exception we would need to call `body.close()` manually.

Related: https://github.com/square/okhttp/issues/2311