### PR TITLE
Explicitly set commit SHA for build coverage uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,4 @@ jobs:
     - run:
           name: Upload Coverage
           when: on_success
-          command: bash <(curl -s https://codecov.io/bash)
+          command: bash <(curl -s https://codecov.io/bash) -Z -C $CIRCLE_SHA1


### PR DESCRIPTION
and fail build if coverage could not get uploaded.

This fixes this error:

```
HTTP 400
Commit sha does not match Circle build.
```