### PR TITLE
Allow SSO error to go through

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -206,4 +206,9 @@ public class AuthenticationException extends Auth0Exception {
         return "access_denied".equals(code);
     }
 
+    /// When authenticating with web-based authentication using prompt=none and the auth0 session had expired
+    public boolean isLoginRequired() {
+        return "login_required".equals(code);
+    }
+
 }

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -37,6 +37,7 @@ class OAuthManager {
 
     private static final String ERROR_VALUE_ACCESS_DENIED = "access_denied";
     private static final String ERROR_VALUE_UNAUTHORIZED = "unauthorized";
+    private static final String ERROR_VALUE_LOGIN_REQUIRED = "login_required";
     private static final String METHOD_SHA_256 = "S256";
     private static final String KEY_CODE_CHALLENGE = "code_challenge";
     private static final String KEY_CODE_CHALLENGE_METHOD = "code_challenge_method";
@@ -171,6 +172,9 @@ class OAuthManager {
             throw new AuthenticationException(ERROR_VALUE_ACCESS_DENIED, "Permissions were not granted. Try again.");
         } else if (ERROR_VALUE_UNAUTHORIZED.equalsIgnoreCase(errorValue)) {
             throw new AuthenticationException(ERROR_VALUE_UNAUTHORIZED, errorDescription);
+        } else if (ERROR_VALUE_LOGIN_REQUIRED.equals(errorValue)) {
+            //Whitelist to allow SSO errors go through
+            throw new AuthenticationException(errorValue, errorDescription);
         } else {
             throw new AuthenticationException("a0.invalid_configuration", "The application isn't configured properly for the social connection. Please check your Auth0's application configuration");
         }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
@@ -280,4 +280,11 @@ public class AuthenticationExceptionTest {
         assertThat(ex.isPasswordLeaked(), is(true));
     }
 
+    @Test
+    public void shouldHaveLoginRequired() throws Exception {
+        values.put(CODE_KEY, "login_required");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isLoginRequired(), is(true));
+    }
+
 }

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -1448,6 +1448,40 @@ public class WebAuthProviderTest {
 
     @SuppressWarnings({"deprecation", "ThrowableResultOfMethodCallIgnored"})
     @Test
+    public void shouldFailToResumeWithIntentWithLoginRequired() throws Exception {
+        WebAuthProvider.init(account)
+                .withState("1234567890")
+                .useCodeGrant(false)
+                .start(activity, callback);
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", "login_required", "Login Required"));
+        assertTrue(WebAuthProvider.resume(intent));
+
+        verify(callback).onFailure(authExceptionCaptor.capture());
+
+        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
+        assertThat(authExceptionCaptor.getValue().getCode(), is("login_required"));
+        assertThat(authExceptionCaptor.getValue().getDescription(), is("Login Required"));
+    }
+
+    @SuppressWarnings({"deprecation", "ThrowableResultOfMethodCallIgnored"})
+    @Test
+    public void shouldFailToResumeWithRequestCodeWithLoginRequired() throws Exception {
+        WebAuthProvider.init(account)
+                .withState("1234567890")
+                .useCodeGrant(false)
+                .start(activity, callback, REQUEST_CODE);
+        Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", "login_required", "Login Required"));
+        assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
+
+        verify(callback).onFailure(authExceptionCaptor.capture());
+
+        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
+        assertThat(authExceptionCaptor.getValue().getCode(), is("login_required"));
+        assertThat(authExceptionCaptor.getValue().getDescription(), is("Login Required"));
+    }
+
+    @SuppressWarnings({"deprecation", "ThrowableResultOfMethodCallIgnored"})
+    @Test
     public void shouldFailToResumeWithIntentWithInvalidState() throws Exception {
         WebAuthProvider.init(account)
                 .withState("abcdefghijk")


### PR DESCRIPTION
Things open to discussion:

- the getter name: `exception.isLoginRequired()`
- whether the error description should be the same as the one returned by the server ("Login Required") or something else, maybe more dev friendly.