### PR TITLE
Fix bug when canceling WebAuth flow

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.java
@@ -14,6 +14,7 @@ public class AuthenticationActivity extends Activity {
     static final String EXTRA_USE_BROWSER = "com.auth0.android.EXTRA_USE_BROWSER";
     static final String EXTRA_USE_FULL_SCREEN = "com.auth0.android.EXTRA_USE_FULL_SCREEN";
     static final String EXTRA_CONNECTION_NAME = "com.auth0.android.EXTRA_CONNECTION_NAME";
+    static final String EXTRA_AUTHORIZE_URI = "com.auth0.android.EXTRA_AUTHORIZE_URI";
     private static final String EXTRA_INTENT_LAUNCHED = "com.auth0.android.EXTRA_INTENT_LAUNCHED";
 
     private boolean intentLaunched;
@@ -21,7 +22,7 @@ public class AuthenticationActivity extends Activity {
 
     static void authenticateUsingBrowser(Context context, Uri authorizeUri) {
         Intent intent = new Intent(context, AuthenticationActivity.class);
-        intent.setData(authorizeUri);
+        intent.putExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI, authorizeUri);
         intent.putExtra(AuthenticationActivity.EXTRA_USE_BROWSER, true);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         context.startActivity(intent);
@@ -29,7 +30,7 @@ public class AuthenticationActivity extends Activity {
 
     static void authenticateUsingWebView(Activity activity, Uri authorizeUri, int requestCode, String connection, boolean useFullScreen) {
         Intent intent = new Intent(activity, AuthenticationActivity.class);
-        intent.setData(authorizeUri);
+        intent.putExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI, authorizeUri);
         intent.putExtra(AuthenticationActivity.EXTRA_USE_BROWSER, false);
         intent.putExtra(AuthenticationActivity.EXTRA_USE_FULL_SCREEN, useFullScreen);
         intent.putExtra(AuthenticationActivity.EXTRA_CONNECTION_NAME, connection);
@@ -77,6 +78,7 @@ public class AuthenticationActivity extends Activity {
         if (getIntent().getData() != null) {
             deliverSuccessfulAuthenticationResult(getIntent());
         }
+        setResult(RESULT_CANCELED);
         finish();
     }
 
@@ -91,7 +93,7 @@ public class AuthenticationActivity extends Activity {
 
     private void launchAuthenticationIntent() {
         Bundle extras = getIntent().getExtras();
-        final Uri authorizeUri = getIntent().getData();
+        Uri authorizeUri = extras.getParcelable(EXTRA_AUTHORIZE_URI);
         if (!extras.getBoolean(EXTRA_USE_BROWSER, true)) {
             Intent intent = new Intent(this, WebAuthActivity.class);
             intent.setData(authorizeUri);

--- a/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
@@ -23,6 +23,7 @@ import org.robolectric.util.ActivityController;
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasData;
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasFlag;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
@@ -144,9 +145,6 @@ public class AuthenticationActivityTest {
         activityController.pause().stop();
         //Browser is shown
 
-        Intent authenticationResultIntent = new Intent();
-        authenticationResultIntent.setData(null);
-        activityController.newIntent(authenticationResultIntent);
         activityController.start().resume();
 
         assertThat(activity.getDeliveredIntent(), is(nullValue()));
@@ -254,9 +252,7 @@ public class AuthenticationActivityTest {
         activityController.pause().stop();
         //WebViewActivity is shown
 
-        Intent authenticationResultIntent = new Intent();
-        authenticationResultIntent.setData(resultUri);
-        activityShadow.receiveResult(webViewIntent.intent, Activity.RESULT_CANCELED, authenticationResultIntent);
+        activityShadow.receiveResult(webViewIntent.intent, Activity.RESULT_CANCELED, null);
 
         assertThat(activity.getDeliveredIntent(), is(nullValue()));
         assertThat(activity.isFinishing(), is(true));
@@ -274,9 +270,10 @@ public class AuthenticationActivityTest {
         Assert.assertThat(intent, is(notNullValue()));
         Assert.assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
         Assert.assertThat(intent, hasFlag(Intent.FLAG_ACTIVITY_CLEAR_TOP));
-        Assert.assertThat(intent, hasData(uri));
+        Assert.assertThat(intent, not(hasData(uri)));
 
         Bundle extras = intent.getExtras();
+        Assert.assertThat((Uri) extras.getParcelable(AuthenticationActivity.EXTRA_AUTHORIZE_URI), is(uri));
         Assert.assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CONNECTION_NAME), is(false));
         Assert.assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(false));
         Assert.assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
@@ -293,9 +290,10 @@ public class AuthenticationActivityTest {
         Assert.assertThat(intent, is(notNullValue()));
         Assert.assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
         Assert.assertThat(intent, hasFlag(Intent.FLAG_ACTIVITY_CLEAR_TOP));
-        Assert.assertThat(intent, hasData(uri));
+        Assert.assertThat(intent, not(hasData(uri)));
 
         Bundle extras = intentCaptor.getValue().getExtras();
+        Assert.assertThat((Uri) extras.getParcelable(AuthenticationActivity.EXTRA_AUTHORIZE_URI), is(uri));
         Assert.assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CONNECTION_NAME), is(true));
         Assert.assertThat(extras.getString(AuthenticationActivity.EXTRA_CONNECTION_NAME), is("facebook"));
         Assert.assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(true));

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -139,7 +139,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .start(activity, callback);
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithName("redirect_uri"));
@@ -154,7 +154,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithName("redirect_uri"));
@@ -170,7 +170,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, not(hasParamWithName("connection")));
@@ -185,7 +185,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("connection", "my-connection"));
@@ -200,7 +200,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("connection", "some-connection"));
@@ -214,7 +214,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("connection", "my-connection"));
@@ -227,7 +227,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("connection", "some-connection"));
@@ -241,7 +241,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, not(hasParamWithName("audience")));
@@ -256,7 +256,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("audience", "https://mydomain.auth0.com/myapi"));
@@ -271,7 +271,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("audience", "https://google.com/apis"));
@@ -285,7 +285,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("audience", "https://mydomain.auth0.com/myapi"));
@@ -298,7 +298,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("audience", "https://google.com/apis"));
@@ -313,7 +313,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("scope", "openid"));
@@ -328,7 +328,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("scope", "openid email contacts"));
@@ -343,7 +343,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("scope", "profile super_scope"));
@@ -357,7 +357,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("scope", "openid email contacts"));
@@ -370,7 +370,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("scope", "profile super_scope"));
@@ -385,7 +385,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, not(hasParamWithName("connection_scope")));
@@ -400,7 +400,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("connection_scope", "openid email contacts"));
@@ -415,7 +415,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("connection_scope", "profile super_scope"));
@@ -429,7 +429,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("connection_scope", "openid email contacts"));
@@ -442,7 +442,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("connection_scope", "the scope of my connection"));
@@ -457,7 +457,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue(is("state"), not(isEmptyOrNullString())));
@@ -470,7 +470,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue(is("state"), not(isEmptyOrNullString())));
@@ -485,7 +485,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("state", "1234567890"));
@@ -500,7 +500,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("state", "abcdefg"));
@@ -514,7 +514,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("state", "1234567890"));
@@ -527,7 +527,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("state", "abcdefg"));
@@ -542,7 +542,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, not(hasParamWithName("nonce")));
@@ -555,7 +555,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, not(hasParamWithName("nonce")));
@@ -568,7 +568,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue(is("nonce"), not(isEmptyOrNullString())));
@@ -582,7 +582,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue(is("nonce"), not(isEmptyOrNullString())));
@@ -596,7 +596,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("nonce", "1234567890"));
@@ -610,7 +610,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("nonce", "1234567890"));
@@ -626,7 +626,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("nonce", "1234567890"));
@@ -642,7 +642,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("nonce", "abcdefg"));
@@ -657,7 +657,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("nonce", "1234567890"));
@@ -671,7 +671,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("nonce", "abcdefg"));
@@ -709,7 +709,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("client_id", "clientId"));
@@ -721,7 +721,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue(is("auth0Client"), not(isEmptyOrNullString())));
@@ -733,7 +733,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("redirect_uri", "https://domain/android/com.auth0.android.auth0/callback"));
@@ -747,7 +747,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("response_type", "code"));
@@ -760,7 +760,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("response_type", "token"));
@@ -773,7 +773,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("response_type", "id_token"));
@@ -786,7 +786,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("response_type", "code"));
@@ -799,7 +799,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("response_type", "code token"));
@@ -812,7 +812,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("response_type", "code id_token"));
@@ -825,7 +825,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("response_type", "id_token token"));
@@ -838,7 +838,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("response_type", "code id_token token"));
@@ -854,7 +854,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("a", "valid"));
@@ -867,7 +867,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         Set<String> params = uri.getQueryParameterNames();
@@ -887,7 +887,7 @@ public class WebAuthProviderTest {
 
         Uri baseUriString = Uri.parse(account.getAuthorizeUrl());
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasScheme(baseUriString.getScheme()));
@@ -904,7 +904,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("nonce", "a-nonce"));
@@ -921,7 +921,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, not(hasParamWithName("nonce")));
@@ -938,7 +938,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, not(hasParamWithName("nonce")));
@@ -961,9 +961,10 @@ public class WebAuthProviderTest {
         assertThat(intent, is(notNullValue()));
         assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
         assertThat(intent, hasFlag(Intent.FLAG_ACTIVITY_CLEAR_TOP));
-        assertThat(intent.getData(), is(notNullValue()));
+        assertThat(intent.getData(), is(nullValue()));
 
         Bundle extras = intentCaptor.getValue().getExtras();
+        assertThat(extras.getParcelable(AuthenticationActivity.EXTRA_AUTHORIZE_URI), is(notNullValue()));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CONNECTION_NAME), is(false));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(false));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
@@ -985,9 +986,10 @@ public class WebAuthProviderTest {
         assertThat(intent, is(notNullValue()));
         assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
         assertThat(intent, hasFlag(Intent.FLAG_ACTIVITY_CLEAR_TOP));
-        assertThat(intent.getData(), is(notNullValue()));
+        assertThat(intent.getData(), is(nullValue()));
 
         Bundle extras = intentCaptor.getValue().getExtras();
+        assertThat(extras.getParcelable(AuthenticationActivity.EXTRA_AUTHORIZE_URI), is(notNullValue()));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CONNECTION_NAME), is(true));
         assertThat(extras.getString(AuthenticationActivity.EXTRA_CONNECTION_NAME), is(nullValue()));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(true));
@@ -1012,9 +1014,10 @@ public class WebAuthProviderTest {
         assertThat(intent, is(notNullValue()));
         assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
         assertThat(intent, hasFlag(Intent.FLAG_ACTIVITY_CLEAR_TOP));
-        assertThat(intent.getData(), is(notNullValue()));
+        assertThat(intent.getData(), is(nullValue()));
 
         Bundle extras = intent.getExtras();
+        assertThat(extras.getParcelable(AuthenticationActivity.EXTRA_AUTHORIZE_URI), is(notNullValue()));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CONNECTION_NAME), is(true));
         assertThat(extras.getString(AuthenticationActivity.EXTRA_CONNECTION_NAME), is("my-connection"));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(true));
@@ -1050,7 +1053,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback, REQUEST_CODE);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         String sentState = uri.getQueryParameter(KEY_STATE);
@@ -1070,7 +1073,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         String sentState = uri.getQueryParameter(KEY_STATE);
@@ -1125,7 +1128,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         String sentState = uri.getQueryParameter(KEY_STATE);
@@ -1164,7 +1167,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback, REQUEST_CODE);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         String sentState = uri.getQueryParameter(KEY_STATE);
@@ -1192,7 +1195,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         String sentState = uri.getQueryParameter(KEY_STATE);
@@ -1219,7 +1222,7 @@ public class WebAuthProviderTest {
                 .start(activity, callback, REQUEST_CODE);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         String sentState = uri.getQueryParameter(KEY_STATE);
@@ -1246,7 +1249,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.getInstance().setCurrentTimeInMillis(CURRENT_TIME_MS);
 
         verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getData();
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
         String sentState = uri.getQueryParameter(KEY_STATE);


### PR DESCRIPTION
Prevent canceled authentication from reaching the `WebAuthProvider.resume()` method.
The important lines are: https://github.com/auth0/Auth0.Android/pull/120/files#diff-101f8235cd64f6d21cfc3fc82d610bd5R25 and https://github.com/auth0/Auth0.Android/pull/120/files#diff-101f8235cd64f6d21cfc3fc82d610bd5R33. The remaining diff is just updating the tests according to that change.
Fixes https://github.com/auth0/Auth0.Android/issues/119