### PR TITLE
Allow Custom Tabs UI to be customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,22 @@ WebAuthProvider.init(account)
 ```
 
 
+#### Customize the Custom Tabs UI
+
+If the device where the app is running has a Custom Tabs compatible Browser, a Custom Tab will be preferred for the authentication flow. You can customize the Page Title visibility and the Toolbar color by using the `CustomTabsOptions` class.
+ 
+```java
+ CustomTabsOptions options = CustomTabsOptions.newBuilder()
+    .withToolbarColor(R.color.ct_toolbar_color)
+    .showTitle(true)
+    .build();
+ 
+  WebAuthProvider.init(account)
+                  .withCustomTabsOptions(options)
+                  .start(MainActivity.this, authCallback);
+```
+
+
 ## Next steps
 
 ### Learning resources

--- a/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.java
@@ -15,20 +15,22 @@ public class AuthenticationActivity extends Activity {
     static final String EXTRA_USE_FULL_SCREEN = "com.auth0.android.EXTRA_USE_FULL_SCREEN";
     static final String EXTRA_CONNECTION_NAME = "com.auth0.android.EXTRA_CONNECTION_NAME";
     static final String EXTRA_AUTHORIZE_URI = "com.auth0.android.EXTRA_AUTHORIZE_URI";
-    private static final String EXTRA_INTENT_LAUNCHED = "com.auth0.android.EXTRA_INTENT_LAUNCHED";
+    static final String EXTRA_INTENT_LAUNCHED = "com.auth0.android.EXTRA_INTENT_LAUNCHED";
+    static final String EXTRA_CT_OPTIONS = "com.auth0.android.EXTRA_CT_OPTIONS";
 
     private boolean intentLaunched;
     private CustomTabsController customTabsController;
 
-    static void authenticateUsingBrowser(Context context, Uri authorizeUri) {
+    static void authenticateUsingBrowser(@NonNull Context context, @NonNull Uri authorizeUri, @Nullable CustomTabsOptions options) {
         Intent intent = new Intent(context, AuthenticationActivity.class);
         intent.putExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI, authorizeUri);
         intent.putExtra(AuthenticationActivity.EXTRA_USE_BROWSER, true);
+        intent.putExtra(AuthenticationActivity.EXTRA_CT_OPTIONS, options);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         context.startActivity(intent);
     }
 
-    static void authenticateUsingWebView(Activity activity, Uri authorizeUri, int requestCode, String connection, boolean useFullScreen) {
+    static void authenticateUsingWebView(@NonNull Activity activity, @NonNull Uri authorizeUri, int requestCode, String connection, boolean useFullScreen) {
         Intent intent = new Intent(activity, AuthenticationActivity.class);
         intent.putExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI, authorizeUri);
         intent.putExtra(AuthenticationActivity.EXTRA_USE_BROWSER, false);
@@ -105,6 +107,7 @@ public class AuthenticationActivity extends Activity {
         }
 
         customTabsController = createCustomTabsController(this);
+        customTabsController.setCustomizationOptions((CustomTabsOptions) extras.getParcelable(EXTRA_CT_OPTIONS));
         customTabsController.bindService();
         customTabsController.launchUri(authorizeUri);
     }

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -124,6 +124,7 @@ class CustomTabsController extends CustomTabsServiceConnection {
                 Log.d(TAG, "Launching URI. Custom Tabs available: " + available);
 
                 final Intent intent = new CustomTabsIntent.Builder(session.get())
+                        .setShowTitle(true)
                         .build()
                         .intent;
                 intent.setData(uri);

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
@@ -74,6 +74,7 @@ public class CustomTabsOptions implements Parcelable {
     };
 
 
+    @SuppressWarnings("WeakerAccess")
     public static class Builder {
         @ColorRes
         private int toolbarColor;

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
@@ -1,0 +1,120 @@
+package com.auth0.android.provider;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.ColorRes;
+import android.support.customtabs.CustomTabsIntent;
+import android.support.customtabs.CustomTabsSession;
+import android.support.v4.content.ContextCompat;
+
+/**
+ * Holder for Custom Tabs customization options. Use {@link CustomTabsOptions#newBuilder()} to begin.
+ */
+public class CustomTabsOptions implements Parcelable {
+
+    private final boolean showTitle;
+    @ColorRes
+    private final int toolbarColor;
+
+    private CustomTabsOptions(boolean showTitle, @ColorRes int toolbarColor) {
+        this.showTitle = showTitle;
+        this.toolbarColor = toolbarColor;
+    }
+
+    /**
+     * Create a new CustomTabsOptions.Builder instance.
+     *
+     * @return a new CustomTabsOptions.Builder ready to customize.
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+
+    Intent toIntent(Context context, CustomTabsSession session) {
+        final CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(session)
+                .setShowTitle(showTitle);
+        if (toolbarColor > 0) {
+            //Resource exists
+            builder.setToolbarColor(ContextCompat.getColor(context, toolbarColor));
+        }
+        return builder.build().intent;
+    }
+
+
+    protected CustomTabsOptions(Parcel in) {
+        showTitle = in.readByte() != 0x00;
+        toolbarColor = in.readInt();
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeByte((byte) (showTitle ? 0x01 : 0x00));
+        dest.writeInt(toolbarColor);
+    }
+
+    @SuppressWarnings("unused")
+    public static final Parcelable.Creator<CustomTabsOptions> CREATOR = new Parcelable.Creator<CustomTabsOptions>() {
+        @Override
+        public CustomTabsOptions createFromParcel(Parcel in) {
+            return new CustomTabsOptions(in);
+        }
+
+        @Override
+        public CustomTabsOptions[] newArray(int size) {
+            return new CustomTabsOptions[size];
+        }
+    };
+
+
+    public static class Builder {
+        @ColorRes
+        private int toolbarColor;
+        private boolean showTitle;
+
+        private Builder() {
+            this.showTitle = false;
+            this.toolbarColor = 0;
+        }
+
+        /**
+         * Change the Custom Tab toolbar color to the given one.
+         *
+         * @param toolbarColor the new toolbar color to set
+         * @return this same builder instance.
+         */
+        public Builder withToolbarColor(@ColorRes int toolbarColor) {
+            this.toolbarColor = toolbarColor;
+            return this;
+        }
+
+        /**
+         * Whether to make the Custom Tab show the Page Title in the toolbar or not.
+         * By default, the Page Title will be hidden.
+         *
+         * @param showTitle whether to show the Page Title in the toolbar or not.
+         * @return this same builder instance.
+         */
+        public Builder showTitle(boolean showTitle) {
+            this.showTitle = showTitle;
+            return this;
+        }
+
+        /**
+         * Create a new CustomTabsOptions instance with the customization settings.
+         *
+         * @return an instance of CustomTabsOptions with the customization settings.
+         */
+        public CustomTabsOptions build() {
+            return new CustomTabsOptions(showTitle, toolbarColor);
+        }
+    }
+
+}

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -62,6 +62,7 @@ class OAuthManager {
     private int requestCode;
     private PKCE pkce;
     private Long currentTimeInMillis;
+    private CustomTabsOptions ctOptions;
 
     OAuthManager(@NonNull Auth0 account, @NonNull AuthCallback callback, @NonNull Map<String, String> parameters) {
         this.account = account;
@@ -77,6 +78,10 @@ class OAuthManager {
         this.useBrowser = useBrowser;
     }
 
+    public void setCustomTabsOptions(@Nullable CustomTabsOptions options) {
+        this.ctOptions = options;
+    }
+
     @VisibleForTesting
     void setPKCE(PKCE pkce) {
         this.pkce = pkce;
@@ -90,7 +95,7 @@ class OAuthManager {
         this.requestCode = requestCode;
 
         if (useBrowser) {
-            AuthenticationActivity.authenticateUsingBrowser(activity, uri);
+            AuthenticationActivity.authenticateUsingBrowser(activity, uri, ctOptions);
         } else {
             AuthenticationActivity.authenticateUsingWebView(activity, uri, requestCode, parameters.get(KEY_CONNECTION), useFullScreen);
         }
@@ -257,6 +262,11 @@ class OAuthManager {
     @VisibleForTesting
     boolean useFullScreen() {
         return useFullScreen;
+    }
+
+    @VisibleForTesting
+    CustomTabsOptions customTabsOptions() {
+        return ctOptions;
     }
 
     @VisibleForTesting

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -72,6 +72,7 @@ public class WebAuthProvider {
         private boolean useFullscreen;
         private PKCE pkce;
         private String scheme;
+        private CustomTabsOptions ctOptions;
 
         Builder(Auth0 account) {
             this.account = account;
@@ -249,6 +250,17 @@ public class WebAuthProvider {
             return this;
         }
 
+        /**
+         * When using a Custom Tabs compatible Browser, apply this customization options.
+         *
+         * @param options the Custom Tabs customization options
+         * @return the current builder instance
+         */
+        public Builder withCustomTabsOptions(@NonNull CustomTabsOptions options) {
+            this.ctOptions = options;
+            return this;
+        }
+
         @VisibleForTesting
         Builder withPKCE(PKCE pkce) {
             this.pkce = pkce;
@@ -275,6 +287,7 @@ public class WebAuthProvider {
             OAuthManager manager = new OAuthManager(account, callback, values);
             manager.useFullScreen(useFullscreen);
             manager.useBrowser(useBrowser);
+            manager.setCustomTabsOptions(ctOptions);
             manager.setPKCE(pkce);
 
             managerInstance = manager;

--- a/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
@@ -45,6 +45,8 @@ public class AuthenticationActivityTest {
     private Uri resultUri;
     @Mock
     private CustomTabsController customTabsController;
+    @Mock
+    private CustomTabsOptions customTabsOptions;
     @Captor
     private ArgumentCaptor<Intent> intentCaptor;
     @Captor
@@ -71,7 +73,7 @@ public class AuthenticationActivityTest {
     @SuppressWarnings("deprecation")
     @Test
     public void shouldAuthenticateUsingBrowser() throws Exception {
-        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri);
+        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions);
         verify(callerActivity).startActivity(intentCaptor.capture());
 
         createActivity(intentCaptor.getValue());
@@ -102,7 +104,7 @@ public class AuthenticationActivityTest {
     @SuppressWarnings("deprecation")
     @Test
     public void shouldAuthenticateAfterRecreatedUsingBrowser() throws Exception {
-        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri);
+        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions);
         verify(callerActivity).startActivity(intentCaptor.capture());
 
         createActivity(intentCaptor.getValue());
@@ -131,7 +133,7 @@ public class AuthenticationActivityTest {
     @SuppressWarnings("deprecation")
     @Test
     public void shouldCancelAuthenticationUsingBrowser() throws Exception {
-        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri);
+        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions);
         verify(callerActivity).startActivity(intentCaptor.capture());
 
         createActivity(intentCaptor.getValue());
@@ -263,7 +265,7 @@ public class AuthenticationActivityTest {
     @SuppressWarnings("deprecation")
     @Test
     public void shouldLaunchForBrowserAuthentication() throws Exception {
-        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri);
+        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions);
         verify(callerActivity).startActivity(intentCaptor.capture());
 
         Intent intent = intentCaptor.getValue();
@@ -278,6 +280,7 @@ public class AuthenticationActivityTest {
         Assert.assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(false));
         Assert.assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
         Assert.assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
+        Assert.assertThat((CustomTabsOptions) extras.getParcelable(AuthenticationActivity.EXTRA_CT_OPTIONS), is(customTabsOptions));
     }
 
     @SuppressWarnings("deprecation")
@@ -300,6 +303,7 @@ public class AuthenticationActivityTest {
         Assert.assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(true));
         Assert.assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
         Assert.assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_BROWSER), is(false));
+        Assert.assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_CT_OPTIONS), is(false));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -37,6 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -163,6 +164,8 @@ public class CustomTabsControllerTest {
         Intent intent = launchIntentCaptor.getValue();
         assertThat(intent.getAction(), is(Intent.ACTION_VIEW));
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_SESSION), is(true));
+        assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
+        assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(not(CustomTabsIntent.NO_TITLE)));
         assertThat(intent.getData(), is(uri));
         assertThat(intent, not(hasFlag(Intent.FLAG_ACTIVITY_NO_HISTORY)));
     }
@@ -203,12 +206,15 @@ public class CustomTabsControllerTest {
         assertThat(customTabIntent.getData(), is(uri));
         assertThat(customTabIntent, not(hasFlag(Intent.FLAG_ACTIVITY_NO_HISTORY)));
         assertThat(customTabIntent.hasExtra(CustomTabsIntent.EXTRA_SESSION), is(true));
+        assertThat(customTabIntent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
+        assertThat(customTabIntent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(not(CustomTabsIntent.NO_TITLE)));
 
         Intent fallbackIntent = intents.get(1);
         assertThat(fallbackIntent.getAction(), is(Intent.ACTION_VIEW));
         assertThat(fallbackIntent.getData(), is(uri));
         assertThat(fallbackIntent, hasFlag(Intent.FLAG_ACTIVITY_NO_HISTORY));
         assertThat(fallbackIntent.hasExtra(CustomTabsIntent.EXTRA_SESSION), is(false));
+        assertThat(fallbackIntent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(false));
     }
 
     //Helper Methods

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
@@ -1,0 +1,78 @@
+package com.auth0.android.provider;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.customtabs.CustomTabsIntent;
+import android.support.v4.content.ContextCompat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = com.auth0.android.auth0.BuildConfig.class, sdk = 21, manifest = Config.NONE)
+public class CustomTabsOptionsTest {
+
+    private Activity context;
+
+    @Before
+    public void setUp() throws Exception {
+        context = Robolectric.setupActivity(Activity.class);
+    }
+
+    @Test
+    public void shouldCreateNewBuilder() throws Exception {
+        CustomTabsOptions.Builder builder = CustomTabsOptions.newBuilder();
+        assertThat(builder, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldHaveDefaultValues() throws Exception {
+        CustomTabsOptions options = CustomTabsOptions.newBuilder().build();
+        assertThat(options, is(notNullValue()));
+
+        Intent intent = options.toIntent(context, null);
+
+        assertThat(intent, is(notNullValue()));
+        assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(false));
+        assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
+        assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(0));
+        assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.NO_TITLE));
+    }
+
+    @Test
+    public void shouldSetShowTitle() throws Exception {
+        CustomTabsOptions options = CustomTabsOptions.newBuilder()
+                .showTitle(true)
+                .build();
+        assertThat(options, is(notNullValue()));
+
+        Intent intent = options.toIntent(context, null);
+
+        assertThat(intent, is(notNullValue()));
+        assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
+        assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.SHOW_PAGE_TITLE));
+    }
+
+    @Test
+    public void shouldSetToolbarColor() throws Exception {
+        CustomTabsOptions options = CustomTabsOptions.newBuilder()
+                .withToolbarColor(android.R.color.black)
+                .build();
+        assertThat(options, is(notNullValue()));
+
+        Intent intent = options.toIntent(context, null);
+
+        assertThat(intent, is(notNullValue()));
+        assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(true));
+        int resolvedColor = ContextCompat.getColor(context, android.R.color.black);
+        assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(resolvedColor));
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
@@ -2,6 +2,7 @@ package com.auth0.android.provider;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Parcel;
 import android.support.customtabs.CustomTabsIntent;
 import android.support.v4.content.ContextCompat;
 
@@ -45,6 +46,20 @@ public class CustomTabsOptionsTest {
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
         assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(0));
         assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.NO_TITLE));
+
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
+        assertThat(parceledOptions, is(notNullValue()));
+
+        Intent parceledIntent = parceledOptions.toIntent(context, null);
+        assertThat(parceledIntent, is(notNullValue()));
+        assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(false));
+        assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
+        assertThat(parceledIntent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(0));
+        assertThat(parceledIntent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.NO_TITLE));
     }
 
     @Test
@@ -59,6 +74,18 @@ public class CustomTabsOptionsTest {
         assertThat(intent, is(notNullValue()));
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
         assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.SHOW_PAGE_TITLE));
+
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
+        assertThat(parceledOptions, is(notNullValue()));
+
+        Intent parceledIntent = parceledOptions.toIntent(context, null);
+        assertThat(parceledIntent, is(notNullValue()));
+        assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
+        assertThat(parceledIntent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.SHOW_PAGE_TITLE));
     }
 
     @Test
@@ -74,5 +101,17 @@ public class CustomTabsOptionsTest {
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(true));
         int resolvedColor = ContextCompat.getColor(context, android.R.color.black);
         assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(resolvedColor));
+
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
+        assertThat(parceledOptions, is(notNullValue()));
+
+        Intent parceledIntent = parceledOptions.toIntent(context, null);
+        assertThat(parceledIntent, is(notNullValue()));
+        assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(true));
+        assertThat(parceledIntent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(resolvedColor));
     }
 }

--- a/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
@@ -18,9 +18,11 @@ import java.util.Date;
 import java.util.HashMap;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 
 @RunWith(RobolectricTestRunner.class)
@@ -64,6 +66,20 @@ public class OAuthManagerTest {
         OAuthManager manager = new OAuthManager(account, callback, new HashMap<String, String>());
         manager.useFullScreen(true);
         assertTrue(manager.useFullScreen());
+    }
+
+    @Test
+    public void shouldNotHaveCustomTabsOptionsByDefault() throws Exception {
+        OAuthManager manager = new OAuthManager(account, callback, new HashMap<String, String>());
+        assertThat(manager.customTabsOptions(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetCustomTabsOptions() throws Exception {
+        CustomTabsOptions options = mock(CustomTabsOptions.class);
+        OAuthManager manager = new OAuthManager(account, callback, new HashMap<String, String>());
+        manager.setCustomTabsOptions(options);
+        assertThat(manager.customTabsOptions(), is(options));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -949,6 +950,33 @@ public class WebAuthProviderTest {
 
     @SuppressWarnings("deprecation")
     @Test
+    public void shouldStartWithBrowserCustomTabsOptions() throws Exception {
+        CustomTabsOptions options = mock(CustomTabsOptions.class);
+        WebAuthProvider.init(account)
+                .withCustomTabsOptions(options)
+                .useCodeGrant(false)
+                .start(activity, callback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+
+        Intent intent = intentCaptor.getValue();
+        assertThat(intent, is(notNullValue()));
+        assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
+        assertThat(intent, hasFlag(Intent.FLAG_ACTIVITY_CLEAR_TOP));
+        assertThat(intent.getData(), is(nullValue()));
+
+        Bundle extras = intentCaptor.getValue().getExtras();
+        assertThat(extras.getParcelable(AuthenticationActivity.EXTRA_AUTHORIZE_URI), is(notNullValue()));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CONNECTION_NAME), is(false));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(false));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CT_OPTIONS), is(true));
+        assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
+        assertThat((CustomTabsOptions) extras.getParcelable(AuthenticationActivity.EXTRA_CT_OPTIONS), is(options));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
     public void shouldStartWithBrowser() throws Exception {
         WebAuthProvider.init(account)
                 .useBrowser(true)
@@ -968,7 +996,9 @@ public class WebAuthProviderTest {
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CONNECTION_NAME), is(false));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(false));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CT_OPTIONS), is(true));
         assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
+        assertThat(extras.getParcelable(AuthenticationActivity.EXTRA_CT_OPTIONS), is(nullValue()));
     }
 
     @SuppressWarnings("deprecation")
@@ -996,6 +1026,7 @@ public class WebAuthProviderTest {
         assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(false));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
         assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_BROWSER), is(false));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CT_OPTIONS), is(false));
     }
 
     @SuppressWarnings("deprecation")
@@ -1024,6 +1055,7 @@ public class WebAuthProviderTest {
         assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(true));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
         assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_BROWSER), is(false));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CT_OPTIONS), is(false));
     }
 
     @SuppressWarnings({"deprecation", "ThrowableResultOfMethodCallIgnored"})


### PR DESCRIPTION
Displaying the page title should be the default and only behavior, along with showing the current page domain. ~This PR doesn't add the ability to turn this off (hide title).~
A builder class is provided to customize the CT UI options.

Related: https://github.com/auth0/Auth0.Android/issues/106