### PR TITLE
Add support for MFA using OIDC conformant endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,32 @@ authentication
 
 > The default scope used is `openid`
 
+
+#### Login using MFA with One Time Password code
+
+This call requires the client to have the *MFA* Client Grant Type enabled. Check [this article](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
+
+When you sign in to a multifactor authentication enabled connection using the `login` method, you receive an error standing that MFA is required for that user along with an `mfa_token` value. Use this value to call `loginWithOTP` and complete the MFA flow passing the One Time Password from the enrolled MFA code generator app.
+
+
+```java
+authentication
+    .loginWithOTP("the mfa token", "123456")
+    .start(new BaseCallback<Credentials>() {
+        @Override
+        public void onSuccess(Credentials payload) {
+            //Logged in!
+        }
+
+        @Override
+        public void onFailure(AuthenticationException error) {
+            //Error!
+        }
+    });
+```
+
+
+
 #### Passwordless Login
 
 This feature requires your Application to have the *Resource Owner* Legacy Grant Type enabled. Check [this article](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it. Note that Passwordless authentication *cannot be used* with the [OIDC Conformant Mode](#oidc-conformant-mode) enabled.

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -216,6 +216,7 @@ public class Auth0 {
 
     /**
      * Set whether to enforce TLS 1.2 on devices with API 16-21.
+     *
      * @param enforced whether TLS 1.2 is enforced on devices with API 16-21.
      */
     public void setTLS12Enforced(boolean enforced) {

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -40,12 +40,12 @@ import com.auth0.android.request.ParameterizableRequest;
 import com.auth0.android.request.Request;
 import com.auth0.android.request.internal.AuthenticationErrorBuilder;
 import com.auth0.android.request.internal.GsonProvider;
+import com.auth0.android.request.internal.OkHttpClientFactory;
 import com.auth0.android.request.internal.RequestFactory;
 import com.auth0.android.result.Credentials;
 import com.auth0.android.result.DatabaseUser;
 import com.auth0.android.result.Delegation;
 import com.auth0.android.result.UserProfile;
-import com.auth0.android.request.internal.OkHttpClientFactory;
 import com.auth0.android.util.Telemetry;
 import com.google.gson.Gson;
 import com.squareup.okhttp.HttpUrl;
@@ -54,6 +54,7 @@ import com.squareup.okhttp.OkHttpClient;
 import java.util.Map;
 
 import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_AUTHORIZATION_CODE;
+import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_MFA_OTP;
 import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_PASSWORD;
 import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_PASSWORD_REALM;
 import static com.auth0.android.authentication.ParameterBuilder.ID_TOKEN_KEY;
@@ -81,6 +82,8 @@ public class AuthenticationAPIClient {
     private static final String OAUTH_CODE_KEY = "code";
     private static final String REDIRECT_URI_KEY = "redirect_uri";
     private static final String TOKEN_KEY = "token";
+    private static final String MFA_TOKEN_KEY = "mfa_token";
+    private static final String ONE_TIME_PASSWORD_KEY = "otp";
     private static final String DELEGATION_PATH = "delegation";
     private static final String ACCESS_TOKEN_PATH = "access_token";
     private static final String SIGN_UP_PATH = "signup";
@@ -97,7 +100,8 @@ public class AuthenticationAPIClient {
     private static final String HEADER_AUTHORIZATION = "Authorization";
 
     private final Auth0 auth0;
-    @VisibleForTesting final OkHttpClient client;
+    @VisibleForTesting
+    final OkHttpClient client;
     private final Gson gson;
     private final RequestFactory factory;
     private final ErrorBuilder<AuthenticationException> authErrorBuilder;
@@ -233,6 +237,43 @@ public class AuthenticationAPIClient {
                 .asDictionary();
 
         return loginWithToken(requestParameters);
+    }
+
+    /**
+     * Log in a user using the One Time Password code after they have received the 'mfa_required' error.
+     * The MFA token tells the server the username or email, password and realm values sent on the first request.
+     * Example usage:
+     * <pre>
+     * {@code
+     * client.loginWithOTP("{mfa token}", "{one time password}")
+     *      .start(new BaseCallback<Credentials>() {
+     *          {@literal}Override
+     *          public void onSuccess(Credentials payload) { }
+     *
+     *          {@literal}Override
+     *          public void onFailure(AuthenticationException error) { }
+     *      });
+     * }
+     * </pre>
+     *
+     * @param mfaToken the token received in the previous {@link #login(String, String, String)} response.
+     * @param otp      the one time password code provided by the resource owner, typically obtained from an
+     *                 MFA application such as Google Authenticator or Guardian.
+     * @return a request to configure and start that will yield {@link Credentials}
+     */
+    @SuppressWarnings("WeakerAccess")
+    public AuthenticationRequest loginWithOTP(@NonNull String mfaToken, @NonNull String otp) {
+        if (!auth0.isOIDCConformant()) {
+            throw new IllegalStateException("Clients that are non OIDC conformant can not call this endpoint.");
+        }
+
+        Map<String, Object> parameters = ParameterBuilder.newBuilder()
+                .setGrantType(GRANT_TYPE_MFA_OTP)
+                .set(MFA_TOKEN_KEY, mfaToken)
+                .set(ONE_TIME_PASSWORD_KEY, otp)
+                .asDictionary();
+
+        return loginWithToken(parameters);
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -242,7 +242,7 @@ public class AuthenticationAPIClient {
     /**
      * Log in a user using the One Time Password code after they have received the 'mfa_required' error.
      * The MFA token tells the server the username or email, password and realm values sent on the first request.
-     * Example usage:
+     * Requires your client to have the <b>MFA</b> Grant Type enabled. See <a href="https://auth0.com/docs/clients/client-grant-types">Client Grant Types</a> to learn how to enable it.* Example usage:
      * <pre>
      * {@code
      * client.loginWithOTP("{mfa token}", "{one time password}")

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -263,10 +263,6 @@ public class AuthenticationAPIClient {
      */
     @SuppressWarnings("WeakerAccess")
     public AuthenticationRequest loginWithOTP(@NonNull String mfaToken, @NonNull String otp) {
-        if (!auth0.isOIDCConformant()) {
-            throw new IllegalStateException("Clients that are non OIDC conformant can not call this endpoint.");
-        }
-
         Map<String, Object> parameters = ParameterBuilder.newBuilder()
                 .setGrantType(GRANT_TYPE_MFA_OTP)
                 .set(MFA_TOKEN_KEY, mfaToken)

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -157,17 +157,22 @@ public class AuthenticationException extends Auth0Exception {
 
     /// When MFA code is required to authenticate
     public boolean isMultifactorRequired() {
-        return "a0.mfa_required".equals(code);
+        return "mfa_required".equals(code) || "a0.mfa_required".equals(code);
     }
 
     /// When MFA is required and the user is not enrolled
     public boolean isMultifactorEnrollRequired() {
-        return "a0.mfa_registration_required".equals(code);
+        return "a0.mfa_registration_required".equals(code) || "unsupported_challenge_type".equals(code);
+    }
+
+    /// When the MFA Token received on the login request has expired
+    public boolean isMultifactorTokenExpired() {
+        return "expired_token".equals(code) && "mfa_token is expired".equals(description);
     }
 
     /// When MFA code sent is invalid or expired
     public boolean isMultifactorCodeInvalid() {
-        return "a0.mfa_invalid_code".equals(code);
+        return "a0.mfa_invalid_code".equals(code) || "invalid_grant".equals(code) && "Invalid otp_code.".equals(description);
     }
 
     /// When password used for SignUp does not match connection's strength requirements.

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -165,9 +165,10 @@ public class AuthenticationException extends Auth0Exception {
         return "a0.mfa_registration_required".equals(code) || "unsupported_challenge_type".equals(code);
     }
 
-    /// When the MFA Token received on the login request has expired
-    public boolean isMultifactorTokenExpired() {
-        return "expired_token".equals(code) && "mfa_token is expired".equals(description);
+    /// When the MFA Token used on the login request is malformed or has expired
+    public boolean isMultifactorTokenInvalid() {
+        return "expired_token".equals(code) && "mfa_token is expired".equals(description) ||
+                "invalid_grant".equals(code) && "Malformed mfa_token".equals(description);
     }
 
     /// When MFA code sent is invalid or expired

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
@@ -53,6 +53,7 @@ public class ParameterBuilder {
     public static final String GRANT_TYPE_PASSWORD_REALM = "http://auth0.com/oauth/grant-type/password-realm";
     public static final String GRANT_TYPE_JWT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
     public static final String GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code";
+    public static final String GRANT_TYPE_MFA_OTP = "http://auth0.com/oauth/grant-type/mfa-otp";
 
     public static final String SCOPE_OPENID = "openid";
     public static final String SCOPE_OFFLINE_ACCESS = "openid offline_access";

--- a/auth0/src/main/java/com/auth0/android/authentication/request/DelegationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/DelegationRequest.java
@@ -38,8 +38,8 @@ import java.util.Map;
  * Represents a delegation request for Auth0 tokens that will yield a new delegation token.
  * The delegation response depends on the 'api_type' parameter.
  *
- * @param <T> type of object that will hold the delegation response. When requesting Auth0’s 'id_token' you can
- *            use {@link Delegation}, otherwise you’ll need to provide an object that can be created from the JSON
+ * @param <T> type of object that will hold the delegation response. When requesting Auth0's 'id_token' you can
+ *            use {@link Delegation}, otherwise you'll need to provide an object that can be created from the JSON
  *            payload or just use {@code Map<String, Object>}
  */
 public class DelegationRequest<T> implements Request<T, AuthenticationException> {

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -102,6 +102,8 @@ public class CredentialsManager {
 
     /**
      * Checks if a non-expired pair of credentials can be obtained from this manager.
+     *
+     * @return whether there are valid credentials stored on this manager.
      */
     public boolean hasValidCredentials() {
         String accessToken = storage.retrieveString(KEY_ACCESS_TOKEN);

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -47,9 +47,7 @@ import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
@@ -59,7 +57,6 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import static com.auth0.android.util.AuthenticationAPI.GENERIC_TOKEN;
 import static com.auth0.android.util.AuthenticationAPI.ID_TOKEN;
@@ -103,7 +100,6 @@ public class AuthenticationAPIClientTest {
     private Gson gson;
 
     private AuthenticationAPI mockAPI;
-    private ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -179,17 +175,6 @@ public class AuthenticationAPIClientTest {
         assertThat(client, is(notNullValue()));
         assertThat(client.getClientId(), is(CLIENT_ID));
         assertThat(client.getBaseURL(), equalTo("https://" + DOMAIN + "/"));
-    }
-
-    @Test
-    public void shouldThrowOnLoginWithMFAOTPCodeWithNonOIDCClient() throws Exception {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("Clients that are non OIDC conformant can not call this endpoint.");
-
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
-        auth0.setOIDCConformant(false);
-        AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-        client.login(SUPPORT_AUTH0_COM, "some-password", MY_CONNECTION);
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
@@ -140,15 +140,23 @@ public class AuthenticationExceptionTest {
 
     @Test
     public void shouldHaveExpiredMultifactorTokenOnOIDCMode() throws Exception {
-        values.put(CODE_KEY, "expired_token");
-        values.put(DESCRIPTION_KEY, "mfa_token is expired");
+        values.put(ERROR_KEY, "expired_token");
+        values.put(ERROR_DESCRIPTION_KEY, "mfa_token is expired");
         AuthenticationException ex = new AuthenticationException(values);
-        assertThat(ex.isMultifactorTokenExpired(), is(true));
+        assertThat(ex.isMultifactorTokenInvalid(), is(true));
+    }
+
+    @Test
+    public void shouldHaveMalformedMultifactorTokenOnOIDCMode() throws Exception {
+        values.put(ERROR_KEY, "invalid_grant");
+        values.put(ERROR_DESCRIPTION_KEY, "Malformed mfa_token");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isMultifactorTokenInvalid(), is(true));
     }
 
     @Test
     public void shouldRequireMultifactorOnOIDCMode() throws Exception {
-        values.put(CODE_KEY, "mfa_required");
+        values.put(ERROR_KEY, "mfa_required");
         values.put("mfa_token", "some-random-token");
         AuthenticationException ex = new AuthenticationException(values);
         assertThat(ex.isMultifactorRequired(), is(true));
@@ -164,8 +172,8 @@ public class AuthenticationExceptionTest {
 
     @Test
     public void shouldRequireMultifactorEnrollOnOIDCMode() throws Exception {
-        values.put(CODE_KEY, "unsupported_challenge_type");
-        values.put(DESCRIPTION_KEY, "User is not enrolled with guardian");
+        values.put(ERROR_KEY, "unsupported_challenge_type");
+        values.put(ERROR_DESCRIPTION_KEY, "User is not enrolled with guardian");
         AuthenticationException ex = new AuthenticationException(values);
         assertThat(ex.isMultifactorEnrollRequired(), is(true));
     }
@@ -179,8 +187,8 @@ public class AuthenticationExceptionTest {
 
     @Test
     public void shouldHaveInvalidMultifactorCodeOnOIDCMode() throws Exception {
-        values.put(CODE_KEY, "invalid_grant");
-        values.put(DESCRIPTION_KEY, "Invalid otp_code.");
+        values.put(ERROR_KEY, "invalid_grant");
+        values.put(ERROR_DESCRIPTION_KEY, "Invalid otp_code.");
         AuthenticationException ex = new AuthenticationException(values);
         assertThat(ex.isMultifactorCodeInvalid(), is(true));
     }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
@@ -139,6 +139,23 @@ public class AuthenticationExceptionTest {
     }
 
     @Test
+    public void shouldHaveExpiredMultifactorTokenOnOIDCMode() throws Exception {
+        values.put(CODE_KEY, "expired_token");
+        values.put(DESCRIPTION_KEY, "mfa_token is expired");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isMultifactorTokenExpired(), is(true));
+    }
+
+    @Test
+    public void shouldRequireMultifactorOnOIDCMode() throws Exception {
+        values.put(CODE_KEY, "mfa_required");
+        values.put("mfa_token", "some-random-token");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isMultifactorRequired(), is(true));
+        assertThat((String) ex.getValue("mfa_token"), is("some-random-token"));
+    }
+
+    @Test
     public void shouldRequireMultifactor() throws Exception {
         values.put(CODE_KEY, "a0.mfa_required");
         AuthenticationException ex = new AuthenticationException(values);
@@ -146,10 +163,26 @@ public class AuthenticationExceptionTest {
     }
 
     @Test
+    public void shouldRequireMultifactorEnrollOnOIDCMode() throws Exception {
+        values.put(CODE_KEY, "unsupported_challenge_type");
+        values.put(DESCRIPTION_KEY, "User is not enrolled with guardian");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isMultifactorEnrollRequired(), is(true));
+    }
+
+    @Test
     public void shouldRequireMultifactorEnroll() throws Exception {
         values.put(CODE_KEY, "a0.mfa_registration_required");
         AuthenticationException ex = new AuthenticationException(values);
         assertThat(ex.isMultifactorEnrollRequired(), is(true));
+    }
+
+    @Test
+    public void shouldHaveInvalidMultifactorCodeOnOIDCMode() throws Exception {
+        values.put(CODE_KEY, "invalid_grant");
+        values.put(DESCRIPTION_KEY, "Invalid otp_code.");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isMultifactorCodeInvalid(), is(true));
     }
 
     @Test

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,7 +15,7 @@ coverage:
       default:
         enabled: true
         target: 80%
-        threshold: 10%
+        threshold: 30%
         if_no_uploads: error
     changes:
       default:


### PR DESCRIPTION
This PR adds support for the new MFA OTP flow which is mainly based on https://github.com/jaredhanson/draft-oauth-mfa/blob/master/Draft-1.0.txt. ~It's still missing the `association_required` error handling (we're blocked) for when the user has not yet enrolled.~ It also adds javadoc fixes.

The only thing I'm not convinced of is throwing an exception when the new "login with otp" method is called on a non-oidc conformant client. Maybe it's better if we let the request to the server fail and return that error response to the user, WDYT?

Also to be reviewed: Name of the login method, currently `loginWithOTP(mfaToken, otp)`.



### Public API changes/additions:

- On the **AuthenticationAPIClient:** New method `loginWithOTP(@NonNull String mfaToken, @NonNull String otp)` to log in sending the mfa-otp grant and the mfa token + otp.
- On the **AuthenticationException:** New method `isMultifactorTokenInvalid()` to evaluate if the error instance corresponds to a "mfa token expired" error.

EDIT: 04/24/18. The `association_required` error code is meant for the challenge endpoint only, which this SDK is not going to implement. 
