### PR TITLE
Fix Web Authentication issues

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -145,6 +145,11 @@ public class AuthenticationException extends Auth0Exception {
         return values.get(key);
     }
 
+    // When there is no Browser app installed to handle the web authentication
+    public boolean isBrowserAppNotAvailable() {
+        return "a0.browser_not_available".equals(code);
+    }
+
     // When the Authorize URL is invalid
     public boolean isInvalidAuthorizeURL() {
         return "a0.invalid_authorize_url".equals(code);

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -114,6 +114,9 @@ class CustomTabsController extends CustomTabsServiceConnection {
      * Opens a Uri in a Custom Tab or Browser.
      * The Custom Tab service will be given up to {@link CustomTabsController#MAX_WAIT_TIME_SECONDS} to be connected.
      * If it fails to connect the Uri will be opened on a Browser.
+     * <p>
+     * In the exceptional case that no Browser app is installed on the device, this method will fail silently and do nothing.
+     * Please, ensure the {@link Intent#ACTION_VIEW} action can be handled before calling this method.
      *
      * @param uri the uri to open in a Custom Tab or Browser.
      */
@@ -143,8 +146,7 @@ class CustomTabsController extends CustomTabsServiceConnection {
                 try {
                     context.startActivity(intent);
                 } catch (ActivityNotFoundException ex) {
-                    Log.e(TAG, "No Browser available to open the URI");
-                    throw new IllegalStateException("Could not find any Browser application installed in this device to handle the intent.", ex);
+                    Log.e(TAG, "Could not find any Browser application installed in this device to handle the intent.");
                 }
             }
         }).start();

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -27,6 +27,8 @@ package com.auth0.android.provider;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
@@ -267,6 +269,11 @@ public class WebAuthProvider {
             return this;
         }
 
+        static boolean hasBrowserAppInstalled(@NonNull PackageManager packageManager) {
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://auth0.com"));
+            return intent.resolveActivity(packageManager) != null;
+        }
+
         /**
          * Request user Authentication. The result will be received in the callback.
          *
@@ -280,6 +287,12 @@ public class WebAuthProvider {
             managerInstance = null;
             if (account.getAuthorizeUrl() == null) {
                 final AuthenticationException ex = new AuthenticationException("a0.invalid_authorize_url", "Auth0 authorize URL not properly set. This can be related to an invalid domain.");
+                callback.onFailure(ex);
+                return;
+            }
+
+            if (useBrowser && !hasBrowserAppInstalled(activity.getPackageManager())) {
+                AuthenticationException ex = new AuthenticationException("a0.browser_not_available", "No Browser application installed to perform web authentication.");
                 callback.onFailure(ex);
                 return;
             }

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -269,6 +269,7 @@ public class WebAuthProvider {
             return this;
         }
 
+        @VisibleForTesting
         static boolean hasBrowserAppInstalled(@NonNull PackageManager packageManager) {
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://auth0.com"));
             return intent.resolveActivity(packageManager) != null;

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
@@ -287,4 +287,11 @@ public class AuthenticationExceptionTest {
         assertThat(ex.isLoginRequired(), is(true));
     }
 
+    @Test
+    public void shouldHaveMissingBrowserApp() throws Exception {
+        values.put(CODE_KEY, "a0.browser_not_available");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isBrowserAppNotAvailable(), is(true));
+    }
+
 }

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -5,17 +5,25 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.content.pm.ActivityInfo;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.test.espresso.intent.matcher.IntentMatchers;
 import android.util.Base64;
+import android.webkit.URLUtil;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.result.Credentials;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -96,6 +104,9 @@ public class WebAuthProviderTest {
         //Next line is needed to avoid CustomTabService from being bound to Test environment
         //noinspection WrongConstant
         doReturn(false).when(activity).bindService(any(Intent.class), any(ServiceConnection.class), anyInt());
+
+        //Next line is needed to tell a Browser app is installed
+        prepareBrowserApp(true, null);
     }
 
     @SuppressWarnings("deprecation")
@@ -1668,12 +1679,68 @@ public class WebAuthProviderTest {
         assertThat(WebAuthProvider.getInstance(), is(nullValue()));
     }
 
+    @Test
+    public void shouldFailToStartWithBrowserWhenNoBrowserAppIsInstalled() throws Exception {
+        PackageManager pm = mock(PackageManager.class);
+        when(activity.getPackageManager()).thenReturn(pm);
+        when(pm.resolveActivity(intentCaptor.capture(), eq(PackageManager.MATCH_DEFAULT_ONLY))).thenReturn(null);
+
+        WebAuthProvider.init(account)
+                .start(activity, callback);
+
+        verify(callback).onFailure(authExceptionCaptor.capture());
+
+        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
+        assertThat(authExceptionCaptor.getValue().getCode(), is("a0.browser_not_available"));
+        assertThat(authExceptionCaptor.getValue().getDescription(), is("No Browser application installed to perform web authentication."));
+        assertThat(WebAuthProvider.getInstance(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHaveBrowserAppInstalled() {
+        ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+        prepareBrowserApp(true, intentCaptor);
+
+        boolean hasBrowserApp = WebAuthProvider.Builder.hasBrowserAppInstalled(activity.getPackageManager());
+        MatcherAssert.assertThat(hasBrowserApp, Is.is(true));
+        MatcherAssert.assertThat(intentCaptor.getValue(), Is.is(IntentMatchers.hasAction(Intent.ACTION_VIEW)));
+        MatcherAssert.assertThat(URLUtil.isValidUrl(intentCaptor.getValue().getDataString()), Is.is(true));
+    }
+
+    @Test
+    public void shouldNotHaveBrowserAppInstalled() {
+        ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+        prepareBrowserApp(false, intentCaptor);
+
+        boolean hasBrowserApp = WebAuthProvider.Builder.hasBrowserAppInstalled(activity.getPackageManager());
+        MatcherAssert.assertThat(hasBrowserApp, Is.is(false));
+        MatcherAssert.assertThat(intentCaptor.getValue(), Is.is(IntentMatchers.hasAction(Intent.ACTION_VIEW)));
+        MatcherAssert.assertThat(URLUtil.isValidUrl(intentCaptor.getValue().getDataString()), Is.is(true));
+    }
+
+
     //Test Helper Functions
     private Intent createAuthIntent(String hash) {
         Uri validUri = Uri.parse("https://domain.auth0.com/android/package/callback" + hash);
         Intent intent = new Intent();
         intent.setData(validUri);
         return intent;
+    }
+
+    private void prepareBrowserApp(boolean isAppInstalled, @Nullable ArgumentCaptor<Intent> intentCaptor) {
+        PackageManager pm = mock(PackageManager.class);
+        ResolveInfo info = null;
+        if (isAppInstalled) {
+            info = mock(ResolveInfo.class);
+            ApplicationInfo appInfo = mock(ApplicationInfo.class);
+            appInfo.packageName = "com.auth0.test";
+            ActivityInfo actInfo = mock(ActivityInfo.class);
+            actInfo.applicationInfo = appInfo;
+            actInfo.name = "Auth0 Browser";
+            info.activityInfo = actInfo;
+        }
+        when(pm.resolveActivity(intentCaptor != null ? intentCaptor.capture() : any(Intent.class), eq(PackageManager.MATCH_DEFAULT_ONLY))).thenReturn(info);
+        when(activity.getPackageManager()).thenReturn(pm);
     }
 
     private String createHash(@Nullable String idToken, @Nullable String accessToken, @Nullable String refreshToken, @Nullable String tokenType, @Nullable Long expiresIn, @Nullable String state, @Nullable String error, @Nullable String errorDescription) {


### PR DESCRIPTION
Occasionally, no browser app was installed in the device triggering the following exception:

> android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat=https://lbalmaceda.auth0.com/authorize?... }

While this is a border case scenario, it can still happen on some modified ROMs where the user is allowed to remove even the default browser app.


Furthermore, when picking the right Custom Tab compatible browser there was a bug where the default browser might be picked even if it was not compatible. Attempting to bind to this app's Custom Tab service resulted in the following exception:

> java.lang.IllegalArgumentException: Service Intent must be explicit: Intent { act=android.support.customtabs.action.CustomTabsService }

Both issues should be fixed on this PR.

Closes https://github.com/auth0/Auth0.Android/issues/138