### PR TITLE
Use latest patch of the OSS plugin

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -23,7 +23,7 @@
  */
 
 plugins {
-    id "com.auth0.gradle.oss-library.android" version "0.7.1"
+    id "com.auth0.gradle.oss-library.android" version "0.7.2"
 }
 
 logger.lifecycle("Using version ${version} for ${name}")

--- a/auth0/src/main/AndroidManifest.xml
+++ b/auth0/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.auth0.android.auth0">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -37,7 +38,8 @@
         <activity
             android:name="com.auth0.android.provider.RedirectActivity"
             android:exported="true">
-            <intent-filter android:autoVerify="true">
+            <intent-filter android:autoVerify="true"
+                tools:targetApi="m">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
This PR fixes the maven publishing plugin.

### Note 
People using this library from version `1.14.0` and up should start targeting latest android SDK versions, as [recommended by Google](https://developer.android.com/distribute/best-practices/develop/target-sdk). Those running into conflicts because of different `com.android.support` libraries versions can choose to use latest release `28.0.0` or exclude the ones required by this library and require a different version in their app's `build.gradle` file as shown below:


e.g. if choosing an older version such as `25.4.0`

```groovy
apply plugin: 'com.android.application'

android {
    //...
}

dependencies {
    compile ('com.auth0.android:auth0:1.14.0'){
        exclude group: 'com.android.support', module: 'appcompat-v7'
        exclude group: 'com.android.support', module: 'customtabs'
    }
    compile 'com.android.support:appcompat-v7:25.4.0'
    compile 'com.android.support:customtabs:25.4.0'
    //...
}
```