### PR TITLE
Make Credential Managers save the refreshed value

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,11 +441,11 @@ This library ships with two additional classes that help you manage the Credenti
 
 ### Basic (Min API 15)
 
-The basic version supports asking for `Credentials` existence, storing them and getting them back. If the credentials have expired and a refresh_token was saved, they are automatically refreshed. The class is called `CredentialsManager`.
+The basic version supports asking for `Credentials` existence, storing them and getting them back. If the credentials have expired and a refresh_token was saved, they are automatically refreshed. The class is called `CredentialsManager` and requires at minimum Android API 15.
 
 #### Usage
 1. **Instantiate the manager:**
-You'll need an `AuthenticationAPIClient` instance to renew the credentials when they expire and a `Storage`. We provide a `SharedPreferencesStorage` that uses `SharedPreferences` to create a file in the application's directory with **Context.MODE_PRIVATE** mode. This implementation is thread safe and can either be obtained through a shared method or on demand.
+You'll need an `AuthenticationAPIClient` instance to renew the credentials when they expire and a `Storage` object. We provide a `SharedPreferencesStorage` class that makes use of `SharedPreferences` to create a file in the application's directory with **Context.MODE_PRIVATE** mode. This implementation is thread safe and can either be obtained through a shared method or on demand.
 
 ```java
 AuthenticationAPIClient authentication = new AuthenticationAPIClient(account);
@@ -507,7 +507,7 @@ manager.clearCredentials();
 
 ### Encryption enforced (Min API 21)
 
-This version expands the minimum version and adds encryption to the data storage. In those devices where a Secure LockScreen has been configured it can require the user authentication before letting them obtain the stored credentials. The class is called `SecureCredentialsManager`.
+This version expands the minimum version and adds encryption to the data storage. In those devices where a Secure LockScreen has been configured it can require the user authentication before letting them obtain the stored credentials. The class is called `SecureCredentialsManager` and requires at minimum Android API 21.
 
 
 #### Usage

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -65,7 +65,7 @@ public class CredentialsManager {
      */
     public void getCredentials(@NonNull final BaseCallback<Credentials, CredentialsManagerException> callback) {
         String accessToken = storage.retrieveString(KEY_ACCESS_TOKEN);
-        String refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN);
+        final String refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN);
         String idToken = storage.retrieveString(KEY_ID_TOKEN);
         String tokenType = storage.retrieveString(KEY_TOKEN_TYPE);
         Long expiresAt = storage.retrieveLong(KEY_EXPIRES_AT);
@@ -86,8 +86,11 @@ public class CredentialsManager {
 
         authClient.renewAuth(refreshToken).start(new AuthenticationCallback<Credentials>() {
             @Override
-            public void onSuccess(Credentials freshCredentials) {
-                callback.onSuccess(freshCredentials);
+            public void onSuccess(Credentials fresh) {
+                //RefreshTokens don't expire. It should remain the same
+                Credentials credentials = new Credentials(fresh.getIdToken(), fresh.getAccessToken(), fresh.getType(), refreshToken, fresh.getExpiresAt(), fresh.getScope());
+                saveCredentials(credentials);
+                callback.onSuccess(credentials);
             }
 
             @Override

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
@@ -16,6 +16,7 @@ import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.AuthenticationCallback;
 import com.auth0.android.callback.BaseCallback;
+import com.auth0.android.request.internal.GsonProvider;
 import com.auth0.android.result.Credentials;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -58,7 +59,7 @@ public class SecureCredentialsManager {
         this.apiClient = apiClient;
         this.storage = storage;
         this.crypto = crypto;
-        this.gson = new Gson();
+        this.gson = GsonProvider.buildGson();
         this.authenticateBeforeDecrypt = false;
     }
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
@@ -19,7 +19,6 @@ import com.auth0.android.callback.BaseCallback;
 import com.auth0.android.request.internal.GsonProvider;
 import com.auth0.android.result.Credentials;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 
 import static android.text.TextUtils.isEmpty;
 
@@ -94,8 +93,9 @@ public class SecureCredentialsManager {
         }
         KeyguardManager kManager = (KeyguardManager) activity.getSystemService(Context.KEYGUARD_SERVICE);
         this.authIntent = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP ? kManager.createConfirmDeviceCredentialIntent(title, description) : null;
-        this.authenticateBeforeDecrypt = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && kManager.isDeviceSecure()
-                || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && kManager.isKeyguardSecure()) && authIntent != null;
+        this.authenticateBeforeDecrypt = ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && kManager.isDeviceSecure())
+                || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && kManager.isKeyguardSecure()))
+                && authIntent != null;
         if (authenticateBeforeDecrypt) {
             this.activity = activity;
             this.authenticationRequestCode = requestCode;

--- a/auth0/src/main/java/com/auth0/android/request/internal/CredentialsDeserializer.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/CredentialsDeserializer.java
@@ -27,12 +27,23 @@ class CredentialsDeserializer implements JsonDeserializer<Credentials> {
         final String refreshToken = context.deserialize(object.remove("refresh_token"), String.class);
         final Long expiresIn = context.deserialize(object.remove("expires_in"), Long.class);
         final String scope = context.deserialize(object.remove("scope"), String.class);
-        final Date expiresAt = expiresIn == null ? null : new Date(getCurrentTimeInMillis() + expiresIn * 1000);
-        return new Credentials(idToken, accessToken, type, refreshToken, expiresAt, scope);
+        Date expiresAt = context.deserialize(object.remove("expires_at"), Date.class);
+        if (expiresAt == null && expiresIn != null) {
+            expiresAt = new Date(getCurrentTimeInMillis() + expiresIn * 1000);
+        }
+
+        return createCredentials(idToken, accessToken, type, refreshToken, expiresAt, scope);
     }
 
     @VisibleForTesting
     long getCurrentTimeInMillis() {
         return System.currentTimeMillis();
     }
+
+    @VisibleForTesting
+    Credentials createCredentials(String idToken, String accessToken, String type, String refreshToken, Date expiresAt, String scope) {
+        return new Credentials(idToken, accessToken, type, refreshToken, expiresAt, scope);
+    }
 }
+
+

--- a/auth0/src/main/java/com/auth0/android/request/internal/GsonProvider.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/GsonProvider.java
@@ -8,12 +8,14 @@ import com.google.gson.GsonBuilder;
 
 public abstract class GsonProvider {
 
+    static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+
     public static Gson buildGson() {
         return new GsonBuilder()
                 .registerTypeAdapterFactory(new JsonRequiredTypeAdapterFactory())
                 .registerTypeAdapter(UserProfile.class, new UserProfileDeserializer())
                 .registerTypeAdapter(Credentials.class, new CredentialsDeserializer())
-                .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+                .setDateFormat(DATE_FORMAT)
                 .create();
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/GsonProvider.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/GsonProvider.java
@@ -1,10 +1,16 @@
 package com.auth0.android.request.internal;
 
+import android.support.annotation.VisibleForTesting;
+
 import com.auth0.android.result.Credentials;
 import com.auth0.android.result.UserProfile;
 import com.auth0.android.util.JsonRequiredTypeAdapterFactory;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
 
 public abstract class GsonProvider {
 
@@ -17,5 +23,11 @@ public abstract class GsonProvider {
                 .registerTypeAdapter(Credentials.class, new CredentialsDeserializer())
                 .setDateFormat(DATE_FORMAT)
                 .create();
+    }
+
+    @VisibleForTesting
+    static String formatDate(Date date) {
+        SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT, Locale.US);
+        return sdf.format(date);
     }
 }

--- a/auth0/src/main/java/com/auth0/android/result/Credentials.java
+++ b/auth0/src/main/java/com/auth0/android/result/Credentials.java
@@ -64,6 +64,7 @@ public class Credentials {
     @SerializedName("scope")
     private String scope;
 
+    @SerializedName("expires_at")
     private Date expiresAt;
 
     //TODO: Deprecate this constructor

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.java
@@ -13,6 +13,7 @@ import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.BaseCallback;
 import com.auth0.android.request.ParameterizableRequest;
+import com.auth0.android.request.internal.GsonProvider;
 import com.auth0.android.result.Credentials;
 import com.auth0.android.result.CredentialsMock;
 import com.google.gson.Gson;
@@ -93,7 +94,7 @@ public class SecureCredentialsManagerTest {
         SecureCredentialsManager secureCredentialsManager = new SecureCredentialsManager(client, storage, crypto);
         manager = spy(secureCredentialsManager);
         doReturn(CredentialsMock.CURRENT_TIME_MS).when(manager).getCurrentTimeInMillis();
-        gson = new Gson();
+        gson = GsonProvider.buildGson();
     }
 
     @Test
@@ -392,8 +393,7 @@ public class SecureCredentialsManagerTest {
         assertThat(renewedStoredCredentials.getRefreshToken(), is("refreshToken"));
         assertThat(renewedStoredCredentials.getType(), is("newType"));
         assertThat(renewedStoredCredentials.getExpiresAt(), is(notNullValue()));
-        //Gson serializes to String dates and strips a few millis. Nothing critical..
-        assertThat(renewedStoredCredentials.getExpiresAt().toString(), is(newDate.toString()));
+        assertThat(renewedStoredCredentials.getExpiresAt().getTime(), is(newDate.getTime()));
         assertThat(renewedStoredCredentials.getScope(), is("newScope"));
     }
 
@@ -581,7 +581,7 @@ public class SecureCredentialsManagerTest {
         when(kService.isKeyguardSecure()).thenReturn(true);
         Intent confirmCredentialsIntent = mock(Intent.class);
         when(kService.createConfirmDeviceCredentialIntent("theTitle", "theDescription")).thenReturn(confirmCredentialsIntent);
-        boolean willRequireAuthentication = manager.requireAuthentication(activity, 123, "theTitle","theDescription");
+        boolean willRequireAuthentication = manager.requireAuthentication(activity, 123, "theTitle", "theDescription");
         assertThat(willRequireAuthentication, is(true));
 
         manager.getCredentials(callback);
@@ -625,7 +625,7 @@ public class SecureCredentialsManagerTest {
         when(kService.isKeyguardSecure()).thenReturn(true);
         Intent confirmCredentialsIntent = mock(Intent.class);
         when(kService.createConfirmDeviceCredentialIntent("theTitle", "theDescription")).thenReturn(confirmCredentialsIntent);
-        boolean willRequireAuthentication = manager.requireAuthentication(activity, 123, "theTitle","theDescription");
+        boolean willRequireAuthentication = manager.requireAuthentication(activity, 123, "theTitle", "theDescription");
         assertThat(willRequireAuthentication, is(true));
 
         manager.getCredentials(callback);

--- a/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerMock.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerMock.java
@@ -1,0 +1,19 @@
+package com.auth0.android.request.internal;
+
+import com.auth0.android.result.Credentials;
+import com.auth0.android.result.CredentialsMock;
+
+import java.util.Date;
+
+class CredentialsDeserializerMock extends CredentialsDeserializer {
+
+    @Override
+    long getCurrentTimeInMillis() {
+        return CredentialsMock.CURRENT_TIME_MS;
+    }
+
+    @Override
+    Credentials createCredentials(String idToken, String accessToken, String type, String refreshToken, Date expiresAt, String scope) {
+        return new CredentialsMock(idToken, accessToken, type, refreshToken, expiresAt, scope);
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerTest.java
@@ -1,5 +1,7 @@
 package com.auth0.android.request.internal;
 
+import android.support.annotation.NonNull;
+
 import com.auth0.android.result.Credentials;
 import com.auth0.android.result.CredentialsMock;
 import com.google.gson.Gson;
@@ -10,6 +12,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.FileReader;
+import java.util.Calendar;
+import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.core.Is.is;
@@ -18,7 +22,6 @@ import static org.junit.Assert.assertThat;
 public class CredentialsDeserializerTest {
 
     private static final String BASIC_CREDENTIALS = "src/test/resources/credentials.json";
-    private static final String EXPIRES_AT_CREDENTIALS = "src/test/resources/credentials_expires_at.json";
 
     private Gson gson;
 
@@ -41,12 +44,25 @@ public class CredentialsDeserializerTest {
 
     @Test
     public void shouldSetExpiresInFromExpiresAt() throws Exception {
-        final Credentials credentials = gson.getAdapter(Credentials.class).fromJson(new FileReader(EXPIRES_AT_CREDENTIALS));
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DAY_OF_YEAR, 7);
+        Date expiresAt = cal.getTime();
+        final Credentials credentials = gson.getAdapter(Credentials.class).fromJson(generateExpiresAtCredentialsJSON(expiresAt));
         assertThat(credentials.getExpiresAt(), is(notNullValue()));
         //The hardcoded value comes from the JSON file
-        assertThat(credentials.getExpiresAt().getTime(), is(1234691346555L));
+        assertThat(credentials.getExpiresAt().getTime(), is(expiresAt.getTime()));
         assertThat(credentials.getExpiresIn(), is(notNullValue()));
-        assertThat(credentials.getExpiresIn(), Matchers.is((1234691346555L - CredentialsMock.CURRENT_TIME_MS) / 1000));
+        assertThat(credentials.getExpiresIn(), Matchers.is((expiresAt.getTime() - CredentialsMock.CURRENT_TIME_MS) / 1000));
+    }
+
+
+    private String generateExpiresAtCredentialsJSON(@NonNull Date expiresAt) {
+        return "{\n" +
+                "\"access_token\": \"s6GS5FGJN2jfd4l6\",\n" +
+                "\"token_type\": \"bearer\",\n" +
+                "\"expires_in\": 86000,\n" +
+                "\"expires_at\": \"" + GsonProvider.formatDate(expiresAt) + "\"\n" +
+                "}";
     }
 
 }

--- a/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerTest.java
@@ -5,6 +5,8 @@ import com.auth0.android.result.CredentialsMock;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.FileReader;
@@ -12,27 +14,39 @@ import java.io.FileReader;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 
 public class CredentialsDeserializerTest {
 
-    private static final String OPEN_ID_OFFLINE_ACCESS_CREDENTIALS = "src/test/resources/credentials_openid_refresh_token.json";
+    private static final String BASIC_CREDENTIALS = "src/test/resources/credentials.json";
+    private static final String EXPIRES_AT_CREDENTIALS = "src/test/resources/credentials_expires_at.json";
 
-    private static final long CURRENT_TIME_MS = 1234567890000L;
+    private Gson gson;
+
+    @Before
+    public void setUp() throws Exception {
+        final CredentialsDeserializerMock deserializer = new CredentialsDeserializerMock();
+        gson = new GsonBuilder()
+                .setDateFormat(GsonProvider.DATE_FORMAT)
+                .registerTypeAdapter(Credentials.class, deserializer)
+                .create();
+    }
 
     @Test
     public void shouldSetExpiresAtFromExpiresIn() throws Exception {
-        final CredentialsDeserializer deserializer = new CredentialsDeserializer();
-        final CredentialsDeserializer spy = spy(deserializer);
-        doReturn(CredentialsMock.CURRENT_TIME_MS).when(spy).getCurrentTimeInMillis();
-
-        final Gson gson = new GsonBuilder()
-                .registerTypeAdapter(Credentials.class, spy)
-                .create();
-
-        final Credentials credentials = gson.getAdapter(Credentials.class).fromJson(new FileReader(OPEN_ID_OFFLINE_ACCESS_CREDENTIALS));
+        final Credentials credentials = gson.getAdapter(Credentials.class).fromJson(new FileReader(BASIC_CREDENTIALS));
+        assertThat(credentials.getExpiresIn(), is(86000L));
         assertThat(credentials.getExpiresAt(), is(notNullValue()));
-        assertThat(credentials.getExpiresAt().getTime(), is(CURRENT_TIME_MS + 86000 * 1000));
+        assertThat(credentials.getExpiresAt().getTime(), is(CredentialsMock.CURRENT_TIME_MS + 86000 * 1000));
     }
+
+    @Test
+    public void shouldSetExpiresInFromExpiresAt() throws Exception {
+        final Credentials credentials = gson.getAdapter(Credentials.class).fromJson(new FileReader(EXPIRES_AT_CREDENTIALS));
+        assertThat(credentials.getExpiresAt(), is(notNullValue()));
+        //The hardcoded value comes from the JSON file
+        assertThat(credentials.getExpiresAt().getTime(), is(1234691346555L));
+        assertThat(credentials.getExpiresIn(), is(notNullValue()));
+        assertThat(credentials.getExpiresIn(), Matchers.is((1234691346555L - CredentialsMock.CURRENT_TIME_MS) / 1000));
+    }
+
 }

--- a/auth0/src/test/java/com/auth0/android/request/internal/CredentialsGsonTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CredentialsGsonTest.java
@@ -1,6 +1,7 @@
 package com.auth0.android.request.internal;
 
 import com.auth0.android.result.Credentials;
+import com.auth0.android.result.CredentialsMock;
 import com.google.gson.JsonParseException;
 
 import org.junit.Before;
@@ -11,7 +12,10 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Date;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -22,6 +26,7 @@ public class CredentialsGsonTest extends GsonBaseTest {
     private static final String OPEN_ID_OFFLINE_ACCESS_CREDENTIALS = "src/test/resources/credentials_openid_refresh_token.json";
     private static final String OPEN_ID_CREDENTIALS = "src/test/resources/credentials_openid.json";
     private static final String BASIC_CREDENTIALS = "src/test/resources/credentials.json";
+    private static final String EXPIRES_AT_CREDENTIALS = "src/test/resources/credentials_expires_at.json";
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -67,6 +72,18 @@ public class CredentialsGsonTest extends GsonBaseTest {
     }
 
     @Test
+    public void shouldReturnWithExpiresAt() throws Exception {
+        final Credentials credentials = buildCredentialsFrom(json(EXPIRES_AT_CREDENTIALS));
+        assertThat(credentials, is(notNullValue()));
+        assertThat(credentials.getAccessToken(), is(notNullValue()));
+        assertThat(credentials.getType(), equalTo("bearer"));
+        assertThat(credentials.getExpiresIn(), is(not(86000L)));
+        assertThat(credentials.getExpiresAt(), is(notNullValue()));
+        //The hardcoded value comes from the JSON file
+        assertThat(credentials.getExpiresAt().getTime(), is(1234691346555L));
+    }
+
+    @Test
     public void shouldReturnWithIdToken() throws Exception {
         final Credentials credentials = buildCredentialsFrom(json(OPEN_ID_CREDENTIALS));
         assertThat(credentials, is(notNullValue()));
@@ -90,6 +107,30 @@ public class CredentialsGsonTest extends GsonBaseTest {
         assertThat(credentials.getExpiresIn(), is(86000L));
         assertThat(credentials.getExpiresAt(), is(notNullValue()));
         assertThat(credentials.getScope(), is("openid profile"));
+    }
+
+    @Test
+    public void shouldSerializeCredentials() throws Exception {
+        final Credentials expiresInCredentials = new CredentialsMock("id", "access", "ty", "refresh", 123456L);
+        final String expiresInJson = gson.toJson(expiresInCredentials);
+        assertThat(expiresInJson, containsString("\"id_token\":\"id\""));
+        assertThat(expiresInJson, containsString("\"access_token\":\"access\""));
+        assertThat(expiresInJson, containsString("\"token_type\":\"ty\""));
+        assertThat(expiresInJson, containsString("\"refresh_token\":\"refresh\""));
+        assertThat(expiresInJson, containsString("\"expires_in\":123456"));
+        assertThat(expiresInJson, containsString("\"expires_at\":\"2009-02-15T07:49:07.234Z\""));
+        assertThat(expiresInJson, not(containsString("\"scope\"")));
+
+
+        final Credentials expiresAtCredentials = new CredentialsMock("id", "access", "ty", "refresh", new Date(CredentialsMock.CURRENT_TIME_MS + 123456 * 1000), "openid");
+        final String expiresAtJson = gson.toJson(expiresAtCredentials);
+        assertThat(expiresAtJson, containsString("\"id_token\":\"id\""));
+        assertThat(expiresAtJson, containsString("\"access_token\":\"access\""));
+        assertThat(expiresAtJson, containsString("\"token_type\":\"ty\""));
+        assertThat(expiresAtJson, containsString("\"refresh_token\":\"refresh\""));
+        assertThat(expiresAtJson, containsString("\"expires_in\":123456"));
+        assertThat(expiresAtJson, containsString("\"expires_at\":\"2009-02-15T07:49:07.234Z\""));
+        assertThat(expiresAtJson, containsString("\"scope\":\"openid\""));
     }
 
     private Credentials buildCredentialsFrom(Reader json) throws IOException {

--- a/auth0/src/test/java/com/auth0/android/request/internal/UserProfileGsonTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/UserProfileGsonTest.java
@@ -182,7 +182,7 @@ public class UserProfileGsonTest extends GsonBaseTest {
         assertThat(profile.getGivenName(), equalTo("John"));
         assertThat(profile.getFamilyName(), equalTo("Foobar"));
         assertThat(profile.isEmailVerified(), is(false));
-        assertThat(profile.getCreatedAt(), equalTo(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").parse("2014-07-06T18:33:49.005Z")));
+        assertThat(profile.getCreatedAt(), equalTo(new SimpleDateFormat(GsonProvider.DATE_FORMAT).parse("2014-07-06T18:33:49.005Z")));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/request/internal/UserProfileGsonTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/UserProfileGsonTest.java
@@ -12,6 +12,7 @@ import org.junit.rules.ExpectedException;
 import java.io.StringReader;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Locale;
 
 import static com.auth0.android.util.UserIdentityMatcher.isUserIdentity;
 import static com.auth0.android.util.UserProfileMatcher.isNormalizedProfile;
@@ -182,7 +183,7 @@ public class UserProfileGsonTest extends GsonBaseTest {
         assertThat(profile.getGivenName(), equalTo("John"));
         assertThat(profile.getFamilyName(), equalTo("Foobar"));
         assertThat(profile.isEmailVerified(), is(false));
-        assertThat(profile.getCreatedAt(), equalTo(new SimpleDateFormat(GsonProvider.DATE_FORMAT).parse("2014-07-06T18:33:49.005Z")));
+        assertThat(profile.getCreatedAt(), equalTo(new SimpleDateFormat(GsonProvider.DATE_FORMAT, Locale.US).parse("2014-07-06T18:33:49.005Z")));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsMock.java
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsMock.java
@@ -9,7 +9,7 @@ import java.util.TimeZone;
 @SuppressWarnings("WeakerAccess")
 public class CredentialsMock extends Credentials {
 
-    public static final long CURRENT_TIME_MS = 1234567891234L;
+    public static final long CURRENT_TIME_MS = calculateCurrentTime();
 
     public CredentialsMock(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Long expiresIn) {
         super(idToken, accessToken, type, refreshToken, expiresIn);
@@ -21,9 +21,12 @@ public class CredentialsMock extends Credentials {
 
     @Override
     long getCurrentTimeInMillis() {
+        return CURRENT_TIME_MS;
+    }
+
+    private static long calculateCurrentTime() {
         Calendar cal = Calendar.getInstance();
         cal.setTimeZone(TimeZone.getTimeZone("UTC"));
-        cal.setTimeInMillis(CURRENT_TIME_MS);
         return cal.getTimeInMillis();
     }
 }

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsMock.java
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsMock.java
@@ -2,12 +2,14 @@ package com.auth0.android.result;
 
 import android.support.annotation.Nullable;
 
+import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 @SuppressWarnings("WeakerAccess")
 public class CredentialsMock extends Credentials {
 
-    public static final long CURRENT_TIME_MS = 1234567890000L;
+    public static final long CURRENT_TIME_MS = 1234567891234L;
 
     public CredentialsMock(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Long expiresIn) {
         super(idToken, accessToken, type, refreshToken, expiresIn);
@@ -19,6 +21,9 @@ public class CredentialsMock extends Credentials {
 
     @Override
     long getCurrentTimeInMillis() {
-        return CURRENT_TIME_MS;
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeZone(TimeZone.getTimeZone("UTC"));
+        cal.setTimeInMillis(CURRENT_TIME_MS);
+        return cal.getTimeInMillis();
     }
 }

--- a/auth0/src/test/resources/credentials_expires_at.json
+++ b/auth0/src/test/resources/credentials_expires_at.json
@@ -1,0 +1,6 @@
+{
+    "access_token": "s6GS5FGJN2jfd4l6",
+    "token_type": "bearer",
+    "expires_in": 86000,
+    "expires_at": "2009-02-15T07:49:06.555Z"
+}


### PR DESCRIPTION
~My only concern in this PR is that when serializing the `Credentials` object, Gson (our Json library) will serialize Java Dates to a string value (not long timestamps), thus losing the precision (milis). Should I make the serializer serialize Longs instead? (I've to code that logic) or is it an edge case and we're ok having a 1 second expired `Credentials`?~
EDIT: Fixed. Now Gson serializes dates in a correct format including Timezone and Millis.

Depends on this PR getting merged: https://github.com/auth0/Auth0.Android/pull/115. Once merged, a rebase will make diff clearer here.

Closes https://github.com/auth0/Auth0.Android/issues/109