### PR TITLE
Add CredentialsManager and generic Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,46 @@ WebAuthProvider.init(account)
 ```
 
 
+## Credentials Manager
+This library ships with a `CredentialsManager` class to easily store and retrieve fresh Credentials from a given `Storage`.
+
+### Usage
+1. **Instantiate the manager**
+
+```java
+AuthenticationAPIClient authClient = //create auth client
+Storage storage = //create new storage
+CredentialsManager manager = new CredentialsManager(authClient, storage);
+```
+
+2. **Save credentials**
+The credentials **must have** `expires_in` and at least an `access_token` or `id_token` value. If one of the values is missing when trying to set the credentials, the method will throw a `CredentialsManagerException`. 
+
+```java
+Credentials credentials = //login to Auth0, i.e. by using the authClient
+manager.setCredentials(credentials);
+```
+
+3. **Retrieve credentials**
+ Existing credentials will be returned if they are still valid, otherwise the `refresh_token` will be used to attempt to renew them. If the `expires_in` or both the `access_token` and `id_token` values are missing, the method will throw a `CredentialsManagerException`. The same will happen if the credentials have expired and there's no `refresh_token` available.
+
+```java
+manager.getCredentials(new BaseCallback<Credentials, CredentialsManagerException>(){
+   public void onSuccess(Credentials credentials){
+      //success
+   }
+
+    public void onFailure(CredentialsManagerException error){
+      //error
+   }
+});
+```
+
+### Customize the Storage
+
+The storage implementation is up to you. We provide a `SharedPreferencesStorage` that uses `SharedPreferences` to create a file in the application directory with Context.MODE_PRIVATE mode.
+
+
 ## FAQ
 
 * Why is the Android Lint _error_ `'InvalidPackage'` considered a _warning_?

--- a/README.md
+++ b/README.md
@@ -389,19 +389,33 @@ This library ships with a `CredentialsManager` class to easily store and retriev
 
 ### Usage
 1. **Instantiate the manager**
+You'll need an `AuthenticationAPIClient` instance used to renew the credentials when they expire and a `Storage`. The Storage implementation is up to you. We provide a `SharedPreferencesStorage` that uses `SharedPreferences` to create a file in the application's directory with Context.MODE_PRIVATE mode. This implementation is thread safe and can either be obtained through a Singleton like method or be created every time it's needed.
 
 ```java
-AuthenticationAPIClient authClient = //create auth client
-Storage storage = //create new storage
-CredentialsManager manager = new CredentialsManager(authClient, storage);
+AuthenticationAPIClient authentication = new AuthenticationAPIClient(account);
+Storage storage = new SharedPreferencesStorage(this);
+CredentialsManager manager = new CredentialsManager(authentication, storage);
 ```
 
 2. **Save credentials**
-The credentials **must have** `expires_in` and at least an `access_token` or `id_token` value. If one of the values is missing when trying to set the credentials, the method will throw a `CredentialsManagerException`. 
+The credentials to save **must have** `expires_in` and at least an `access_token` or `id_token` value. If one of the values is missing when trying to set the credentials, the method will throw a `CredentialsManagerException`. If you want the manager to successfully renew the credentials when expired you must also request the `offline_access` scope when logging in in order to receive a `refresh_token` value along with the rest of the tokens. i.e. Logging in with a database connection and saving the credentials:
 
 ```java
-Credentials credentials = //login to Auth0, i.e. by using the authClient
-manager.setCredentials(credentials);
+authentication
+    .login("info@auth0.com", "a secret password", "my-database-connection")
+    .setScope("openid offline_access")
+    .start(new BaseCallback<Credentials>() {
+        @Override
+        public void onSuccess(Credentials credentials) {
+            //Save the credentials
+            manager.saveCredentials(credentials);
+        }
+
+        @Override
+        public void onFailure(AuthenticationException error) {
+            //Error!
+        }
+    });
 ```
 
 3. **Retrieve credentials**
@@ -410,18 +424,14 @@ manager.setCredentials(credentials);
 ```java
 manager.getCredentials(new BaseCallback<Credentials, CredentialsManagerException>(){
    public void onSuccess(Credentials credentials){
-      //success
+      //Use the Credentials
    }
 
     public void onFailure(CredentialsManagerException error){
-      //error
+      //Error!
    }
 });
 ```
-
-### Customize the Storage
-
-The storage implementation is up to you. We provide a `SharedPreferencesStorage` that uses `SharedPreferences` to create a file in the application directory with Context.MODE_PRIVATE mode.
 
 
 ## FAQ

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -10,6 +10,10 @@ import com.auth0.android.result.Credentials;
 
 import static android.text.TextUtils.isEmpty;
 
+/**
+ * Class that handles credentials and allows to save and retrieve them.
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
 public class CredentialsManager {
     private static final String KEY_ACCESS_TOKEN = "com.auth0.access_token";
     private static final String KEY_REFRESH_TOKEN = "com.auth0.refresh_token";
@@ -21,11 +25,22 @@ public class CredentialsManager {
     private final AuthenticationAPIClient authClient;
     private final Storage storage;
 
+    /**
+     * Creates a new instance of the manager that will store the credentials in the given Storage.
+     *
+     * @param authenticationClient the Auth0 Authentication client to refresh credentials with.
+     * @param storage              the storage to use for the credentials.
+     */
     public CredentialsManager(@NonNull AuthenticationAPIClient authenticationClient, @NonNull Storage storage) {
         this.authClient = authenticationClient;
         this.storage = storage;
     }
 
+    /**
+     * Saves the given credentials in the storage. Must have an access_token or id_token and a expires_in value.
+     *
+     * @param credentials the credentials to save in the storage.
+     */
     public void setCredentials(@NonNull Credentials credentials) {
         if ((credentials.getAccessToken() == null && credentials.getIdToken() == null) || credentials.getExpiresIn() == null) {
             throw new CredentialsManagerException("Credentials must have a valid expires_in value and a valid access_token or id_token value.");
@@ -41,6 +56,13 @@ public class CredentialsManager {
         storage.save(KEY_EXPIRATION_TIME, Long.toString(expirationTime));
     }
 
+    /**
+     * Retrieves the credentials from the storage and refresh them if they have already expired.
+     * It will fail with {@link CredentialsManagerException} if the saved access_token or id_token is null,
+     * or if the tokens have already expired and the refresh_token is null.
+     *
+     * @param callback the callback that will receive a valid {@link Credentials} or the {@link CredentialsManagerException}.
+     */
     public void getCredentials(@NonNull final BaseCallback<Credentials, CredentialsManagerException> callback) {
         String accessToken = storage.retrieve(KEY_ACCESS_TOKEN);
         String refreshToken = storage.retrieve(KEY_REFRESH_TOKEN);

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -1,0 +1,81 @@
+package com.auth0.android.authentication.storage;
+
+import android.support.annotation.NonNull;
+
+import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.authentication.AuthenticationException;
+import com.auth0.android.callback.AuthenticationCallback;
+import com.auth0.android.callback.BaseCallback;
+import com.auth0.android.result.Credentials;
+
+import static android.text.TextUtils.isEmpty;
+
+public class CredentialsManager {
+    private static final String KEY_ACCESS_TOKEN = "com.auth0.access_token";
+    private static final String KEY_REFRESH_TOKEN = "com.auth0.refresh_token";
+    private static final String KEY_ID_TOKEN = "com.auth0.id_token";
+    private static final String KEY_TOKEN_TYPE = "com.auth0.token_type";
+    private static final String KEY_EXPIRES_IN = "com.auth0.expires_in";
+    private static final String KEY_EXPIRATION_TIME = "com.auth0.expiration_time";
+
+    private final AuthenticationAPIClient authClient;
+    private final Storage storage;
+
+    public CredentialsManager(@NonNull AuthenticationAPIClient authenticationClient, @NonNull Storage storage) {
+        this.authClient = authenticationClient;
+        this.storage = storage;
+    }
+
+    public void setCredentials(@NonNull Credentials credentials) {
+        if ((credentials.getAccessToken() == null && credentials.getIdToken() == null) || credentials.getExpiresIn() == null) {
+            throw new CredentialsManagerException("Credentials must have a valid expires_in value and a valid access_token or id_token value.");
+        }
+        storage.save(KEY_ACCESS_TOKEN, credentials.getAccessToken());
+        storage.save(KEY_REFRESH_TOKEN, credentials.getRefreshToken());
+        storage.save(KEY_ID_TOKEN, credentials.getIdToken());
+        storage.save(KEY_TOKEN_TYPE, credentials.getType());
+
+        long expiresIn = credentials.getExpiresIn() == null ? 0 : credentials.getExpiresIn();
+        storage.save(KEY_EXPIRES_IN, Long.toString(expiresIn));
+        long expirationTime = System.currentTimeMillis() + (expiresIn * 1000);
+        storage.save(KEY_EXPIRATION_TIME, Long.toString(expirationTime));
+    }
+
+    public void getCredentials(@NonNull final BaseCallback<Credentials, CredentialsManagerException> callback) {
+        String accessToken = storage.retrieve(KEY_ACCESS_TOKEN);
+        String refreshToken = storage.retrieve(KEY_REFRESH_TOKEN);
+        String idToken = storage.retrieve(KEY_ID_TOKEN);
+        String tokenType = storage.retrieve(KEY_TOKEN_TYPE);
+        String expiresInValue = storage.retrieve(KEY_EXPIRES_IN);
+        String expirationTimeValue = storage.retrieve(KEY_EXPIRATION_TIME);
+        Long expiresIn = Long.parseLong(expiresInValue);
+
+        boolean invalidTokens = isEmpty(accessToken) && isEmpty(idToken);
+        if (invalidTokens) {
+            callback.onFailure(new CredentialsManagerException("No Credentials where previously set."));
+            return;
+        }
+        long expirationTime = expirationTimeValue == null ? 0 : Long.parseLong(expirationTimeValue);
+        if (expirationTime > System.currentTimeMillis()) {
+            callback.onSuccess(new Credentials(idToken, accessToken, tokenType, refreshToken, expiresIn));
+            return;
+        }
+        if (refreshToken == null) {
+            callback.onFailure(new CredentialsManagerException("No Refresh Token available."));
+            return;
+        }
+
+        authClient.renewAuth(refreshToken).start(new AuthenticationCallback<Credentials>() {
+            @Override
+            public void onSuccess(Credentials freshCredentials) {
+                callback.onSuccess(freshCredentials);
+            }
+
+            @Override
+            public void onFailure(AuthenticationException error) {
+                callback.onFailure(new CredentialsManagerException("An error occurred while trying to use the refresh_token to renew the credentials.", error));
+            }
+        });
+    }
+
+}

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -37,7 +37,7 @@ public class CredentialsManager {
     }
 
     /**
-     * Saves the given credentials in the storage. Must have an access_token or id_token and a expires_in value.
+     * Stores the given credentials in the storage. Must have an access_token or id_token and a expires_in value.
      *
      * @param credentials the credentials to save in the storage.
      */
@@ -45,15 +45,15 @@ public class CredentialsManager {
         if ((credentials.getAccessToken() == null && credentials.getIdToken() == null) || credentials.getExpiresIn() == null) {
             throw new CredentialsManagerException("Credentials must have a valid expires_in value and a valid access_token or id_token value.");
         }
-        storage.save(KEY_ACCESS_TOKEN, credentials.getAccessToken());
-        storage.save(KEY_REFRESH_TOKEN, credentials.getRefreshToken());
-        storage.save(KEY_ID_TOKEN, credentials.getIdToken());
-        storage.save(KEY_TOKEN_TYPE, credentials.getType());
+        storage.store(KEY_ACCESS_TOKEN, credentials.getAccessToken());
+        storage.store(KEY_REFRESH_TOKEN, credentials.getRefreshToken());
+        storage.store(KEY_ID_TOKEN, credentials.getIdToken());
+        storage.store(KEY_TOKEN_TYPE, credentials.getType());
 
         long expiresIn = credentials.getExpiresIn() == null ? 0 : credentials.getExpiresIn();
-        storage.save(KEY_EXPIRES_IN, Long.toString(expiresIn));
+        storage.store(KEY_EXPIRES_IN, Long.toString(expiresIn));
         long expirationTime = System.currentTimeMillis() + (expiresIn * 1000);
-        storage.save(KEY_EXPIRATION_TIME, Long.toString(expirationTime));
+        storage.store(KEY_EXPIRATION_TIME, Long.toString(expirationTime));
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -1,6 +1,7 @@
 package com.auth0.android.authentication.storage;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 
 import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.authentication.AuthenticationException;
@@ -52,7 +53,7 @@ public class CredentialsManager {
 
         long expiresIn = credentials.getExpiresIn() == null ? 0 : credentials.getExpiresIn();
         storage.store(KEY_EXPIRES_IN, Long.toString(expiresIn));
-        long expirationTime = System.currentTimeMillis() + (expiresIn * 1000);
+        long expirationTime = getCurrentTimeInMillis() + (expiresIn * 1000);
         storage.store(KEY_EXPIRATION_TIME, Long.toString(expirationTime));
     }
 
@@ -78,7 +79,7 @@ public class CredentialsManager {
             return;
         }
         long expirationTime = expirationTimeValue == null ? 0 : Long.parseLong(expirationTimeValue);
-        if (expirationTime > System.currentTimeMillis()) {
+        if (expirationTime > getCurrentTimeInMillis()) {
             callback.onSuccess(new Credentials(idToken, accessToken, tokenType, refreshToken, expiresIn));
             return;
         }
@@ -98,6 +99,11 @@ public class CredentialsManager {
                 callback.onFailure(new CredentialsManagerException("An error occurred while trying to use the refresh_token to renew the credentials.", error));
             }
         });
+    }
+
+    @VisibleForTesting
+    long getCurrentTimeInMillis() {
+        return System.currentTimeMillis();
     }
 
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -48,12 +48,12 @@ public class CredentialsManager {
         if ((isEmpty(credentials.getAccessToken()) && isEmpty(credentials.getIdToken())) || credentials.getExpiresAt() == null) {
             throw new CredentialsManagerException("Credentials must have a valid date of expiration and a valid access_token or id_token value.");
         }
-        storage.store(KEY_ACCESS_TOKEN, credentials.getAccessToken(), String.class);
-        storage.store(KEY_REFRESH_TOKEN, credentials.getRefreshToken(), String.class);
-        storage.store(KEY_ID_TOKEN, credentials.getIdToken(), String.class);
-        storage.store(KEY_TOKEN_TYPE, credentials.getType(), String.class);
-        storage.store(KEY_EXPIRES_AT, credentials.getExpiresAt().getTime(), Long.class);
-        storage.store(KEY_SCOPE, credentials.getScope(), String.class);
+        storage.store(KEY_ACCESS_TOKEN, credentials.getAccessToken());
+        storage.store(KEY_REFRESH_TOKEN, credentials.getRefreshToken());
+        storage.store(KEY_ID_TOKEN, credentials.getIdToken());
+        storage.store(KEY_TOKEN_TYPE, credentials.getType());
+        storage.store(KEY_EXPIRES_AT, credentials.getExpiresAt().getTime());
+        storage.store(KEY_SCOPE, credentials.getScope());
     }
 
     /**
@@ -64,12 +64,12 @@ public class CredentialsManager {
      * @param callback the callback that will receive a valid {@link Credentials} or the {@link CredentialsManagerException}.
      */
     public void getCredentials(@NonNull final BaseCallback<Credentials, CredentialsManagerException> callback) {
-        String accessToken = storage.retrieve(KEY_ACCESS_TOKEN, String.class);
-        String refreshToken = storage.retrieve(KEY_REFRESH_TOKEN, String.class);
-        String idToken = storage.retrieve(KEY_ID_TOKEN, String.class);
-        String tokenType = storage.retrieve(KEY_TOKEN_TYPE, String.class);
-        Long expiresAt = storage.retrieve(KEY_EXPIRES_AT, Long.class);
-        String scope = storage.retrieve(KEY_SCOPE, String.class);
+        String accessToken = storage.retrieveString(KEY_ACCESS_TOKEN);
+        String refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN);
+        String idToken = storage.retrieveString(KEY_ID_TOKEN);
+        String tokenType = storage.retrieveString(KEY_TOKEN_TYPE);
+        Long expiresAt = storage.retrieveLong(KEY_EXPIRES_AT);
+        String scope = storage.retrieveString(KEY_SCOPE);
 
         if (isEmpty(accessToken) && isEmpty(idToken) || expiresAt == null) {
             callback.onFailure(new CredentialsManagerException("No Credentials were previously set."));

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.java
@@ -1,0 +1,14 @@
+package com.auth0.android.authentication.storage;
+
+
+import com.auth0.android.Auth0Exception;
+
+public class CredentialsManagerException extends Auth0Exception {
+    public CredentialsManagerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CredentialsManagerException(String message) {
+        super(message);
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.java
@@ -3,6 +3,10 @@ package com.auth0.android.authentication.storage;
 
 import com.auth0.android.Auth0Exception;
 
+/**
+ * Represents an error raised by the {@link CredentialsManager}.
+ */
+@SuppressWarnings("WeakerAccess")
 public class CredentialsManagerException extends Auth0Exception {
     public CredentialsManagerException(String message, Throwable cause) {
         super(message, cause);

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SharedPreferencesStorage.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SharedPreferencesStorage.java
@@ -39,14 +39,66 @@ public class SharedPreferencesStorage implements Storage {
         sp = context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE);
     }
 
+    /**
+     * Store a given value in the Storage.
+     * Supported value types are: {@link String}, {@link Boolean}, {@link Long}, {@link Float} and {@link Integer}.
+     *
+     * @param name   the name of the value to store.
+     * @param value  the value to store. Can be null.
+     * @param tClazz the class of the value to store.
+     * @param <T>    the type of the value to store.
+     * @throws IllegalArgumentException if the given class type is not supported
+     */
+    @SuppressWarnings("unchecked")
     @Override
-    public void store(@NonNull String name, @Nullable String value) {
-        sp.edit().putString(name, value).apply();
+    public <T> void store(@NonNull String name, @Nullable T value, @NonNull Class<T> tClazz) throws IllegalArgumentException {
+        if (value == null) {
+            sp.edit().remove(name).apply();
+        } else if (tClazz.isAssignableFrom(String.class)) {
+            sp.edit().putString(name, (String) value).apply();
+        } else if (tClazz.isAssignableFrom(Boolean.class)) {
+            sp.edit().putBoolean(name, (Boolean) value).apply();
+        } else if (tClazz.isAssignableFrom(Long.class)) {
+            sp.edit().putLong(name, (Long) value).apply();
+        } else if (tClazz.isAssignableFrom(Float.class)) {
+            sp.edit().putFloat(name, (Float) value).apply();
+        } else if (tClazz.isAssignableFrom(Integer.class)) {
+            sp.edit().putInt(name, (Integer) value).apply();
+        } else {
+            throw new IllegalArgumentException("The class type is not supported. Supported types are: String, Boolean, Long, Float and Integer.");
+        }
     }
 
+    /**
+     * Retrieve a value from the Storage.
+     * Supported value types are: {@link String}, {@link Boolean}, {@link Long}, {@link Float} and {@link Integer}.
+     *
+     * @param name   the name of the value to retrieve.
+     * @param tClazz the class of the value to retrieve.
+     * @param <T>    the type of the value to retrieve.
+     * @return the value that was previously saved. Can be null.
+     * @throws IllegalArgumentException if the given class type is not supported
+     */
     @Nullable
     @Override
-    public String retrieve(@NonNull String name) {
-        return sp.getString(name, null);
+    public <T> T retrieve(@NonNull String name, @NonNull Class<T> tClazz) throws IllegalArgumentException {
+        if (!sp.contains(name)) {
+            return null;
+        }
+        Object value;
+        if (tClazz.isAssignableFrom(String.class)) {
+            value = sp.getString(name, null);
+        } else if (tClazz.isAssignableFrom(Boolean.class)) {
+            value = sp.getBoolean(name, false);
+        } else if (tClazz.isAssignableFrom(Long.class)) {
+            value = sp.getLong(name, 0);
+        } else if (tClazz.isAssignableFrom(Float.class)) {
+            value = sp.getFloat(name, 0);
+        } else if (tClazz.isAssignableFrom(Integer.class)) {
+            value = sp.getInt(name, 0);
+        } else {
+            throw new IllegalArgumentException("The class type is not supported. Supported types are: String, Boolean, Long, Float and Integer.");
+        }
+        return tClazz.cast(value);
     }
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SharedPreferencesStorage.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SharedPreferencesStorage.java
@@ -39,66 +39,57 @@ public class SharedPreferencesStorage implements Storage {
         sp = context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE);
     }
 
-    /**
-     * Store a given value in the Storage.
-     * Supported value types are: {@link String}, {@link Boolean}, {@link Long}, {@link Float} and {@link Integer}.
-     *
-     * @param name   the name of the value to store.
-     * @param value  the value to store. Can be null.
-     * @param tClazz the class of the value to store.
-     * @param <T>    the type of the value to store.
-     * @throws IllegalArgumentException if the given class type is not supported
-     */
-    @SuppressWarnings("unchecked")
     @Override
-    public <T> void store(@NonNull String name, @Nullable T value, @NonNull Class<T> tClazz) throws IllegalArgumentException {
+    public void store(@NonNull String name, @Nullable Long value) {
         if (value == null) {
             sp.edit().remove(name).apply();
-        } else if (tClazz.isAssignableFrom(String.class)) {
-            sp.edit().putString(name, (String) value).apply();
-        } else if (tClazz.isAssignableFrom(Boolean.class)) {
-            sp.edit().putBoolean(name, (Boolean) value).apply();
-        } else if (tClazz.isAssignableFrom(Long.class)) {
-            sp.edit().putLong(name, (Long) value).apply();
-        } else if (tClazz.isAssignableFrom(Float.class)) {
-            sp.edit().putFloat(name, (Float) value).apply();
-        } else if (tClazz.isAssignableFrom(Integer.class)) {
-            sp.edit().putInt(name, (Integer) value).apply();
         } else {
-            throw new IllegalArgumentException("The class type is not supported. Supported types are: String, Boolean, Long, Float and Integer.");
+            sp.edit().putLong(name, value).apply();
         }
     }
 
-    /**
-     * Retrieve a value from the Storage.
-     * Supported value types are: {@link String}, {@link Boolean}, {@link Long}, {@link Float} and {@link Integer}.
-     *
-     * @param name   the name of the value to retrieve.
-     * @param tClazz the class of the value to retrieve.
-     * @param <T>    the type of the value to retrieve.
-     * @return the value that was previously saved. Can be null.
-     * @throws IllegalArgumentException if the given class type is not supported
-     */
+    @Override
+    public void store(@NonNull String name, @Nullable Integer value) {
+        if (value == null) {
+            sp.edit().remove(name).apply();
+        } else {
+            sp.edit().putInt(name, value).apply();
+        }
+    }
+
+    @Override
+    public void store(@NonNull String name, @Nullable String value) {
+        if (value == null) {
+            sp.edit().remove(name).apply();
+        } else {
+            sp.edit().putString(name, value).apply();
+        }
+    }
+
     @Nullable
     @Override
-    public <T> T retrieve(@NonNull String name, @NonNull Class<T> tClazz) throws IllegalArgumentException {
+    public Long retrieveLong(@NonNull String name) {
         if (!sp.contains(name)) {
             return null;
         }
-        Object value;
-        if (tClazz.isAssignableFrom(String.class)) {
-            value = sp.getString(name, null);
-        } else if (tClazz.isAssignableFrom(Boolean.class)) {
-            value = sp.getBoolean(name, false);
-        } else if (tClazz.isAssignableFrom(Long.class)) {
-            value = sp.getLong(name, 0);
-        } else if (tClazz.isAssignableFrom(Float.class)) {
-            value = sp.getFloat(name, 0);
-        } else if (tClazz.isAssignableFrom(Integer.class)) {
-            value = sp.getInt(name, 0);
-        } else {
-            throw new IllegalArgumentException("The class type is not supported. Supported types are: String, Boolean, Long, Float and Integer.");
+        return sp.getLong(name, 0);
+    }
+
+    @Nullable
+    @Override
+    public String retrieveString(@NonNull String name) {
+        if (!sp.contains(name)) {
+            return null;
         }
-        return tClazz.cast(value);
+        return sp.getString(name, null);
+    }
+
+    @Nullable
+    @Override
+    public Integer retrieveInteger(@NonNull String name) {
+        if (!sp.contains(name)) {
+            return null;
+        }
+        return sp.getInt(name, 0);
     }
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SharedPreferencesStorage.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SharedPreferencesStorage.java
@@ -1,0 +1,52 @@
+package com.auth0.android.authentication.storage;
+
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+/**
+ * An implementation of {@link Storage} that uses {@link android.content.SharedPreferences} in Context.MODE_PRIVATE to store the values.
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class SharedPreferencesStorage implements Storage {
+
+    private static final String SHARED_PREFERENCES_NAME = "com.auth0.authentication.storage";
+
+    private final SharedPreferences sp;
+
+    /**
+     * Creates a new {@link Storage} that uses {@link SharedPreferences} in Context.MODE_PRIVATE to store values.
+     *
+     * @param context a valid context
+     */
+    public SharedPreferencesStorage(@NonNull Context context) {
+        this(context, SHARED_PREFERENCES_NAME);
+    }
+
+    /**
+     * Creates a new {@link Storage} that uses {@link SharedPreferences} in Context.MODE_PRIVATE to store values.
+     *
+     * @param context               a valid context
+     * @param sharedPreferencesName the preferences file name
+     */
+    public SharedPreferencesStorage(@NonNull Context context, @NonNull String sharedPreferencesName) {
+        if (TextUtils.isEmpty(sharedPreferencesName)) {
+            throw new IllegalArgumentException("The SharedPreferences name is invalid.");
+        }
+        sp = context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE);
+    }
+
+    @Override
+    public void store(@NonNull String name, @Nullable String value) {
+        sp.edit().putString(name, value).apply();
+    }
+
+    @Nullable
+    @Override
+    public String retrieve(@NonNull String name) {
+        return sp.getString(name, null);
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
@@ -1,0 +1,12 @@
+package com.auth0.android.authentication.storage;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+public abstract class Storage {
+
+    public abstract void save(@NonNull String name, @Nullable String value);
+
+    @Nullable
+    public abstract String retrieve(@NonNull String name);
+}

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
@@ -12,21 +12,51 @@ public interface Storage {
     /**
      * Store a given value in the Storage.
      *
-     * @param name   the name of the value to store.
-     * @param value  the value to store. Can be null.
-     * @param tClazz the class of the value to store.
-     * @param <T>    the type of the value to store.
+     * @param name  the name of the value to store.
+     * @param value the value to store. Can be null.
      */
-    <T> void store(@NonNull String name, @Nullable T value, @NonNull Class<T> tClazz);
+    void store(@NonNull String name, @Nullable Long value);
+
+    /**
+     * Store a given value in the Storage.
+     *
+     * @param name  the name of the value to store.
+     * @param value the value to store. Can be null.
+     */
+    void store(@NonNull String name, @Nullable Integer value);
+
+    /**
+     * Store a given value in the Storage.
+     *
+     * @param name  the name of the value to store.
+     * @param value the value to store. Can be null.
+     */
+    void store(@NonNull String name, @Nullable String value);
 
     /**
      * Retrieve a value from the Storage.
      *
-     * @param name   the name of the value to retrieve.
-     * @param tClazz the class of the value to retrieve.
-     * @param <T>    the type of the value to retrieve.
+     * @param name the name of the value to retrieve.
      * @return the value that was previously saved. Can be null.
      */
     @Nullable
-    <T> T retrieve(@NonNull String name, @NonNull Class<T> tClazz);
+    Long retrieveLong(@NonNull String name);
+
+    /**
+     * Retrieve a value from the Storage.
+     *
+     * @param name the name of the value to retrieve.
+     * @return the value that was previously saved. Can be null.
+     */
+    @Nullable
+    String retrieveString(@NonNull String name);
+
+    /**
+     * Retrieve a value from the Storage.
+     *
+     * @param name the name of the value to retrieve.
+     * @return the value that was previously saved. Can be null.
+     */
+    @Nullable
+    Integer retrieveInteger(@NonNull String name);
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
@@ -4,18 +4,18 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 /**
- * Abstract class that represents a Storage of key-value data.
+ * Represents a Storage of key-value data.
  */
 @SuppressWarnings("WeakerAccess")
-public abstract class Storage {
+public interface Storage {
 
     /**
-     * Save a given value in the Storage.
+     * Store a given value in the Storage.
      *
      * @param name  the name of the value to save.
      * @param value the value to save. Can be null.
      */
-    public abstract void save(@NonNull String name, @Nullable String value);
+    void store(@NonNull String name, @Nullable String value);
 
     /**
      * Retrieve a value from the Storage.
@@ -24,5 +24,5 @@ public abstract class Storage {
      * @return the value that was previously saved. Can be null.
      */
     @Nullable
-    public abstract String retrieve(@NonNull String name);
+    String retrieve(@NonNull String name);
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
@@ -4,7 +4,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 /**
- * Represents a Storage of generic key-value data.
+ * Represents a Storage of key-value data.
+ * Supported classes are String, Long and Integer.
  */
 @SuppressWarnings("WeakerAccess")
 public interface Storage {

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
@@ -3,10 +3,26 @@ package com.auth0.android.authentication.storage;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+/**
+ * Abstract class that represents a Storage of key-value data.
+ */
+@SuppressWarnings("WeakerAccess")
 public abstract class Storage {
 
+    /**
+     * Save a given value in the Storage.
+     *
+     * @param name  the name of the value to save.
+     * @param value the value to save. Can be null.
+     */
     public abstract void save(@NonNull String name, @Nullable String value);
 
+    /**
+     * Retrieve a value from the Storage.
+     *
+     * @param name the name of the value to retrieve.
+     * @return the value that was previously saved. Can be null.
+     */
     @Nullable
     public abstract String retrieve(@NonNull String name);
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/Storage.java
@@ -4,7 +4,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 /**
- * Represents a Storage of key-value data.
+ * Represents a Storage of generic key-value data.
  */
 @SuppressWarnings("WeakerAccess")
 public interface Storage {
@@ -12,17 +12,21 @@ public interface Storage {
     /**
      * Store a given value in the Storage.
      *
-     * @param name  the name of the value to save.
-     * @param value the value to save. Can be null.
+     * @param name   the name of the value to store.
+     * @param value  the value to store. Can be null.
+     * @param tClazz the class of the value to store.
+     * @param <T>    the type of the value to store.
      */
-    void store(@NonNull String name, @Nullable String value);
+    <T> void store(@NonNull String name, @Nullable T value, @NonNull Class<T> tClazz);
 
     /**
      * Retrieve a value from the Storage.
      *
-     * @param name the name of the value to retrieve.
+     * @param name   the name of the value to retrieve.
+     * @param tClazz the class of the value to retrieve.
+     * @param <T>    the type of the value to retrieve.
      * @return the value that was previously saved. Can be null.
      */
     @Nullable
-    String retrieve(@NonNull String name);
+    <T> T retrieve(@NonNull String name, @NonNull Class<T> tClazz);
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/CredentialsDeserializer.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/CredentialsDeserializer.java
@@ -1,0 +1,38 @@
+package com.auth0.android.request.internal;
+
+import android.support.annotation.VisibleForTesting;
+
+import com.auth0.android.result.Credentials;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.util.Date;
+
+class CredentialsDeserializer implements JsonDeserializer<Credentials> {
+
+    @Override
+    public Credentials deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        if (!json.isJsonObject() || json.isJsonNull() || json.getAsJsonObject().entrySet().isEmpty()) {
+            throw new JsonParseException("credentials json is not a valid json object");
+        }
+
+        JsonObject object = json.getAsJsonObject();
+        final String idToken = context.deserialize(object.remove("id_token"), String.class);
+        final String accessToken = context.deserialize(object.remove("access_token"), String.class);
+        final String type = context.deserialize(object.remove("token_type"), String.class);
+        final String refreshToken = context.deserialize(object.remove("refresh_token"), String.class);
+        final Long expiresIn = context.deserialize(object.remove("expires_in"), Long.class);
+        final String scope = context.deserialize(object.remove("scope"), String.class);
+        final Date expiresAt = expiresIn == null ? null : new Date(getCurrentTimeInMillis() + expiresIn * 1000);
+        return new Credentials(idToken, accessToken, type, refreshToken, expiresAt, scope);
+    }
+
+    @VisibleForTesting
+    long getCurrentTimeInMillis() {
+        return System.currentTimeMillis();
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/request/internal/GsonProvider.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/GsonProvider.java
@@ -1,5 +1,6 @@
 package com.auth0.android.request.internal;
 
+import com.auth0.android.result.Credentials;
 import com.auth0.android.result.UserProfile;
 import com.auth0.android.util.JsonRequiredTypeAdapterFactory;
 import com.google.gson.Gson;
@@ -11,6 +12,7 @@ public abstract class GsonProvider {
         return new GsonBuilder()
                 .registerTypeAdapterFactory(new JsonRequiredTypeAdapterFactory())
                 .registerTypeAdapter(UserProfile.class, new UserProfileDeserializer())
+                .registerTypeAdapter(Credentials.class, new CredentialsDeserializer())
                 .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
                 .create();
     }

--- a/auth0/src/main/java/com/auth0/android/result/Credentials.java
+++ b/auth0/src/main/java/com/auth0/android/result/Credentials.java
@@ -60,7 +60,7 @@ public class Credentials {
     @SerializedName("scope")
     private String scope;
 
-    public Credentials(String idToken, String accessToken, String type, String refreshToken, Long expiresIn, String scope) {
+    public Credentials(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Long expiresIn, @Nullable String scope) {
         this.idToken = idToken;
         this.accessToken = accessToken;
         this.type = type;
@@ -70,7 +70,7 @@ public class Credentials {
     }
 
     //TODO: Deprecate this constructor
-    public Credentials(String idToken, String accessToken, String type, String refreshToken, Long expiresIn) {
+    public Credentials(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Long expiresIn) {
         this(idToken, accessToken, type, refreshToken, expiresIn, null);
     }
 
@@ -114,6 +114,13 @@ public class Credentials {
         return refreshToken;
     }
 
+    /**
+     * Getter for the amount of seconds since the tokens were issued in which they will be deemed invalid.
+     * To know precisely when this is going to happen you need to save the time every time you request a new pair of tokens.
+     *
+     * @return the seconds since the tokens where issued in which they will be deemed invalid.
+     */
+    @Nullable
     public Long getExpiresIn() {
         return expiresIn;
     }

--- a/auth0/src/main/java/com/auth0/android/result/Credentials.java
+++ b/auth0/src/main/java/com/auth0/android/result/Credentials.java
@@ -115,10 +115,10 @@ public class Credentials {
     }
 
     /**
-     * Getter for the amount of seconds since the tokens were issued in which they will be deemed invalid.
-     * To know precisely when this is going to happen you need to save the time every time you request a new pair of tokens.
+     * Getter for the token lifetime in seconds.
+     * Once expired, the token can no longer be used to access an API and a new token needs to be obtained.
      *
-     * @return the seconds since the tokens where issued in which they will be deemed invalid.
+     * @return the token lifetime in seconds.
      */
     @Nullable
     public Long getExpiresIn() {

--- a/auth0/src/main/java/com/auth0/android/result/Credentials.java
+++ b/auth0/src/main/java/com/auth0/android/result/Credentials.java
@@ -26,8 +26,11 @@ package com.auth0.android.result;
 
 
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import com.google.gson.annotations.SerializedName;
+
+import java.util.Date;
 
 /**
  * Holds the user's credentials returned by Auth0.
@@ -37,6 +40,7 @@ import com.google.gson.annotations.SerializedName;
  * <li><i>refreshToken</i>: Refresh Token that can be used to request new tokens without signing in again</li>
  * <li><i>type</i>: The type of the received Token.</li>
  * <li><i>expiresIn</i>: The token lifetime in seconds.</li>
+ * <li><i>expiresAt</i>: The token expiration date.</li>
  * <li><i>scope</i>: The token's granted scope.</li>
  * </ul>
  */
@@ -60,18 +64,36 @@ public class Credentials {
     @SerializedName("scope")
     private String scope;
 
-    public Credentials(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Long expiresIn, @Nullable String scope) {
+    private Date expiresAt;
+
+    //TODO: Deprecate this constructor
+    public Credentials(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Long expiresIn) {
+        this(idToken, accessToken, type, refreshToken, expiresIn, null, null);
+    }
+
+    public Credentials(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Date expiresAt, @Nullable String scope) {
+        this(idToken, accessToken, type, refreshToken, null, expiresAt, scope);
+    }
+
+    private Credentials(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Long expiresIn, @Nullable Date expiresAt, @Nullable String scope) {
         this.idToken = idToken;
         this.accessToken = accessToken;
         this.type = type;
         this.refreshToken = refreshToken;
         this.expiresIn = expiresIn;
         this.scope = scope;
+        this.expiresAt = expiresAt;
+        if (expiresAt == null && expiresIn != null) {
+            this.expiresAt = new Date(getCurrentTimeInMillis() + expiresIn * 1000);
+        }
+        if (expiresIn == null && expiresAt != null) {
+            this.expiresIn = (expiresAt.getTime() - getCurrentTimeInMillis()) / 1000;
+        }
     }
 
-    //TODO: Deprecate this constructor
-    public Credentials(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Long expiresIn) {
-        this(idToken, accessToken, type, refreshToken, expiresIn, null);
+    @VisibleForTesting
+    long getCurrentTimeInMillis() {
+        return System.currentTimeMillis();
     }
 
     /**
@@ -133,5 +155,16 @@ public class Credentials {
     @Nullable
     public String getScope() {
         return scope;
+    }
+
+    /**
+     * Getter for the expiration date of this token.
+     * Once expired, the token can no longer be used to access an API and a new token needs to be obtained.
+     *
+     * @return the expiration date of this token
+     */
+    @Nullable
+    public Date getExpiresAt() {
+        return expiresAt;
     }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
@@ -1,0 +1,220 @@
+package com.auth0.android.authentication.storage;
+
+import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.authentication.AuthenticationException;
+import com.auth0.android.callback.BaseCallback;
+import com.auth0.android.request.ParameterizableRequest;
+import com.auth0.android.result.Credentials;
+
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = com.auth0.android.auth0.BuildConfig.class, sdk = 21, manifest = Config.NONE)
+public class CredentialsManagerTest {
+
+    @Mock
+    private AuthenticationAPIClient client;
+    @Mock
+    private Storage storage;
+    @Mock
+    private BaseCallback<Credentials, CredentialsManagerException> callback;
+    @Mock
+    private ParameterizableRequest<Credentials, AuthenticationException> request;
+    @Captor
+    private ArgumentCaptor<Credentials> credentialsCaptor;
+    @Captor
+    private ArgumentCaptor<CredentialsManagerException> exceptionCaptor;
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private static final long CURRENT_TIME_MS = 999000000L;
+    private CredentialsManager manager;
+    @Captor
+    private ArgumentCaptor<BaseCallback<Credentials, AuthenticationException>> requestCallbackCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        CredentialsManager credentialsManager = new CredentialsManager(client, storage);
+        manager = spy(credentialsManager);
+        doReturn(CURRENT_TIME_MS).when(manager).getCurrentTimeInMillis();
+    }
+
+    @Test
+    public void shouldSaveCredentialsInStorage() throws Exception {
+        Credentials credentials = new Credentials("idToken", "accessToken", "type", "refreshToken", 123456L);
+        manager.setCredentials(credentials);
+
+        verify(storage).store("com.auth0.id_token", "idToken");
+        verify(storage).store("com.auth0.access_token", "accessToken");
+        verify(storage).store("com.auth0.refresh_token", "refreshToken");
+        verify(storage).store("com.auth0.token_type", "type");
+        verify(storage).store("com.auth0.expires_in", "123456");
+        long expirationTime = CURRENT_TIME_MS + (123456 * 1000);
+        verify(storage).store("com.auth0.expiration_time", Long.toString(expirationTime));
+    }
+
+    @Test
+    public void shouldThrowOnSetIfCredentialsDoesNotHaveIdTokenOrAccessToken() throws Exception {
+        exception.expect(CredentialsManagerException.class);
+        exception.expectMessage("Credentials must have a valid expires_in value and a valid access_token or id_token value.");
+
+        Credentials credentials = new Credentials(null, null, "type", "refreshToken", 123456L);
+        manager.setCredentials(credentials);
+    }
+
+    @Test
+    public void shouldThrowOnSetIfCredentialsDoesNotHaveExpiresIn() throws Exception {
+        exception.expect(CredentialsManagerException.class);
+        exception.expectMessage("Credentials must have a valid expires_in value and a valid access_token or id_token value.");
+
+        Credentials credentials = new Credentials("idToken", "accessToken", "type", "refreshToken", null);
+        manager.setCredentials(credentials);
+    }
+
+    @Test
+    public void shouldNotThrowOnSetIfCredentialsHaveAccessTokenAndExpiresIn() throws Exception {
+        Credentials credentials = new Credentials(null, "accessToken", "type", "refreshToken", 123456L);
+        manager.setCredentials(credentials);
+    }
+
+    @Test
+    public void shouldNotThrowOnSetIfCredentialsHaveIdTokenAndExpiresIn() throws Exception {
+        Credentials credentials = new Credentials("idToken", null, "type", "refreshToken", 123456L);
+        manager.setCredentials(credentials);
+    }
+
+    @Test
+    public void shouldThrowOnGetCredentialsWhenNoAccessTokenOrIdTokenWasSaved() throws Exception {
+        verifyNoMoreInteractions(client);
+
+        when(storage.retrieve("com.auth0.id_token")).thenReturn(null);
+        when(storage.retrieve("com.auth0.access_token")).thenReturn(null);
+        when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
+        when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
+        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
+        String expirationTime = Long.toString(CURRENT_TIME_MS + (123456L * 1000));
+        when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
+
+        manager.getCredentials(callback);
+
+        verify(callback).onFailure(exceptionCaptor.capture());
+        CredentialsManagerException exception = exceptionCaptor.getValue();
+        assertThat(exception, is(notNullValue()));
+        assertThat(exception.getMessage(), is("No Credentials where previously set."));
+    }
+
+    @Test
+    public void shouldThrowOnGetCredentialsWhenExpiredAndNoRefreshTokenWasSaved() throws Exception {
+        verifyNoMoreInteractions(client);
+
+        when(storage.retrieve("com.auth0.id_token")).thenReturn("idToken");
+        when(storage.retrieve("com.auth0.access_token")).thenReturn("accessToken");
+        when(storage.retrieve("com.auth0.refresh_token")).thenReturn(null);
+        when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
+        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
+        String expirationTime = Long.toString(CURRENT_TIME_MS); //Same as current time --> expired
+        when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
+
+        manager.getCredentials(callback);
+
+        verify(callback).onFailure(exceptionCaptor.capture());
+        CredentialsManagerException exception = exceptionCaptor.getValue();
+        assertThat(exception, is(notNullValue()));
+        assertThat(exception.getMessage(), is("No Refresh Token available."));
+    }
+
+    @Test
+    public void shouldGetNonExpiredCredentialsFromStorage() throws Exception {
+        verifyNoMoreInteractions(client);
+
+        when(storage.retrieve("com.auth0.id_token")).thenReturn("idToken");
+        when(storage.retrieve("com.auth0.access_token")).thenReturn("accessToken");
+        when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
+        when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
+        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
+        String expirationTime = Long.toString(CURRENT_TIME_MS + (123456L * 1000));
+        when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
+
+        manager.getCredentials(callback);
+        verify(callback).onSuccess(credentialsCaptor.capture());
+        Credentials retrievedCredentials = credentialsCaptor.getValue();
+
+        assertThat(retrievedCredentials, is(notNullValue()));
+        assertThat(retrievedCredentials.getAccessToken(), is("accessToken"));
+        assertThat(retrievedCredentials.getIdToken(), is("idToken"));
+        assertThat(retrievedCredentials.getRefreshToken(), is("refreshToken"));
+        assertThat(retrievedCredentials.getType(), is("type"));
+        assertThat(retrievedCredentials.getExpiresIn(), is(123456L));
+    }
+
+    @Test
+    public void shouldGetAndSuccessfullyRenewExpiredCredentials() throws Exception {
+        when(storage.retrieve("com.auth0.id_token")).thenReturn("idToken");
+        when(storage.retrieve("com.auth0.access_token")).thenReturn("accessToken");
+        when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
+        when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
+        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
+        String expirationTime = Long.toString(CURRENT_TIME_MS); //Same as current time --> expired
+        when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
+        when(client.renewAuth("refreshToken")).thenReturn(request);
+
+        manager.getCredentials(callback);
+        verify(request).start(requestCallbackCaptor.capture());
+
+        //Trigger success
+        Credentials renewedCredentials = mock(Credentials.class);
+        requestCallbackCaptor.getValue().onSuccess(renewedCredentials);
+        verify(callback).onSuccess(credentialsCaptor.capture());
+
+        Credentials retrievedCredentials = credentialsCaptor.getValue();
+        assertThat(retrievedCredentials, is(notNullValue()));
+        assertThat(retrievedCredentials, is(renewedCredentials));
+    }
+
+    @Test
+    public void shouldGetAndFailToRenewExpiredCredentials() throws Exception {
+        when(storage.retrieve("com.auth0.id_token")).thenReturn("idToken");
+        when(storage.retrieve("com.auth0.access_token")).thenReturn("accessToken");
+        when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
+        when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
+        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
+        String expirationTime = Long.toString(CURRENT_TIME_MS); //Same as current time --> expired
+        when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
+        when(client.renewAuth("refreshToken")).thenReturn(request);
+
+        manager.getCredentials(callback);
+        verify(request).start(requestCallbackCaptor.capture());
+
+        //Trigger failure
+        AuthenticationException authenticationException = mock(AuthenticationException.class);
+        requestCallbackCaptor.getValue().onFailure(authenticationException);
+        verify(callback).onFailure(exceptionCaptor.capture());
+
+        CredentialsManagerException exception = exceptionCaptor.getValue();
+        assertThat(exception, is(notNullValue()));
+        assertThat(exception.getCause(), Is.<Throwable>is(authenticationException));
+        assertThat(exception.getMessage(), is("An error occurred while trying to use the refresh_token to renew the credentials."));
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
@@ -71,7 +71,6 @@ public class CredentialsManagerTest {
         verify(storage).store("com.auth0.access_token", "accessToken");
         verify(storage).store("com.auth0.refresh_token", "refreshToken");
         verify(storage).store("com.auth0.token_type", "type");
-        verify(storage).store("com.auth0.expires_in", "123456");
         long expirationTime = CURRENT_TIME_MS + (123456 * 1000);
         verify(storage).store("com.auth0.expiration_time", Long.toString(expirationTime));
     }
@@ -114,27 +113,6 @@ public class CredentialsManagerTest {
         when(storage.retrieve("com.auth0.access_token")).thenReturn(null);
         when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
         when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
-        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
-        String expirationTime = Long.toString(CURRENT_TIME_MS + (123456L * 1000));
-        when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
-
-        manager.getCredentials(callback);
-
-        verify(callback).onFailure(exceptionCaptor.capture());
-        CredentialsManagerException exception = exceptionCaptor.getValue();
-        assertThat(exception, is(notNullValue()));
-        assertThat(exception.getMessage(), is("No Credentials were previously set."));
-    }
-
-    @Test
-    public void shouldFailOnGetCredentialsWhenNoExpiresInWasSaved() throws Exception {
-        verifyNoMoreInteractions(client);
-
-        when(storage.retrieve("com.auth0.id_token")).thenReturn("idToken");
-        when(storage.retrieve("com.auth0.access_token")).thenReturn("accessToken");
-        when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
-        when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
-        when(storage.retrieve("com.auth0.expires_in")).thenReturn(null);
         String expirationTime = Long.toString(CURRENT_TIME_MS + (123456L * 1000));
         when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
 
@@ -154,7 +132,6 @@ public class CredentialsManagerTest {
         when(storage.retrieve("com.auth0.access_token")).thenReturn("accessToken");
         when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
         when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
-        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
         when(storage.retrieve("com.auth0.expiration_time")).thenReturn(null);
 
         manager.getCredentials(callback);
@@ -173,7 +150,6 @@ public class CredentialsManagerTest {
         when(storage.retrieve("com.auth0.access_token")).thenReturn("accessToken");
         when(storage.retrieve("com.auth0.refresh_token")).thenReturn(null);
         when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
-        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
         String expirationTime = Long.toString(CURRENT_TIME_MS); //Same as current time --> expired
         when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
 
@@ -182,7 +158,7 @@ public class CredentialsManagerTest {
         verify(callback).onFailure(exceptionCaptor.capture());
         CredentialsManagerException exception = exceptionCaptor.getValue();
         assertThat(exception, is(notNullValue()));
-        assertThat(exception.getMessage(), is("No Refresh Token available."));
+        assertThat(exception.getMessage(), is("Credentials have expired and no Refresh Token was available to renew them."));
     }
 
     @Test
@@ -193,7 +169,6 @@ public class CredentialsManagerTest {
         when(storage.retrieve("com.auth0.access_token")).thenReturn("accessToken");
         when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
         when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
-        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
         String expirationTime = Long.toString(CURRENT_TIME_MS + (123456L * 1000));
         when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
 
@@ -217,7 +192,6 @@ public class CredentialsManagerTest {
         when(storage.retrieve("com.auth0.access_token")).thenReturn(null);
         when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
         when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
-        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
         String expirationTime = Long.toString(CURRENT_TIME_MS + (123456L * 1000));
         when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
 
@@ -241,7 +215,6 @@ public class CredentialsManagerTest {
         when(storage.retrieve("com.auth0.access_token")).thenReturn("accessToken");
         when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
         when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
-        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
         String expirationTime = Long.toString(CURRENT_TIME_MS + (123456L * 1000));
         when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
 
@@ -263,7 +236,6 @@ public class CredentialsManagerTest {
         when(storage.retrieve("com.auth0.access_token")).thenReturn("accessToken");
         when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
         when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
-        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
         String expirationTime = Long.toString(CURRENT_TIME_MS); //Same as current time --> expired
         when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
         when(client.renewAuth("refreshToken")).thenReturn(request);
@@ -287,7 +259,6 @@ public class CredentialsManagerTest {
         when(storage.retrieve("com.auth0.access_token")).thenReturn("accessToken");
         when(storage.retrieve("com.auth0.refresh_token")).thenReturn("refreshToken");
         when(storage.retrieve("com.auth0.token_type")).thenReturn("type");
-        when(storage.retrieve("com.auth0.expires_in")).thenReturn("123456");
         String expirationTime = Long.toString(CURRENT_TIME_MS); //Same as current time --> expired
         when(storage.retrieve("com.auth0.expiration_time")).thenReturn(expirationTime);
         when(client.renewAuth("refreshToken")).thenReturn(request);
@@ -303,6 +274,6 @@ public class CredentialsManagerTest {
         CredentialsManagerException exception = exceptionCaptor.getValue();
         assertThat(exception, is(notNullValue()));
         assertThat(exception.getCause(), Is.<Throwable>is(authenticationException));
-        assertThat(exception.getMessage(), is("An error occurred while trying to use the refresh_token to renew the credentials."));
+        assertThat(exception.getMessage(), is("An error occurred while trying to use the Refresh Token to renew the Credentials."));
     }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
@@ -88,12 +88,12 @@ public class CredentialsManagerTest {
         Credentials credentials = new CredentialsMock("idToken", "accessToken", "type", "refreshToken", new Date(expirationTime), "scope");
         manager.saveCredentials(credentials);
 
-        verify(storage).store("com.auth0.id_token", "idToken", String.class);
-        verify(storage).store("com.auth0.access_token", "accessToken", String.class);
-        verify(storage).store("com.auth0.refresh_token", "refreshToken", String.class);
-        verify(storage).store("com.auth0.token_type", "type", String.class);
-        verify(storage).store("com.auth0.expires_at", expirationTime, Long.class);
-        verify(storage).store("com.auth0.scope", "scope", String.class);
+        verify(storage).store("com.auth0.id_token", "idToken");
+        verify(storage).store("com.auth0.access_token", "accessToken");
+        verify(storage).store("com.auth0.refresh_token", "refreshToken");
+        verify(storage).store("com.auth0.token_type", "type");
+        verify(storage).store("com.auth0.expires_at", expirationTime);
+        verify(storage).store("com.auth0.scope", "scope");
     }
 
     @Test
@@ -132,13 +132,13 @@ public class CredentialsManagerTest {
     public void shouldFailOnGetCredentialsWhenNoAccessTokenOrIdTokenWasSaved() throws Exception {
         verifyNoMoreInteractions(client);
 
-        when(storage.retrieve("com.auth0.id_token", String.class)).thenReturn(null);
-        when(storage.retrieve("com.auth0.access_token", String.class)).thenReturn(null);
-        when(storage.retrieve("com.auth0.refresh_token", String.class)).thenReturn("refreshToken");
-        when(storage.retrieve("com.auth0.token_type", String.class)).thenReturn("type");
+        when(storage.retrieveString("com.auth0.id_token")).thenReturn(null);
+        when(storage.retrieveString("com.auth0.access_token")).thenReturn(null);
+        when(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken");
+        when(storage.retrieveString("com.auth0.token_type")).thenReturn("type");
         long expirationTime = CredentialsMock.CURRENT_TIME_MS + 123456L * 1000;
-        when(storage.retrieve("com.auth0.expires_at", Long.class)).thenReturn(expirationTime);
-        when(storage.retrieve("com.auth0.scope", String.class)).thenReturn("scope");
+        when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime);
+        when(storage.retrieveString("com.auth0.scope")).thenReturn("scope");
 
         manager.getCredentials(callback);
 
@@ -152,12 +152,12 @@ public class CredentialsManagerTest {
     public void shouldFailOnGetCredentialsWhenNoExpirationTimeWasSaved() throws Exception {
         verifyNoMoreInteractions(client);
 
-        when(storage.retrieve("com.auth0.id_token", String.class)).thenReturn("idToken");
-        when(storage.retrieve("com.auth0.access_token", String.class)).thenReturn("accessToken");
-        when(storage.retrieve("com.auth0.refresh_token", String.class)).thenReturn("refreshToken");
-        when(storage.retrieve("com.auth0.token_type", String.class)).thenReturn("type");
-        when(storage.retrieve("com.auth0.expires_at", Long.class)).thenReturn(null);
-        when(storage.retrieve("com.auth0.scope", String.class)).thenReturn("scope");
+        when(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken");
+        when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
+        when(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken");
+        when(storage.retrieveString("com.auth0.token_type")).thenReturn("type");
+        when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(null);
+        when(storage.retrieveString("com.auth0.scope")).thenReturn("scope");
 
         manager.getCredentials(callback);
 
@@ -172,13 +172,13 @@ public class CredentialsManagerTest {
     public void shouldFailOnGetCredentialsWhenExpiredAndNoRefreshTokenWasSaved() throws Exception {
         verifyNoMoreInteractions(client);
 
-        when(storage.retrieve("com.auth0.id_token", String.class)).thenReturn("idToken");
-        when(storage.retrieve("com.auth0.access_token", String.class)).thenReturn("accessToken");
-        when(storage.retrieve("com.auth0.refresh_token", String.class)).thenReturn(null);
-        when(storage.retrieve("com.auth0.token_type", String.class)).thenReturn("type");
+        when(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken");
+        when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
+        when(storage.retrieveString("com.auth0.refresh_token")).thenReturn(null);
+        when(storage.retrieveString("com.auth0.token_type")).thenReturn("type");
         long expirationTime = CredentialsMock.CURRENT_TIME_MS; //Same as current time --> expired
-        when(storage.retrieve("com.auth0.expires_at", Long.class)).thenReturn(expirationTime);
-        when(storage.retrieve("com.auth0.scope", String.class)).thenReturn("scope");
+        when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime);
+        when(storage.retrieveString("com.auth0.scope")).thenReturn("scope");
 
         manager.getCredentials(callback);
 
@@ -192,13 +192,13 @@ public class CredentialsManagerTest {
     public void shouldGetNonExpiredCredentialsFromStorage() throws Exception {
         verifyNoMoreInteractions(client);
 
-        when(storage.retrieve("com.auth0.id_token", String.class)).thenReturn("idToken");
-        when(storage.retrieve("com.auth0.access_token", String.class)).thenReturn("accessToken");
-        when(storage.retrieve("com.auth0.refresh_token", String.class)).thenReturn("refreshToken");
-        when(storage.retrieve("com.auth0.token_type", String.class)).thenReturn("type");
+        when(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken");
+        when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
+        when(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken");
+        when(storage.retrieveString("com.auth0.token_type")).thenReturn("type");
         long expirationTime = CredentialsMock.CURRENT_TIME_MS + 123456L * 1000;
-        when(storage.retrieve("com.auth0.expires_at", Long.class)).thenReturn(expirationTime);
-        when(storage.retrieve("com.auth0.scope", String.class)).thenReturn("scope");
+        when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime);
+        when(storage.retrieveString("com.auth0.scope")).thenReturn("scope");
 
         manager.getCredentials(callback);
         verify(callback).onSuccess(credentialsCaptor.capture());
@@ -219,13 +219,13 @@ public class CredentialsManagerTest {
     public void shouldGetNonExpiredCredentialsFromStorageWhenOnlyIdTokenIsAvailable() throws Exception {
         verifyNoMoreInteractions(client);
 
-        when(storage.retrieve("com.auth0.id_token", String.class)).thenReturn("idToken");
-        when(storage.retrieve("com.auth0.access_token", String.class)).thenReturn(null);
-        when(storage.retrieve("com.auth0.refresh_token", String.class)).thenReturn("refreshToken");
-        when(storage.retrieve("com.auth0.token_type", String.class)).thenReturn("type");
+        when(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken");
+        when(storage.retrieveString("com.auth0.access_token")).thenReturn(null);
+        when(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken");
+        when(storage.retrieveString("com.auth0.token_type")).thenReturn("type");
         long expirationTime = CredentialsMock.CURRENT_TIME_MS + 123456L * 1000;
-        when(storage.retrieve("com.auth0.expires_at", Long.class)).thenReturn(expirationTime);
-        when(storage.retrieve("com.auth0.scope", String.class)).thenReturn("scope");
+        when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime);
+        when(storage.retrieveString("com.auth0.scope")).thenReturn("scope");
 
         manager.getCredentials(callback);
         verify(callback).onSuccess(credentialsCaptor.capture());
@@ -246,13 +246,13 @@ public class CredentialsManagerTest {
     public void shouldGetNonExpiredCredentialsFromStorageWhenOnlyAccessTokenIsAvailable() throws Exception {
         verifyNoMoreInteractions(client);
 
-        when(storage.retrieve("com.auth0.id_token", String.class)).thenReturn(null);
-        when(storage.retrieve("com.auth0.access_token", String.class)).thenReturn("accessToken");
-        when(storage.retrieve("com.auth0.refresh_token", String.class)).thenReturn("refreshToken");
-        when(storage.retrieve("com.auth0.token_type", String.class)).thenReturn("type");
+        when(storage.retrieveString("com.auth0.id_token")).thenReturn(null);
+        when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
+        when(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken");
+        when(storage.retrieveString("com.auth0.token_type")).thenReturn("type");
         Long expirationTime = CredentialsMock.CURRENT_TIME_MS + 123456L * 1000;
-        when(storage.retrieve("com.auth0.expires_at", Long.class)).thenReturn(expirationTime);
-        when(storage.retrieve("com.auth0.scope", String.class)).thenReturn("scope");
+        when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime);
+        when(storage.retrieveString("com.auth0.scope")).thenReturn("scope");
 
         manager.getCredentials(callback);
         verify(callback).onSuccess(credentialsCaptor.capture());
@@ -272,13 +272,13 @@ public class CredentialsManagerTest {
     @SuppressWarnings("UnnecessaryLocalVariable")
     @Test
     public void shouldGetAndSuccessfullyRenewExpiredCredentials() throws Exception {
-        when(storage.retrieve("com.auth0.id_token", String.class)).thenReturn("idToken");
-        when(storage.retrieve("com.auth0.access_token", String.class)).thenReturn("accessToken");
-        when(storage.retrieve("com.auth0.refresh_token", String.class)).thenReturn("refreshToken");
-        when(storage.retrieve("com.auth0.token_type", String.class)).thenReturn("type");
+        when(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken");
+        when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
+        when(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken");
+        when(storage.retrieveString("com.auth0.token_type")).thenReturn("type");
         long expirationTime = CredentialsMock.CURRENT_TIME_MS; //Same as current time --> expired
-        when(storage.retrieve("com.auth0.expires_at", Long.class)).thenReturn(expirationTime);
-        when(storage.retrieve("com.auth0.scope", String.class)).thenReturn("scope");
+        when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime);
+        when(storage.retrieveString("com.auth0.scope")).thenReturn("scope");
         when(client.renewAuth("refreshToken")).thenReturn(request);
 
         manager.getCredentials(callback);
@@ -297,13 +297,13 @@ public class CredentialsManagerTest {
     @SuppressWarnings("UnnecessaryLocalVariable")
     @Test
     public void shouldGetAndFailToRenewExpiredCredentials() throws Exception {
-        when(storage.retrieve("com.auth0.id_token", String.class)).thenReturn("idToken");
-        when(storage.retrieve("com.auth0.access_token", String.class)).thenReturn("accessToken");
-        when(storage.retrieve("com.auth0.refresh_token", String.class)).thenReturn("refreshToken");
-        when(storage.retrieve("com.auth0.token_type", String.class)).thenReturn("type");
+        when(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken");
+        when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
+        when(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken");
+        when(storage.retrieveString("com.auth0.token_type")).thenReturn("type");
         long expirationTime = CredentialsMock.CURRENT_TIME_MS; //Same as current time --> expired
-        when(storage.retrieve("com.auth0.expires_at", Long.class)).thenReturn(expirationTime);
-        when(storage.retrieve("com.auth0.scope", String.class)).thenReturn("scope");
+        when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime);
+        when(storage.retrieveString("com.auth0.scope")).thenReturn("scope");
         when(client.renewAuth("refreshToken")).thenReturn(request);
 
         manager.getCredentials(callback);

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,6 +15,17 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.Map;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyFloat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anySet;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -38,20 +50,24 @@ public class SharedPreferencesStorageTest {
         MockitoAnnotations.initMocks(this);
         when(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences);
         when(sharedPreferences.edit()).thenReturn(sharedPreferencesEditor);
+        when(sharedPreferencesEditor.remove(anyString())).thenReturn(sharedPreferencesEditor);
         when(sharedPreferencesEditor.putString(anyString(), anyString())).thenReturn(sharedPreferencesEditor);
+        when(sharedPreferencesEditor.putBoolean(anyString(), anyBoolean())).thenReturn(sharedPreferencesEditor);
+        when(sharedPreferencesEditor.putLong(anyString(), anyLong())).thenReturn(sharedPreferencesEditor);
+        when(sharedPreferencesEditor.putFloat(anyString(), anyFloat())).thenReturn(sharedPreferencesEditor);
+        when(sharedPreferencesEditor.putInt(anyString(), anyInt())).thenReturn(sharedPreferencesEditor);
+        when(sharedPreferencesEditor.putStringSet(anyString(), anySet())).thenReturn(sharedPreferencesEditor);
     }
 
     @Test
     public void shouldCreateWithDefaultPreferencesFileName() throws Exception {
         new SharedPreferencesStorage(context);
-
         verify(context).getSharedPreferences("com.auth0.authentication.storage", Context.MODE_PRIVATE);
     }
 
     @Test
     public void shouldCreateWithCustomPreferencesFileName() throws Exception {
         new SharedPreferencesStorage(context, "my-preferences-file");
-
         verify(context).getSharedPreferences("my-preferences-file", Context.MODE_PRIVATE);
     }
 
@@ -63,18 +79,122 @@ public class SharedPreferencesStorageTest {
         new SharedPreferencesStorage(context, null);
     }
 
+
+    //Store
+
     @Test
-    public void shouldStoreValueOnPreferences() throws Exception {
+    public void shouldThrowOnStoreUnsupportedType() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The class type is not supported. Supported types are: String, Boolean, Long, Float and Integer.");
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.store("name", "value");
+        storage.store("name", Collections.emptyMap(), Map.class);
+    }
+
+    @Test
+    public void shouldRemovePreferencesKeyOnNullValue() throws Exception {
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.store("name", null, String.class);
+        verify(sharedPreferencesEditor).remove("name");
+        verify(sharedPreferencesEditor).apply();
+    }
+
+    @Test
+    public void shouldStoreStringValueOnPreferences() throws Exception {
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.store("name", "value", String.class);
         verify(sharedPreferencesEditor).putString("name", "value");
         verify(sharedPreferencesEditor).apply();
     }
 
     @Test
-    public void shouldRetrieveValueFromPreferencesDefaultingToNull() throws Exception {
+    public void shouldStoreBooleanValueOnPreferences() throws Exception {
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.retrieve("name");
+        storage.store("name", true, Boolean.class);
+        verify(sharedPreferencesEditor).putBoolean("name", true);
+        verify(sharedPreferencesEditor).apply();
+    }
+
+    @Test
+    public void shouldStoreLongValueOnPreferences() throws Exception {
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.store("name", 123L, Long.class);
+        verify(sharedPreferencesEditor).putLong("name", 123L);
+        verify(sharedPreferencesEditor).apply();
+    }
+
+    @Test
+    public void shouldStoreFloatValueOnPreferences() throws Exception {
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.store("name", 123F, Float.class);
+        verify(sharedPreferencesEditor).putFloat("name", 123F);
+        verify(sharedPreferencesEditor).apply();
+    }
+
+    @Test
+    public void shouldStoreIntegerValueOnPreferences() throws Exception {
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.store("name", 123, Integer.class);
+        verify(sharedPreferencesEditor).putInt("name", 123);
+        verify(sharedPreferencesEditor).apply();
+    }
+
+
+    //Retrieve
+
+    @Test
+    public void shouldRetrieveNullValueIfMissingKeyFromPreferences() throws Exception {
+        when(sharedPreferences.contains("name")).thenReturn(false);
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        Boolean value = storage.retrieve("name", Boolean.class);
+        Assert.assertThat(value, is(nullValue()));
+    }
+
+    @Test
+    public void shouldRetrieveStringValueFromPreferences() throws Exception {
+        when(sharedPreferences.contains("name")).thenReturn(true);
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.retrieve("name", String.class);
         verify(sharedPreferences).getString("name", null);
+    }
+
+    @Test
+    public void shouldRetrieveBooleanValueFromPreferences() throws Exception {
+        when(sharedPreferences.contains("name")).thenReturn(true);
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.retrieve("name", Boolean.class);
+        verify(sharedPreferences).getBoolean("name", false);
+    }
+
+    @Test
+    public void shouldRetrieveLongValueFromPreferences() throws Exception {
+        when(sharedPreferences.contains("name")).thenReturn(true);
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.retrieve("name", Long.class);
+        verify(sharedPreferences).getLong("name", 0);
+    }
+
+    @Test
+    public void shouldRetrieveFloatValueFromPreferences() throws Exception {
+        when(sharedPreferences.contains("name")).thenReturn(true);
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.retrieve("name", Float.class);
+        verify(sharedPreferences).getFloat("name", 0);
+    }
+
+    @Test
+    public void shouldRetrieveIntegerValueFromPreferences() throws Exception {
+        when(sharedPreferences.contains("name")).thenReturn(true);
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.retrieve("name", Integer.class);
+        verify(sharedPreferences).getInt("name", 0);
+    }
+
+    @Test
+    public void shouldThrowOnRetrieveUnsupportedType() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The class type is not supported. Supported types are: String, Boolean, Long, Float and Integer.");
+        when(sharedPreferences.contains("name")).thenReturn(true);
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.retrieve("name", Map.class);
     }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
@@ -1,0 +1,80 @@
+package com.auth0.android.authentication.storage;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = com.auth0.android.auth0.BuildConfig.class, sdk = 21, manifest = Config.NONE)
+@SuppressLint("CommitPrefEdits")
+public class SharedPreferencesStorageTest {
+
+    @Mock
+    private Context context;
+    @Mock
+    private SharedPreferences sharedPreferences;
+    @Mock
+    private SharedPreferences.Editor sharedPreferencesEditor;
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences);
+        when(sharedPreferences.edit()).thenReturn(sharedPreferencesEditor);
+        when(sharedPreferencesEditor.putString(anyString(), anyString())).thenReturn(sharedPreferencesEditor);
+    }
+
+    @Test
+    public void shouldCreateWithDefaultPreferencesFileName() throws Exception {
+        new SharedPreferencesStorage(context);
+
+        verify(context).getSharedPreferences("com.auth0.authentication.storage", Context.MODE_PRIVATE);
+    }
+
+    @Test
+    public void shouldCreateWithCustomPreferencesFileName() throws Exception {
+        new SharedPreferencesStorage(context, "my-preferences-file");
+
+        verify(context).getSharedPreferences("my-preferences-file", Context.MODE_PRIVATE);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void shouldThrowOnCreateIfCustomPreferencesFileNameIsNull() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The SharedPreferences name is invalid");
+        new SharedPreferencesStorage(context, null);
+    }
+
+    @Test
+    public void shouldStoreValueOnPreferences() throws Exception {
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.store("name", "value");
+        verify(sharedPreferencesEditor).putString("name", "value");
+        verify(sharedPreferencesEditor).apply();
+    }
+
+    @Test
+    public void shouldRetrieveValueFromPreferencesDefaultingToNull() throws Exception {
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        storage.retrieve("name");
+        verify(sharedPreferences).getString("name", null);
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,12 +14,9 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.Map;
-
-import edu.emory.mathcs.backport.java.util.Collections;
-
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyFloat;
 import static org.mockito.Matchers.anyInt;
@@ -82,18 +78,32 @@ public class SharedPreferencesStorageTest {
 
     //Store
 
+    @SuppressWarnings("ConstantConditions")
     @Test
-    public void shouldThrowOnStoreUnsupportedType() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The class type is not supported. Supported types are: String, Boolean, Long, Float and Integer.");
+    public void shouldRemovePreferencesKeyOnNullStringValue() throws Exception {
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.store("name", Collections.emptyMap(), Map.class);
+        String value = null;
+        storage.store("name", value);
+        verify(sharedPreferencesEditor).remove("name");
+        verify(sharedPreferencesEditor).apply();
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
-    public void shouldRemovePreferencesKeyOnNullValue() throws Exception {
+    public void shouldRemovePreferencesKeyOnNullLongValue() throws Exception {
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.store("name", null, String.class);
+        Long value = null;
+        storage.store("name", value);
+        verify(sharedPreferencesEditor).remove("name");
+        verify(sharedPreferencesEditor).apply();
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void shouldRemovePreferencesKeyOnNullIntegerValue() throws Exception {
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        Integer value = null;
+        storage.store("name", value);
         verify(sharedPreferencesEditor).remove("name");
         verify(sharedPreferencesEditor).apply();
     }
@@ -101,39 +111,23 @@ public class SharedPreferencesStorageTest {
     @Test
     public void shouldStoreStringValueOnPreferences() throws Exception {
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.store("name", "value", String.class);
+        storage.store("name", "value");
         verify(sharedPreferencesEditor).putString("name", "value");
-        verify(sharedPreferencesEditor).apply();
-    }
-
-    @Test
-    public void shouldStoreBooleanValueOnPreferences() throws Exception {
-        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.store("name", true, Boolean.class);
-        verify(sharedPreferencesEditor).putBoolean("name", true);
         verify(sharedPreferencesEditor).apply();
     }
 
     @Test
     public void shouldStoreLongValueOnPreferences() throws Exception {
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.store("name", 123L, Long.class);
+        storage.store("name", 123L);
         verify(sharedPreferencesEditor).putLong("name", 123L);
-        verify(sharedPreferencesEditor).apply();
-    }
-
-    @Test
-    public void shouldStoreFloatValueOnPreferences() throws Exception {
-        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.store("name", 123F, Float.class);
-        verify(sharedPreferencesEditor).putFloat("name", 123F);
         verify(sharedPreferencesEditor).apply();
     }
 
     @Test
     public void shouldStoreIntegerValueOnPreferences() throws Exception {
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.store("name", 123, Integer.class);
+        storage.store("name", 123);
         verify(sharedPreferencesEditor).putInt("name", 123);
         verify(sharedPreferencesEditor).apply();
     }
@@ -142,59 +136,54 @@ public class SharedPreferencesStorageTest {
     //Retrieve
 
     @Test
-    public void shouldRetrieveNullValueIfMissingKeyFromPreferences() throws Exception {
+    public void shouldRetrieveNullStringValueIfMissingKeyFromPreferences() throws Exception {
         when(sharedPreferences.contains("name")).thenReturn(false);
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        Boolean value = storage.retrieve("name", Boolean.class);
-        Assert.assertThat(value, is(nullValue()));
+        String value = storage.retrieveString("name");
+        assertThat(value, is(nullValue()));
+    }
+
+    @Test
+    public void shouldRetrieveNullLongValueIfMissingKeyFromPreferences() throws Exception {
+        when(sharedPreferences.contains("name")).thenReturn(false);
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        Long value = storage.retrieveLong("name");
+        assertThat(value, is(nullValue()));
+    }
+
+    @Test
+    public void shouldRetrieveNullIntegerValueIfMissingKeyFromPreferences() throws Exception {
+        when(sharedPreferences.contains("name")).thenReturn(false);
+        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
+        Integer value = storage.retrieveInteger("name");
+        assertThat(value, is(nullValue()));
     }
 
     @Test
     public void shouldRetrieveStringValueFromPreferences() throws Exception {
         when(sharedPreferences.contains("name")).thenReturn(true);
+        when(sharedPreferences.getString("name", null)).thenReturn("value");
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.retrieve("name", String.class);
-        verify(sharedPreferences).getString("name", null);
-    }
-
-    @Test
-    public void shouldRetrieveBooleanValueFromPreferences() throws Exception {
-        when(sharedPreferences.contains("name")).thenReturn(true);
-        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.retrieve("name", Boolean.class);
-        verify(sharedPreferences).getBoolean("name", false);
+        String value = storage.retrieveString("name");
+        assertThat(value, is("value"));
     }
 
     @Test
     public void shouldRetrieveLongValueFromPreferences() throws Exception {
         when(sharedPreferences.contains("name")).thenReturn(true);
+        when(sharedPreferences.getLong("name", 0)).thenReturn(1234567890L);
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.retrieve("name", Long.class);
-        verify(sharedPreferences).getLong("name", 0);
-    }
-
-    @Test
-    public void shouldRetrieveFloatValueFromPreferences() throws Exception {
-        when(sharedPreferences.contains("name")).thenReturn(true);
-        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.retrieve("name", Float.class);
-        verify(sharedPreferences).getFloat("name", 0);
+        Long value = storage.retrieveLong("name");
+        assertThat(value, is(1234567890L));
     }
 
     @Test
     public void shouldRetrieveIntegerValueFromPreferences() throws Exception {
         when(sharedPreferences.contains("name")).thenReturn(true);
+        when(sharedPreferences.getInt("name", 0)).thenReturn(123);
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.retrieve("name", Integer.class);
-        verify(sharedPreferences).getInt("name", 0);
+        Integer value = storage.retrieveInteger("name");
+        assertThat(value, is(123));
     }
 
-    @Test
-    public void shouldThrowOnRetrieveUnsupportedType() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The class type is not supported. Supported types are: String, Boolean, Long, Float and Integer.");
-        when(sharedPreferences.contains("name")).thenReturn(true);
-        SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
-        storage.retrieve("name", Map.class);
-    }
 }

--- a/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
@@ -14,8 +14,10 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.Date;
 import java.util.HashMap;
 
+import static org.cyberneko.html.HTMLElements.HEAD;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -67,8 +69,9 @@ public class OAuthManagerTest {
 
     @Test
     public void shouldMergeCredentials() throws Exception {
-        Credentials urlCredentials = new Credentials("urlId", "urlAccess", "urlType", "urlRefresh", 9999L, "urlScope");
-        Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", 9999L, "codeScope");
+        Date expiresAt = new Date();
+        Credentials urlCredentials = new Credentials("urlId", "urlAccess", "urlType", "urlRefresh", expiresAt, "urlScope");
+        Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", expiresAt, "codeScope");
         Credentials merged = OAuthManager.mergeCredentials(urlCredentials, codeCredentials);
 
         assertThat(merged.getIdToken(), is(codeCredentials.getIdToken()));
@@ -76,12 +79,15 @@ public class OAuthManagerTest {
         assertThat(merged.getType(), is(codeCredentials.getType()));
         assertThat(merged.getRefreshToken(), is(codeCredentials.getRefreshToken()));
         assertThat(merged.getExpiresIn(), is(codeCredentials.getExpiresIn()));
+        assertThat(merged.getExpiresAt(), is(expiresAt));
+        assertThat(merged.getExpiresAt(), is(codeCredentials.getExpiresAt()));
         assertThat(merged.getScope(), is(codeCredentials.getScope()));
     }
 
     @Test
+    @SuppressWarnings("ConstantConditions")
     public void shouldPreferNonNullValuesWhenMergingCredentials() throws Exception {
-        Credentials urlCredentials = new Credentials("urlId", "urlAccess", "urlType", "urlRefresh", 9999L, "urlScope");
+        Credentials urlCredentials = new Credentials("urlId", "urlAccess", "urlType", "urlRefresh", new Date(), "urlScope");
         Credentials codeCredentials = new Credentials(null, null, null, null, null, null);
         Credentials merged = OAuthManager.mergeCredentials(urlCredentials, codeCredentials);
 
@@ -91,6 +97,7 @@ public class OAuthManagerTest {
         assertThat(merged.getRefreshToken(), is(urlCredentials.getRefreshToken()));
         assertThat(merged.getExpiresIn(), is(urlCredentials.getExpiresIn()));
         assertThat(merged.getScope(), is(urlCredentials.getScope()));
+        assertThat(merged.getExpiresAt(), is(urlCredentials.getExpiresAt()));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -31,6 +31,7 @@ import org.robolectric.annotation.Config;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -70,6 +71,7 @@ public class WebAuthProviderTest {
     private static final int REQUEST_CODE = 11;
     private static final String KEY_STATE = "state";
     private static final String KEY_NONCE = "nonce";
+    private static final long CURRENT_TIME_MS = 1234567890000L;
 
     @Mock
     private AuthCallback callback;
@@ -1045,7 +1047,7 @@ public class WebAuthProviderTest {
         String sentNonce = uri.getQueryParameter(KEY_NONCE);
         assertThat(sentState, is(not(isEmptyOrNullString())));
         assertThat(sentNonce, is(not(isEmptyOrNullString())));
-        Intent intent = createAuthIntent(createHash(customNonceJWT(sentNonce), null, null, null, sentState, null, null));
+        Intent intent = createAuthIntent(createHash(customNonceJWT(sentNonce), null, null, null, null, sentState, null, null));
         assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
 
         verify(callback).onSuccess(any(Credentials.class));
@@ -1065,7 +1067,7 @@ public class WebAuthProviderTest {
         String sentNonce = uri.getQueryParameter(KEY_NONCE);
         assertThat(sentState, is(not(isEmptyOrNullString())));
         assertThat(sentNonce, is(not(isEmptyOrNullString())));
-        Intent intent = createAuthIntent(createHash(customNonceJWT(sentNonce), null, null, null, sentState, null, null));
+        Intent intent = createAuthIntent(createHash(customNonceJWT(sentNonce), null, null, null, null, sentState, null, null));
         assertTrue(WebAuthProvider.resume(intent));
 
         verify(callback).onSuccess(any(Credentials.class));
@@ -1088,7 +1090,7 @@ public class WebAuthProviderTest {
                 .useCodeGrant(true)
                 .withPKCE(pkce)
                 .start(activity, callback);
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", null, null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", null, null));
         int DEFAULT_REQUEST_CODE = 110;
         assertTrue(WebAuthProvider.resume(DEFAULT_REQUEST_CODE, Activity.RESULT_OK, intent));
     }
@@ -1096,7 +1098,8 @@ public class WebAuthProviderTest {
     @SuppressWarnings("deprecation")
     @Test
     public void shouldResumeWithIntentWithCodeGrant() throws Exception {
-        final Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", 9999L, "codeScope");
+        Date expiresAt = new Date();
+        final Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", expiresAt, "codeScope");
         PKCE pkce = Mockito.mock(PKCE.class);
         Mockito.doAnswer(new Answer() {
             @Override
@@ -1116,7 +1119,7 @@ public class WebAuthProviderTest {
 
         String sentState = uri.getQueryParameter(KEY_STATE);
         assertThat(sentState, is(not(isEmptyOrNullString())));
-        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", sentState, null, null));
+        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", null, sentState, null, null));
         assertTrue(WebAuthProvider.resume(intent));
 
         ArgumentCaptor<Credentials> credentialsCaptor = ArgumentCaptor.forClass(Credentials.class);
@@ -1127,14 +1130,15 @@ public class WebAuthProviderTest {
         assertThat(credentialsCaptor.getValue().getAccessToken(), is("codeAccess"));
         assertThat(credentialsCaptor.getValue().getRefreshToken(), is("codeRefresh"));
         assertThat(credentialsCaptor.getValue().getType(), is("codeType"));
-        assertThat(credentialsCaptor.getValue().getExpiresIn(), is(9999L));
+        assertThat(credentialsCaptor.getValue().getExpiresAt(), is(expiresAt));
         assertThat(credentialsCaptor.getValue().getScope(), is("codeScope"));
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void shouldResumeWithRequestCodeWithCodeGrant() throws Exception {
-        final Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", 9999L, "codeScope");
+        Date expiresAt = new Date();
+        final Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", expiresAt, "codeScope");
         PKCE pkce = Mockito.mock(PKCE.class);
         Mockito.doAnswer(new Answer() {
             @Override
@@ -1154,7 +1158,7 @@ public class WebAuthProviderTest {
 
         String sentState = uri.getQueryParameter(KEY_STATE);
         assertThat(sentState, is(not(isEmptyOrNullString())));
-        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", sentState, null, null));
+        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", null, sentState, null, null));
         assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
 
         ArgumentCaptor<Credentials> credentialsCaptor = ArgumentCaptor.forClass(Credentials.class);
@@ -1165,7 +1169,7 @@ public class WebAuthProviderTest {
         assertThat(credentialsCaptor.getValue().getAccessToken(), is("codeAccess"));
         assertThat(credentialsCaptor.getValue().getRefreshToken(), is("codeRefresh"));
         assertThat(credentialsCaptor.getValue().getType(), is("codeType"));
-        assertThat(credentialsCaptor.getValue().getExpiresIn(), is(9999L));
+        assertThat(credentialsCaptor.getValue().getExpiresAt(), is(expiresAt));
         assertThat(credentialsCaptor.getValue().getScope(), is("codeScope"));
     }
 
@@ -1182,7 +1186,7 @@ public class WebAuthProviderTest {
 
         String sentState = uri.getQueryParameter(KEY_STATE);
         assertThat(sentState, is(not(isEmptyOrNullString())));
-        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", sentState, null, null));
+        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", null, sentState, null, null));
         assertTrue(WebAuthProvider.resume(intent));
 
         verify(callback).onSuccess(any(Credentials.class));
@@ -1201,10 +1205,35 @@ public class WebAuthProviderTest {
 
         String sentState = uri.getQueryParameter(KEY_STATE);
         assertThat(sentState, is(not(isEmptyOrNullString())));
-        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", sentState, null, null));
+        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", null, sentState, null, null));
         assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
 
         verify(callback).onSuccess(any(Credentials.class));
+    }
+
+    @Test
+    public void shouldCalculateExpiresAtDateOnResumeAuthentication() throws Exception {
+        WebAuthProvider.init(account)
+                .useCodeGrant(false)
+                .start(activity, callback, REQUEST_CODE);
+        WebAuthProvider.getInstance().setCurrentTimeInMillis(CURRENT_TIME_MS);
+
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getData();
+        assertThat(uri, is(notNullValue()));
+
+        String sentState = uri.getQueryParameter(KEY_STATE);
+        assertThat(sentState, is(not(isEmptyOrNullString())));
+        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", 1111L, sentState, null, null));
+        assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
+
+        ArgumentCaptor<Credentials> credentialsCaptor = ArgumentCaptor.forClass(Credentials.class);
+        verify(callback).onSuccess(credentialsCaptor.capture());
+
+        assertThat(credentialsCaptor.getValue(), is(notNullValue()));
+        long expirationTime = CURRENT_TIME_MS + 1111L * 1000;
+        assertThat(credentialsCaptor.getValue().getExpiresAt(), is(notNullValue()));
+        assertThat(credentialsCaptor.getValue().getExpiresAt().getTime(), is(expirationTime));
     }
 
     @SuppressWarnings("deprecation")
@@ -1224,7 +1253,7 @@ public class WebAuthProviderTest {
                 .useCodeGrant(true)
                 .withPKCE(pkce)
                 .start(activity, callback);
-        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", "1234567890", null, null));
+        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", null, "1234567890", null, null));
         assertTrue(WebAuthProvider.resume(intent));
 
         verify(callback).onFailure(dialog);
@@ -1247,7 +1276,7 @@ public class WebAuthProviderTest {
                 .useCodeGrant(true)
                 .withPKCE(pkce)
                 .start(activity, callback);
-        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", "1234567890", null, null));
+        Intent intent = createAuthIntent(createHash("urlId", "urlAccess", "urlRefresh", "urlType", null, "1234567890", null, null));
         assertTrue(WebAuthProvider.resume(intent));
 
         verify(callback).onFailure(exception);
@@ -1260,7 +1289,7 @@ public class WebAuthProviderTest {
                 .withState("1234567890")
                 .useCodeGrant(false)
                 .start(activity, callback);
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", "access_denied", null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", "access_denied", null));
         assertTrue(WebAuthProvider.resume(intent));
 
         verify(callback).onFailure(authExceptionCaptor.capture());
@@ -1277,7 +1306,7 @@ public class WebAuthProviderTest {
                 .withState("1234567890")
                 .useCodeGrant(false)
                 .start(activity, callback, REQUEST_CODE);
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", "access_denied", null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", "access_denied", null));
         assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
 
         verify(callback).onFailure(authExceptionCaptor.capture());
@@ -1294,7 +1323,7 @@ public class WebAuthProviderTest {
                 .withState("1234567890")
                 .useCodeGrant(false)
                 .start(activity, callback);
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", "unauthorized", "Custom Rule Error"));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", "unauthorized", "Custom Rule Error"));
         assertTrue(WebAuthProvider.resume(intent));
 
         verify(callback).onFailure(authExceptionCaptor.capture());
@@ -1311,7 +1340,7 @@ public class WebAuthProviderTest {
                 .withState("1234567890")
                 .useCodeGrant(false)
                 .start(activity, callback, REQUEST_CODE);
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", "unauthorized", "Custom Rule Error"));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", "unauthorized", "Custom Rule Error"));
         assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
 
         verify(callback).onFailure(authExceptionCaptor.capture());
@@ -1328,7 +1357,7 @@ public class WebAuthProviderTest {
                 .withState("1234567890")
                 .useCodeGrant(false)
                 .start(activity, callback);
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", "some other error", null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", "some other error", null));
         assertTrue(WebAuthProvider.resume(intent));
 
         verify(callback).onFailure(authExceptionCaptor.capture());
@@ -1345,7 +1374,7 @@ public class WebAuthProviderTest {
                 .withState("1234567890")
                 .useCodeGrant(false)
                 .start(activity, callback, REQUEST_CODE);
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", "some other error", null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", "some other error", null));
         assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
 
         verify(callback).onFailure(authExceptionCaptor.capture());
@@ -1362,7 +1391,7 @@ public class WebAuthProviderTest {
                 .withState("abcdefghijk")
                 .useCodeGrant(false)
                 .start(activity, callback);
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", null, null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", null, null));
         assertTrue(WebAuthProvider.resume(intent));
 
         verify(callback).onFailure(authExceptionCaptor.capture());
@@ -1379,7 +1408,7 @@ public class WebAuthProviderTest {
                 .withState("abcdefghijk")
                 .useCodeGrant(false)
                 .start(activity, callback, REQUEST_CODE);
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", null, null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", null, null));
         assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
 
         verify(callback).onFailure(authExceptionCaptor.capture());
@@ -1397,7 +1426,7 @@ public class WebAuthProviderTest {
                 .withNonce("0987654321")
                 .withResponseType(ResponseType.ID_TOKEN)
                 .start(activity, callback);
-        Intent intent = createAuthIntent(createHash("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6IjEyMzQ1Njc4OTAifQ.oUb6xFIEPJQrFbel_Js4SaOwpFfM_kxHxI7xDOHgghk", null, null, null, "state", null, null));
+        Intent intent = createAuthIntent(createHash("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6IjEyMzQ1Njc4OTAifQ.oUb6xFIEPJQrFbel_Js4SaOwpFfM_kxHxI7xDOHgghk", null, null, null, null, "state", null, null));
         assertTrue(WebAuthProvider.resume(intent));
 
         verify(callback).onFailure(authExceptionCaptor.capture());
@@ -1415,7 +1444,7 @@ public class WebAuthProviderTest {
                 .withNonce("0987654321")
                 .withResponseType(ResponseType.ID_TOKEN)
                 .start(activity, callback, REQUEST_CODE);
-        Intent intent = createAuthIntent(createHash("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6IjEyMzQ1Njc4OTAifQ.oUb6xFIEPJQrFbel_Js4SaOwpFfM_kxHxI7xDOHgghk", null, null, null, "state", null, null));
+        Intent intent = createAuthIntent(createHash("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6IjEyMzQ1Njc4OTAifQ.oUb6xFIEPJQrFbel_Js4SaOwpFfM_kxHxI7xDOHgghk", null, null, null, null, "state", null, null));
         assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
 
         verify(callback).onFailure(authExceptionCaptor.capture());
@@ -1433,7 +1462,7 @@ public class WebAuthProviderTest {
                 .useCodeGrant(false)
                 .start(activity, callback);
 
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", null, null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", null, null));
         assertFalse(WebAuthProvider.resume(999, Activity.RESULT_OK, intent));
     }
 
@@ -1445,7 +1474,7 @@ public class WebAuthProviderTest {
                 .useCodeGrant(false)
                 .start(activity, callback, REQUEST_CODE);
 
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", null, null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", null, null));
         assertFalse(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_CANCELED, intent));
     }
 
@@ -1457,7 +1486,7 @@ public class WebAuthProviderTest {
                 .useCodeGrant(false)
                 .start(activity, callback, REQUEST_CODE);
 
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", null, null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", null, null));
         assertFalse(WebAuthProvider.resume(REQUEST_CODE, 999, intent));
     }
 
@@ -1526,7 +1555,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         assertThat(WebAuthProvider.getInstance(), is(notNullValue()));
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", null, null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", null, null));
         assertTrue(WebAuthProvider.resume(intent));
         assertThat(WebAuthProvider.getInstance(), is(nullValue()));
     }
@@ -1538,7 +1567,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback, REQUEST_CODE);
 
         assertThat(WebAuthProvider.getInstance(), is(notNullValue()));
-        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", "1234567890", null, null));
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", null, null));
         assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
         assertThat(WebAuthProvider.getInstance(), is(nullValue()));
     }
@@ -1551,7 +1580,7 @@ public class WebAuthProviderTest {
         return intent;
     }
 
-    private String createHash(@Nullable String idToken, @Nullable String accessToken, @Nullable String refreshToken, @Nullable String tokenType, @Nullable String state, @Nullable String error, @Nullable String errorDescription) {
+    private String createHash(@Nullable String idToken, @Nullable String accessToken, @Nullable String refreshToken, @Nullable String tokenType, @Nullable Long expiresIn, @Nullable String state, @Nullable String error, @Nullable String errorDescription) {
         String hash = "#";
         if (accessToken != null) {
             hash = hash.concat("access_token=")
@@ -1571,6 +1600,11 @@ public class WebAuthProviderTest {
         if (tokenType != null) {
             hash = hash.concat("token_type=")
                     .concat(tokenType)
+                    .concat("&");
+        }
+        if (expiresIn != null) {
+            hash = hash.concat("expires_in=")
+                    .concat(String.valueOf(expiresIn))
                     .concat("&");
         }
         if (state != null) {

--- a/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerTest.java
@@ -1,0 +1,38 @@
+package com.auth0.android.request.internal;
+
+import com.auth0.android.result.Credentials;
+import com.auth0.android.result.CredentialsMock;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.junit.Test;
+
+import java.io.FileReader;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class CredentialsDeserializerTest {
+
+    private static final String OPEN_ID_OFFLINE_ACCESS_CREDENTIALS = "src/test/resources/credentials_openid_refresh_token.json";
+
+    private static final long CURRENT_TIME_MS = 1234567890000L;
+
+    @Test
+    public void shouldSetExpiresAtFromExpiresIn() throws Exception {
+        final CredentialsDeserializer deserializer = new CredentialsDeserializer();
+        final CredentialsDeserializer spy = spy(deserializer);
+        doReturn(CredentialsMock.CURRENT_TIME_MS).when(spy).getCurrentTimeInMillis();
+
+        final Gson gson = new GsonBuilder()
+                .registerTypeAdapter(Credentials.class, spy)
+                .create();
+
+        final Credentials credentials = gson.getAdapter(Credentials.class).fromJson(new FileReader(OPEN_ID_OFFLINE_ACCESS_CREDENTIALS));
+        assertThat(credentials.getExpiresAt(), is(notNullValue()));
+        assertThat(credentials.getExpiresAt().getTime(), is(CURRENT_TIME_MS + 86000 * 1000));
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/request/internal/CredentialsGsonTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CredentialsGsonTest.java
@@ -32,14 +32,15 @@ public class CredentialsGsonTest extends GsonBaseTest {
     }
 
     @Test
-    public void shouldNotFailWithEmptyJson() throws Exception {
-        buildCredentialsFrom(json(EMPTY_OBJECT));
-    }
-
-    @Test
     public void shouldFailWithInvalidJson() throws Exception {
         expectedException.expect(JsonParseException.class);
         buildCredentialsFrom(json(INVALID));
+    }
+
+    @Test
+    public void shouldFailWithEmptyJson() throws Exception {
+        expectedException.expect(JsonParseException.class);
+        buildCredentialsFrom(json(EMPTY_OBJECT));
     }
 
     @Test
@@ -61,6 +62,7 @@ public class CredentialsGsonTest extends GsonBaseTest {
         assertThat(credentials.getType(), equalTo("bearer"));
         assertThat(credentials.getRefreshToken(), is(nullValue()));
         assertThat(credentials.getExpiresIn(), is(86000L));
+        assertThat(credentials.getExpiresAt(), is(notNullValue()));
         assertThat(credentials.getScope(), is(nullValue()));
     }
 
@@ -73,6 +75,7 @@ public class CredentialsGsonTest extends GsonBaseTest {
         assertThat(credentials.getType(), equalTo("bearer"));
         assertThat(credentials.getRefreshToken(), is(nullValue()));
         assertThat(credentials.getExpiresIn(), is(86000L));
+        assertThat(credentials.getExpiresAt(), is(notNullValue()));
         assertThat(credentials.getScope(), is("openid profile"));
     }
 
@@ -85,6 +88,7 @@ public class CredentialsGsonTest extends GsonBaseTest {
         assertThat(credentials.getType(), equalTo("bearer"));
         assertThat(credentials.getRefreshToken(), is(notNullValue()));
         assertThat(credentials.getExpiresIn(), is(86000L));
+        assertThat(credentials.getExpiresAt(), is(notNullValue()));
         assertThat(credentials.getScope(), is("openid profile"));
     }
 

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsMock.java
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsMock.java
@@ -1,0 +1,24 @@
+package com.auth0.android.result;
+
+import android.support.annotation.Nullable;
+
+import java.util.Date;
+
+@SuppressWarnings("WeakerAccess")
+public class CredentialsMock extends Credentials {
+
+    public static final long CURRENT_TIME_MS = 1234567890000L;
+
+    public CredentialsMock(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Long expiresIn) {
+        super(idToken, accessToken, type, refreshToken, expiresIn);
+    }
+
+    public CredentialsMock(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Date expiresAt, @Nullable String scope) {
+        super(idToken, accessToken, type, refreshToken, expiresAt, scope);
+    }
+
+    @Override
+    long getCurrentTimeInMillis() {
+        return CURRENT_TIME_MS;
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsTest.java
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsTest.java
@@ -1,47 +1,43 @@
 package com.auth0.android.result;
 
-import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Date;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 public class CredentialsTest {
 
-    private Credentials credentials;
-
-    @Before
-    public void setUp() throws Exception {
-        credentials = new Credentials("idToken", "accessToken", "type", "refreshToken", 999999L, "openid profile");
-    }
-
     @Test
-    public void getIdToken() throws Exception {
+    public void shouldCreateWithExpiresAtDateAndSetExpiresIn() throws Exception {
+        Date date = new Date();
+        long expiresIn = (date.getTime() - CredentialsMock.CURRENT_TIME_MS) / 1000;
+        Credentials credentials = new CredentialsMock("idToken", "accessToken", "type", "refreshToken", date, "scope");
         assertThat(credentials.getIdToken(), is("idToken"));
-    }
-
-    @Test
-    public void getAccessToken() throws Exception {
         assertThat(credentials.getAccessToken(), is("accessToken"));
-    }
-
-    @Test
-    public void getType() throws Exception {
         assertThat(credentials.getType(), is("type"));
-    }
-
-    @Test
-    public void getRefreshToken() throws Exception {
         assertThat(credentials.getRefreshToken(), is("refreshToken"));
+        assertThat(credentials.getExpiresIn(), is(expiresIn));
+        assertThat(credentials.getExpiresAt(), is(date));
+        assertThat(credentials.getScope(), is("scope"));
     }
 
     @Test
-    public void getExpiresIn() throws Exception {
-        assertThat(credentials.getExpiresIn(), is(999999L));
+    public void shouldCreateWithExpiresInAndSetExpiresAt() throws Exception {
+        Credentials credentials = new CredentialsMock("idToken", "accessToken", "type", "refreshToken", 86400L);
+        assertThat(credentials.getIdToken(), is("idToken"));
+        assertThat(credentials.getAccessToken(), is("accessToken"));
+        assertThat(credentials.getType(), is("type"));
+        assertThat(credentials.getRefreshToken(), is("refreshToken"));
+        assertThat(credentials.getExpiresIn(), is(86400L));
+        Date expirationDate = new Date(CredentialsMock.CURRENT_TIME_MS + 86400L * 1000);
+        assertThat(credentials.getExpiresAt(), is(expirationDate));
     }
 
     @Test
     public void getScope() throws Exception {
+        Credentials credentials = new Credentials("idToken", "accessToken", "type", "refreshToken", new Date(), "openid profile");
         assertThat(credentials.getScope(), is("openid profile"));
     }
 }


### PR DESCRIPTION
A Credentials Manager will save credentials and retrieve them checking for valid values, expiration and even refreshing them if needed. If an error arises the user receives a `CredentialsManagerException`.

### Usage
1. **Instantiate the manager:** the Storage interface will let the user customize the persistence of the values.

```java
AuthenticationAPIClient authClient = //create auth client
Storage storage = //create new storage
CredentialsManager manager = new CredentialsManager(authClient, storage);
```

2. **Save credentials:** An `access_token` or `id_token` value is needed along with a valid `expires_in` value, if not it will raise `CredentialsManagerException`.

```java
Credentials credentials = //login to Auth0, i.e. by using the authClient
manager.setCredentials(credentials);
```

3. **Retrieve credentials:** If the `access_token` or `id_token` was not set it will raise `CredentialsManagerException`. If the saved credentials haven't expired they will be returned. If the credentials have expired and the `refresh_token` is null a `CredentialsManagerException` will be raised; else it will try to renew them by using the given authClient.

```java
manager.getCredentials(new BaseCallback<Credentials, CredentialsManagerException>(){
   public void onSuccess(Credentials credentials){
      //success
   }

    public void onFailure(CredentialsManagerException error){
      //error
   }
});
```

### TODO
- [x] Add tests
- [x] Provide an implementation of `Storage` with the library that uses `SharedPreferences`.
- [x] Javadoc
- [x] README
