### PR TITLE
Add granted scope to the Credentials object

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
 
@@ -49,6 +50,7 @@ class OAuthManager {
     private static final String KEY_REFRESH_TOKEN = "refresh_token";
     private static final String KEY_EXPIRES_IN = "expires_in";
     private static final String KEY_CODE = "code";
+    private static final String KEY_SCOPE = "scope";
 
     private final Auth0 account;
     private final AuthCallback callback;
@@ -126,7 +128,7 @@ class OAuthManager {
             if (values.containsKey(KEY_EXPIRES_IN)) {
                 expiresIn = Long.valueOf(values.get(KEY_EXPIRES_IN));
             }
-            final Credentials urlCredentials = new Credentials(values.get(KEY_ID_TOKEN), values.get(KEY_ACCESS_TOKEN), values.get(KEY_TOKEN_TYPE), values.get(KEY_REFRESH_TOKEN), expiresIn);
+            final Credentials urlCredentials = new Credentials(values.get(KEY_ID_TOKEN), values.get(KEY_ACCESS_TOKEN), values.get(KEY_TOKEN_TYPE), values.get(KEY_REFRESH_TOKEN), expiresIn, values.get(KEY_SCOPE));
             if (!shouldUsePKCE()) {
                 callback.onSuccess(urlCredentials);
             } else {
@@ -260,13 +262,14 @@ class OAuthManager {
 
     @VisibleForTesting
     static Credentials mergeCredentials(Credentials urlCredentials, Credentials codeCredentials) {
-        final String idToken = codeCredentials.getIdToken() != null ? codeCredentials.getIdToken() : urlCredentials.getIdToken();
-        final String accessToken = codeCredentials.getAccessToken() != null ? codeCredentials.getAccessToken() : urlCredentials.getAccessToken();
-        final String type = codeCredentials.getType() != null ? codeCredentials.getType() : urlCredentials.getType();
-        final String refreshToken = codeCredentials.getRefreshToken() != null ? codeCredentials.getRefreshToken() : urlCredentials.getRefreshToken();
+        final String idToken = TextUtils.isEmpty(codeCredentials.getIdToken()) ? urlCredentials.getIdToken() : codeCredentials.getIdToken();
+        final String accessToken = TextUtils.isEmpty(codeCredentials.getAccessToken()) ? urlCredentials.getAccessToken() : codeCredentials.getAccessToken();
+        final String type = TextUtils.isEmpty(codeCredentials.getType()) ? urlCredentials.getType() : codeCredentials.getType();
+        final String refreshToken = TextUtils.isEmpty(codeCredentials.getRefreshToken()) ? urlCredentials.getRefreshToken() : codeCredentials.getRefreshToken();
         final Long expiresIn = codeCredentials.getExpiresIn() != null ? codeCredentials.getExpiresIn() : urlCredentials.getExpiresIn();
+        final String scope = TextUtils.isEmpty(codeCredentials.getScope()) ? urlCredentials.getScope() : codeCredentials.getScope();
 
-        return new Credentials(idToken, accessToken, type, refreshToken, expiresIn);
+        return new Credentials(idToken, accessToken, type, refreshToken, expiresIn, scope);
     }
 
     @VisibleForTesting

--- a/auth0/src/main/java/com/auth0/android/result/Credentials.java
+++ b/auth0/src/main/java/com/auth0/android/result/Credentials.java
@@ -36,6 +36,8 @@ import com.google.gson.annotations.SerializedName;
  * <li><i>accessToken</i>: Access Token for Auth0 API</li>
  * <li><i>refreshToken</i>: Refresh Token that can be used to request new tokens without signing in again</li>
  * <li><i>type</i>: The type of the received Token.</li>
+ * <li><i>expiresIn</i>: The token lifetime in seconds.</li>
+ * <li><i>scope</i>: The token's granted scope.</li>
  * </ul>
  */
 public class Credentials {
@@ -55,12 +57,21 @@ public class Credentials {
     @SerializedName("expires_in")
     private Long expiresIn;
 
-    public Credentials(String idToken, String accessToken, String type, String refreshToken, Long expiresIn) {
+    @SerializedName("scope")
+    private String scope;
+
+    public Credentials(String idToken, String accessToken, String type, String refreshToken, Long expiresIn, String scope) {
         this.idToken = idToken;
         this.accessToken = accessToken;
         this.type = type;
         this.refreshToken = refreshToken;
         this.expiresIn = expiresIn;
+        this.scope = scope;
+    }
+
+    //TODO: Deprecate this constructor
+    public Credentials(String idToken, String accessToken, String type, String refreshToken, Long expiresIn) {
+        this(idToken, accessToken, type, refreshToken, expiresIn, null);
     }
 
     /**
@@ -105,5 +116,15 @@ public class Credentials {
 
     public Long getExpiresIn() {
         return expiresIn;
+    }
+
+    /**
+     * Getter for the token's granted scope. Only available if the requested scope differs from the granted one.
+     *
+     * @return the granted scope.
+     */
+    @Nullable
+    public String getScope() {
+        return scope;
     }
 }

--- a/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
@@ -67,8 +67,8 @@ public class OAuthManagerTest {
 
     @Test
     public void shouldMergeCredentials() throws Exception {
-        Credentials urlCredentials = new Credentials("urlId", "urlAccess", "urlType", "urlRefresh", 9999L);
-        Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", 9999L);
+        Credentials urlCredentials = new Credentials("urlId", "urlAccess", "urlType", "urlRefresh", 9999L, "urlScope");
+        Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", 9999L, "codeScope");
         Credentials merged = OAuthManager.mergeCredentials(urlCredentials, codeCredentials);
 
         assertThat(merged.getIdToken(), is(codeCredentials.getIdToken()));
@@ -76,12 +76,13 @@ public class OAuthManagerTest {
         assertThat(merged.getType(), is(codeCredentials.getType()));
         assertThat(merged.getRefreshToken(), is(codeCredentials.getRefreshToken()));
         assertThat(merged.getExpiresIn(), is(codeCredentials.getExpiresIn()));
+        assertThat(merged.getScope(), is(codeCredentials.getScope()));
     }
 
     @Test
     public void shouldPreferNonNullValuesWhenMergingCredentials() throws Exception {
-        Credentials urlCredentials = new Credentials("urlId", "urlAccess", "urlType", "urlRefresh", 9999L);
-        Credentials codeCredentials = new Credentials(null, null, null, null, null);
+        Credentials urlCredentials = new Credentials("urlId", "urlAccess", "urlType", "urlRefresh", 9999L, "urlScope");
+        Credentials codeCredentials = new Credentials(null, null, null, null, null, null);
         Credentials merged = OAuthManager.mergeCredentials(urlCredentials, codeCredentials);
 
         assertThat(merged.getIdToken(), is(urlCredentials.getIdToken()));
@@ -89,6 +90,7 @@ public class OAuthManagerTest {
         assertThat(merged.getType(), is(urlCredentials.getType()));
         assertThat(merged.getRefreshToken(), is(urlCredentials.getRefreshToken()));
         assertThat(merged.getExpiresIn(), is(urlCredentials.getExpiresIn()));
+        assertThat(merged.getScope(), is(urlCredentials.getScope()));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -1096,7 +1096,7 @@ public class WebAuthProviderTest {
     @SuppressWarnings("deprecation")
     @Test
     public void shouldResumeWithIntentWithCodeGrant() throws Exception {
-        final Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", 9999L);
+        final Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", 9999L, "codeScope");
         PKCE pkce = Mockito.mock(PKCE.class);
         Mockito.doAnswer(new Answer() {
             @Override
@@ -1128,12 +1128,13 @@ public class WebAuthProviderTest {
         assertThat(credentialsCaptor.getValue().getRefreshToken(), is("codeRefresh"));
         assertThat(credentialsCaptor.getValue().getType(), is("codeType"));
         assertThat(credentialsCaptor.getValue().getExpiresIn(), is(9999L));
+        assertThat(credentialsCaptor.getValue().getScope(), is("codeScope"));
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void shouldResumeWithRequestCodeWithCodeGrant() throws Exception {
-        final Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", 9999L);
+        final Credentials codeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", 9999L, "codeScope");
         PKCE pkce = Mockito.mock(PKCE.class);
         Mockito.doAnswer(new Answer() {
             @Override
@@ -1165,6 +1166,7 @@ public class WebAuthProviderTest {
         assertThat(credentialsCaptor.getValue().getRefreshToken(), is("codeRefresh"));
         assertThat(credentialsCaptor.getValue().getType(), is("codeType"));
         assertThat(credentialsCaptor.getValue().getExpiresIn(), is(9999L));
+        assertThat(credentialsCaptor.getValue().getScope(), is("codeScope"));
     }
 
     @SuppressWarnings("deprecation")

--- a/auth0/src/test/java/com/auth0/android/request/internal/CredentialsGsonTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CredentialsGsonTest.java
@@ -61,6 +61,7 @@ public class CredentialsGsonTest extends GsonBaseTest {
         assertThat(credentials.getType(), equalTo("bearer"));
         assertThat(credentials.getRefreshToken(), is(nullValue()));
         assertThat(credentials.getExpiresIn(), is(86000L));
+        assertThat(credentials.getScope(), is(nullValue()));
     }
 
     @Test
@@ -72,6 +73,7 @@ public class CredentialsGsonTest extends GsonBaseTest {
         assertThat(credentials.getType(), equalTo("bearer"));
         assertThat(credentials.getRefreshToken(), is(nullValue()));
         assertThat(credentials.getExpiresIn(), is(86000L));
+        assertThat(credentials.getScope(), is("openid profile"));
     }
 
     @Test
@@ -83,6 +85,7 @@ public class CredentialsGsonTest extends GsonBaseTest {
         assertThat(credentials.getType(), equalTo("bearer"));
         assertThat(credentials.getRefreshToken(), is(notNullValue()));
         assertThat(credentials.getExpiresIn(), is(86000L));
+        assertThat(credentials.getScope(), is("openid profile"));
     }
 
     private Credentials buildCredentialsFrom(Reader json) throws IOException {

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsTest.java
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsTest.java
@@ -12,7 +12,7 @@ public class CredentialsTest {
 
     @Before
     public void setUp() throws Exception {
-        credentials = new Credentials("idToken", "accessToken", "type", "refreshToken", 999999L);
+        credentials = new Credentials("idToken", "accessToken", "type", "refreshToken", 999999L, "openid profile");
     }
 
     @Test
@@ -40,4 +40,8 @@ public class CredentialsTest {
         assertThat(credentials.getExpiresIn(), is(999999L));
     }
 
+    @Test
+    public void getScope() throws Exception {
+        assertThat(credentials.getScope(), is("openid profile"));
+    }
 }

--- a/auth0/src/test/resources/credentials_openid.json
+++ b/auth0/src/test/resources/credentials_openid.json
@@ -2,5 +2,6 @@
   "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3NhbXBsZXMuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDUzYjk5NWY4YmNlNjhkOWZjOTAwMDk5YyIsImF1ZCI6Ikk5bWhVcmZrVEdGVldqbEVxWlNUQ0JVRkFCTGJKRkdMMyIsImV4cCI6MTQ2NTEwOTAzMywiaWF0IjoxNDY1MDczMDMzfQ.TdRc-lnVcX0LT7ZySzVysjVcYzAUIRnCPufTO8VV6g8",
   "access_token": "s6GS5FGJN2jfd4l6",
   "token_type": "bearer",
-  "expires_in": 86000
+  "expires_in": 86000,
+  "scope": "openid profile"
 }

--- a/auth0/src/test/resources/credentials_openid_refresh_token.json
+++ b/auth0/src/test/resources/credentials_openid_refresh_token.json
@@ -3,5 +3,6 @@
     "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3NhbXBsZXMuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDUzYjk5NWY4YmNlNjhkOWZjOTAwMDk5YyIsImF1ZCI6Ikk5bWhVcmZrVEdGVldqbEVxWlNUQ0JVRkFCTGJKRkdMMyIsImV4cCI6MTQ2NTEwOTAzMywiaWF0IjoxNDY1MDczMDMzfQ.TdRc-lnVcX0LT7ZySzVysjVcYzAUIRnCPufTO8VV6g8",
     "access_token": "s6GS5FGJN2jfd4l6",
     "token_type": "bearer",
-    "expires_in": 86000
+    "expires_in": 86000,
+    "scope": "openid profile"
 }


### PR DESCRIPTION
The scope is only present on OIDC authentication calls when an `audience` is requested and the requested `scope` differs from the final scope that the server grants. i.e. requested scope is invalid or a rule edited the `access_token.scope` value.

Deprecation note: The previous Credentials constructor must be deprecated (in a separate PR).