### PR TITLE
Replace compile with implementation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Auth0.android is available through [Gradle](https://gradle.org/). To install it,
 
 ```gradle
 dependencies {
-    compile 'com.auth0.android:auth0:1.13.2'
+    implementation 'com.auth0.android:auth0:1.13.2'
 }
 ```
 


### PR DESCRIPTION
Most recent gradle versions use `implementation` instead of `compile`