### PR TITLE
Disable HTTP 2 protocol on OkHttp client

### DIFF
--- a/auth0/src/main/java/com/auth0/android/request/internal/OkHttpClientFactory.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/OkHttpClientFactory.java
@@ -7,12 +7,14 @@ import android.util.Log;
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.TlsVersion;
 import com.squareup.okhttp.logging.HttpLoggingInterceptor;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.net.ssl.SSLContext;
@@ -29,8 +31,9 @@ public class OkHttpClientFactory {
     /**
      * This method creates an instance of OKHttpClient according to the provided parameters.
      * It is used internally and is not intended to be used directly.
+     *
      * @param loggingEnabled Enable logging in the created OkHttpClient.
-     * @param tls12Enforced Enforce TLS 1.2 in the created OkHttpClient on devices with API 16-21
+     * @param tls12Enforced  Enforce TLS 1.2 in the created OkHttpClient on devices with API 16-21
      * @return new OkHttpClient instance created according to the parameters.
      */
     public OkHttpClient createClient(boolean loggingEnabled, boolean tls12Enforced) {
@@ -45,6 +48,7 @@ public class OkHttpClientFactory {
         if (tls12Enforced) {
             enforceTls12(client);
         }
+        client.setProtocols(Arrays.asList(Protocol.HTTP_1_1, Protocol.SPDY_3));
         return client;
     }
 
@@ -56,6 +60,7 @@ public class OkHttpClientFactory {
 
     /**
      * Enable TLS 1.2 on the OkHttpClient on API 16-21, which is supported but not enabled by default.
+     *
      * @link https://github.com/square/okhttp/issues/2372
      * @see TLS12SocketFactory
      */

--- a/auth0/src/test/java/com/auth0/android/request/internal/OkHttpClientFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/OkHttpClientFactoryTest.java
@@ -1,10 +1,9 @@
 package com.auth0.android.request.internal;
 
-import android.app.Activity;
-
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.TlsVersion;
 import com.squareup.okhttp.logging.HttpLoggingInterceptor;
 
@@ -14,7 +13,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -37,25 +35,34 @@ import static org.mockito.Mockito.when;
 @Config(constants = com.auth0.android.auth0.BuildConfig.class, sdk = 21, manifest = Config.NONE)
 public class OkHttpClientFactoryTest {
 
-    private Activity activity;
     private OkHttpClientFactory factory;
-    @Mock private OkHttpClient mockClient;
+    @Mock
+    private OkHttpClient mockClient;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         MockitoAnnotations.initMocks(this);
         factory = new OkHttpClientFactory();
-        activity = Robolectric.setupActivity(Activity.class);
     }
 
     @Test
     // Verify that there's no error when creating a new OkHttpClient instance
-    public void shouldCreateNewClient(){
+    public void shouldCreateNewClient() {
         factory.createClient(false, false);
     }
 
     @Test
-    @Config(sdk=21)
+    public void shouldNotUseHttp2Protocol() {
+        OkHttpClient client = factory.createClient(false, false);
+        //Doesn't use default protocols
+        assertThat(client.getProtocols(), is(notNullValue()));
+        assertThat(client.getProtocols().contains(Protocol.HTTP_1_1), is(true));
+        assertThat(client.getProtocols().contains(Protocol.SPDY_3), is(true));
+        assertThat(client.getProtocols().contains(Protocol.HTTP_2), is(false));
+    }
+
+    @Test
+    @Config(sdk = 21)
     public void shouldEnableLoggingTLS12Enforced() {
         List list = generateInterceptorsMockList(mockClient);
         OkHttpClient client = factory.modifyClient(mockClient, true, true);
@@ -64,8 +71,8 @@ public class OkHttpClientFactoryTest {
     }
 
     @Test
-    @Config(sdk=21)
-    public void shouldEnableLoggingTLS12NotEnforced(){
+    @Config(sdk = 21)
+    public void shouldEnableLoggingTLS12NotEnforced() {
         List list = generateInterceptorsMockList(mockClient);
         OkHttpClient client = factory.modifyClient(mockClient, true, false);
         verifyLoggingEnabled(client, list);
@@ -73,8 +80,8 @@ public class OkHttpClientFactoryTest {
     }
 
     @Test
-    @Config(sdk=21)
-    public void shouldDisableLoggingTLS12Enforced(){
+    @Config(sdk = 21)
+    public void shouldDisableLoggingTLS12Enforced() {
         List list = generateInterceptorsMockList(mockClient);
         OkHttpClient client = factory.modifyClient(mockClient, false, true);
         verifyLoggingDisabled(client, list);
@@ -82,8 +89,8 @@ public class OkHttpClientFactoryTest {
     }
 
     @Test
-    @Config(sdk=21)
-    public void shouldDisableLoggingTLS12NotEnforced(){
+    @Config(sdk = 21)
+    public void shouldDisableLoggingTLS12NotEnforced() {
         List list = generateInterceptorsMockList(mockClient);
         OkHttpClient client = factory.modifyClient(mockClient, false, false);
         verifyLoggingDisabled(client, list);
@@ -91,7 +98,7 @@ public class OkHttpClientFactoryTest {
     }
 
     @Test
-    @Config(sdk=22)
+    @Config(sdk = 22)
     public void shouldEnableLoggingTLS12Enforced_postLollipopTLS12NoEffect() {
         List list = generateInterceptorsMockList(mockClient);
         OkHttpClient client = factory.modifyClient(mockClient, true, true);
@@ -100,8 +107,8 @@ public class OkHttpClientFactoryTest {
     }
 
     @Test
-    @Config(sdk=22)
-    public void shouldEnableLoggingTLS12NotEnforced_posLollipop(){
+    @Config(sdk = 22)
+    public void shouldEnableLoggingTLS12NotEnforced_posLollipop() {
         List list = generateInterceptorsMockList(mockClient);
         OkHttpClient client = factory.modifyClient(mockClient, true, false);
         verifyLoggingEnabled(client, list);
@@ -109,8 +116,8 @@ public class OkHttpClientFactoryTest {
     }
 
     @Test
-    @Config(sdk=22)
-    public void shouldDisableLoggingTLS12Enforced_postLollipopTLS12NoEffect(){
+    @Config(sdk = 22)
+    public void shouldDisableLoggingTLS12Enforced_postLollipopTLS12NoEffect() {
         List list = generateInterceptorsMockList(mockClient);
         OkHttpClient client = factory.modifyClient(mockClient, false, true);
         verifyLoggingDisabled(client, list);
@@ -118,8 +125,8 @@ public class OkHttpClientFactoryTest {
     }
 
     @Test
-    @Config(sdk=22)
-    public void shouldDisableLoggingTLS12NotEnforced_postLollipop(){
+    @Config(sdk = 22)
+    public void shouldDisableLoggingTLS12NotEnforced_postLollipop() {
         List list = generateInterceptorsMockList(mockClient);
         OkHttpClient client = factory.modifyClient(mockClient, false, false);
         verifyLoggingDisabled(client, list);


### PR DESCRIPTION
OkHttp 2.7.5 (latest) doesn't seem to handle very well the `HTTP 2` protocol. While this is fixed on the new OkHttp 3 that implies a breaking change we can't deal with right now.

The present fix is removing the `HTTP 2` protocol from the client allowed protocols list. Since the [default protocols](https://github.com/square/okhttp/blob/okhttp_27/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java#L54-L55) include both `HTTP 1.1` and `SPDY 3`, those remain enabled. 

This will fix https://github.com/auth0/Lock.Android/issues/457

