### PR TITLE
Fix default Locale tests

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -80,7 +80,6 @@ dependencies {
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.powermock:powermock-module-junit4:1.6.5'
     testCompile 'org.powermock:powermock-module-junit4-rule:1.6.5'
-    testCompile 'org.powermock:powermock-classloading-xstream:1.6.5'
     testCompile 'org.powermock:powermock-api-mockito:1.6.5'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
@@ -43,6 +43,8 @@ import java.util.Map;
 
 public class RequestFactory {
 
+    public static final String DEFAULT_LOCALE_IF_MISSING = "en_US";
+
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String USER_AGENT_HEADER = "User-Agent";
     private static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
@@ -149,6 +151,6 @@ public class RequestFactory {
 
     static String getDefaultLocale() {
         String language = Locale.getDefault().toString();
-        return !language.isEmpty() ? language : "en_US";
+        return !language.isEmpty() ? language : DEFAULT_LOCALE_IF_MISSING;
     }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -1725,6 +1725,6 @@ public class AuthenticationAPIClientTest {
 
     private String getDefaultLocale() {
         String language = Locale.getDefault().toString();
-        return !language.isEmpty() ? language : "en";
+        return !language.isEmpty() ? language : RequestFactory.DEFAULT_LOCALE_IF_MISSING;
     }
 }


### PR DESCRIPTION
Somehow, when running the tests the default locale wasn't specified in the environment. When this value is missing, a default hard-coded value is returned. This value should be the same as the one used in the `RequestFactory` class. I've added a public (agh!) constant to prevent this issue from happening again.