### PR TITLE
Fix NPE when browser re-attempts a finished authentication

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.java
@@ -71,7 +71,11 @@ public class AuthenticationActivity extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
-        if (!intentLaunched) {
+        if (!intentLaunched && getIntent().getExtras() == null) {
+            //Activity was launched in an unexpected way
+            finish();
+            return;
+        } else if (!intentLaunched) {
             intentLaunched = true;
             launchAuthenticationIntent();
             return;

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -144,7 +144,6 @@ class CustomTabsController extends CustomTabsServiceConnection {
                     context.startActivity(intent);
                 } catch (ActivityNotFoundException ignored) {
                     Intent fallbackIntent = new Intent(Intent.ACTION_VIEW, uri);
-                    fallbackIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                     context.startActivity(fallbackIntent);
                 }
             }

--- a/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
@@ -72,6 +72,22 @@ public class AuthenticationActivityTest {
 
     @SuppressWarnings("deprecation")
     @Test
+    public void shouldFinishGracefullyWhenCalledByError() throws Exception {
+        Intent intent = new Intent(callerActivity, AuthenticationActivity.class);
+        //An invalid call will not pass any expected extras
+        createActivity(intent);
+
+        activityController.create().newIntent(intent).start().resume();
+
+        verifyNoMoreInteractions(customTabsController);
+        assertThat(activity.getDeliveredIntent(), is(nullValue()));
+        assertThat(activity.isFinishing(), is(true));
+
+        activityController.destroy();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
     public void shouldAuthenticateUsingBrowser() throws Exception {
         AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions);
         verify(callerActivity).startActivity(intentCaptor.capture());

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -256,7 +256,7 @@ public class CustomTabsControllerTest {
         Intent fallbackIntent = intents.get(1);
         assertThat(fallbackIntent.getAction(), is(Intent.ACTION_VIEW));
         assertThat(fallbackIntent.getData(), is(uri));
-        assertThat(fallbackIntent, hasFlag(Intent.FLAG_ACTIVITY_NO_HISTORY));
+        assertThat(fallbackIntent, not(hasFlag(Intent.FLAG_ACTIVITY_NO_HISTORY)));
         assertThat(fallbackIntent.hasExtra(CustomTabsIntent.EXTRA_SESSION), is(false));
         assertThat(fallbackIntent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(false));
     }


### PR DESCRIPTION
This PR also removes the unwanted NO_HISTORY flag to prevent auto browser refreshing when minimized.
Fixes https://github.com/auth0/Auth0.Android/issues/137