### PR TITLE
Make CCT stay alive when activity is paused

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -126,7 +126,6 @@ class CustomTabsController extends CustomTabsServiceConnection {
                 final Intent intent = new CustomTabsIntent.Builder(session.get())
                         .build()
                         .intent;
-                intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                 intent.setData(uri);
                 try {
                     context.startActivity(intent);

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -50,6 +50,7 @@ import static com.auth0.android.provider.OAuthManager.RESPONSE_TYPE_ID_TOKEN;
  * It can use an external browser by sending the {@link android.content.Intent#ACTION_VIEW} intent or also the {@link WebAuthActivity}.
  * This behaviour is changed using {@link WebAuthProvider.Builder#useBrowser(boolean)}, and defaults to use browser.
  */
+@SuppressWarnings("WeakerAccess")
 public class WebAuthProvider {
 
     private static final String TAG = WebAuthProvider.class.getName();

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -32,7 +32,9 @@ import org.robolectric.annotation.Config;
 import java.util.ArrayList;
 import java.util.List;
 
+import static android.support.test.espresso.intent.matcher.IntentMatchers.hasFlag;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -162,7 +164,7 @@ public class CustomTabsControllerTest {
         assertThat(intent.getAction(), is(Intent.ACTION_VIEW));
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_SESSION), is(true));
         assertThat(intent.getData(), is(uri));
-        assertThat(intent.getFlags() & Intent.FLAG_ACTIVITY_NO_HISTORY, is(Intent.FLAG_ACTIVITY_NO_HISTORY));
+        assertThat(intent, not(hasFlag(Intent.FLAG_ACTIVITY_NO_HISTORY)));
     }
 
     @Test
@@ -174,7 +176,8 @@ public class CustomTabsControllerTest {
         Intent intent = launchIntentCaptor.getValue();
         assertThat(intent.getAction(), is(Intent.ACTION_VIEW));
         assertThat(intent.getData(), is(uri));
-        assertThat(intent.getFlags() & Intent.FLAG_ACTIVITY_NO_HISTORY, is(Intent.FLAG_ACTIVITY_NO_HISTORY));
+        assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_SESSION), is(true));
+        assertThat(intent, not(hasFlag(Intent.FLAG_ACTIVITY_NO_HISTORY)));
     }
 
     @Test
@@ -198,13 +201,13 @@ public class CustomTabsControllerTest {
         Intent customTabIntent = intents.get(0);
         assertThat(customTabIntent.getAction(), is(Intent.ACTION_VIEW));
         assertThat(customTabIntent.getData(), is(uri));
-        assertThat(customTabIntent.getFlags() & Intent.FLAG_ACTIVITY_NO_HISTORY, is(Intent.FLAG_ACTIVITY_NO_HISTORY));
+        assertThat(customTabIntent, not(hasFlag(Intent.FLAG_ACTIVITY_NO_HISTORY)));
         assertThat(customTabIntent.hasExtra(CustomTabsIntent.EXTRA_SESSION), is(true));
 
         Intent fallbackIntent = intents.get(1);
         assertThat(fallbackIntent.getAction(), is(Intent.ACTION_VIEW));
         assertThat(fallbackIntent.getData(), is(uri));
-        assertThat(fallbackIntent.getFlags() & Intent.FLAG_ACTIVITY_NO_HISTORY, is(Intent.FLAG_ACTIVITY_NO_HISTORY));
+        assertThat(fallbackIntent, hasFlag(Intent.FLAG_ACTIVITY_NO_HISTORY));
         assertThat(fallbackIntent.hasExtra(CustomTabsIntent.EXTRA_SESSION), is(false));
     }
 


### PR DESCRIPTION
By removing the flag, the CCT is not closed when the activity is paused and resumed. This is already working for Browser (not CCT mode) and Webview authentication. It might fix https://github.com/auth0/Auth0.Android/issues/116.