### PR TITLE
Fix service handling when custom tabs are not available

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -42,6 +42,7 @@ class CustomTabsController extends CustomTabsServiceConnection {
 
     @Nullable
     private CustomTabsOptions customTabsOptions;
+    private boolean isBound;
 
     @VisibleForTesting
     CustomTabsController(@NonNull Context context, @Nullable String browserPackage) {
@@ -92,11 +93,11 @@ class CustomTabsController extends CustomTabsServiceConnection {
     public void bindService() {
         Log.v(TAG, "Trying to bind the service");
         Context context = this.context.get();
-        boolean success = false;
+        isBound = false;
         if (context != null && preferredPackage != null) {
-            success = CustomTabsClient.bindCustomTabsService(context, preferredPackage, this);
+            isBound = CustomTabsClient.bindCustomTabsService(context, preferredPackage, this);
         }
-        Log.v(TAG, "Bind request result: " + success);
+        Log.v(TAG, "Bind request result: " + isBound);
     }
 
     /**
@@ -105,8 +106,9 @@ class CustomTabsController extends CustomTabsServiceConnection {
     public void unbindService() {
         Log.v(TAG, "Trying to unbind the service");
         Context context = this.context.get();
-        if (context != null) {
+        if (isBound && context != null) {
             context.unbindService(this);
+            isBound = false;
         }
     }
 

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -5,6 +5,7 @@ import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.ServiceConnection;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
@@ -172,6 +173,15 @@ public class CustomTabsControllerTest {
         final CustomTabsServiceConnection connection = serviceConnectionCaptor.getValue();
         CustomTabsServiceConnection controllerConnection = controller;
         assertThat(connection, is(equalTo(controllerConnection)));
+    }
+
+    @Test
+    public void shouldNotUnbindIfNotBound() throws Exception {
+        bindService(false);
+        connectBoundService();
+
+        controller.unbindService();
+        verify(context, never()).unbindService(any(ServiceConnection.class));
     }
 
     @Test


### PR DESCRIPTION
This will check the service was bound before attempting to unbind it