### PR TITLE
Update gson to 2.8.5

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     compile 'com.android.support:customtabs:25.3.1'
     compile 'com.squareup.okhttp:okhttp:2.7.5'
     compile 'com.squareup.okhttp:logging-interceptor:2.7.5'
-    compile 'com.google.code.gson:gson:2.8.2'
+    compile 'com.google.code.gson:gson:2.8.5'
     compile 'com.auth0.android:jwtdecode:1.1.1'
 
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
Just a minor [Gson](https://github.com/google/gson) update from `2.8.2` to `2.8.5`.