### PR TITLE
Update telemetry format

### DIFF
--- a/auth0/src/main/java/com/auth0/android/util/Telemetry.java
+++ b/auth0/src/main/java/com/auth0/android/util/Telemetry.java
@@ -1,6 +1,7 @@
 package com.auth0.android.util;
 
 import android.support.annotation.VisibleForTesting;
+import android.text.TextUtils;
 import android.util.Base64;
 
 import com.google.gson.Gson;
@@ -17,7 +18,7 @@ public class Telemetry {
     private static final String NAME_KEY = "name";
     private static final String VERSION_KEY = "version";
     private static final String ENV_KEY = "env";
-    private static final String CORE_KEY = "core";
+    private static final String LIBRARY_VERSION_KEY = "auth0.android";
     private static final String ANDROID_KEY = "android";
 
     private final String name;
@@ -29,21 +30,24 @@ public class Telemetry {
         this(name, version, null);
     }
 
-    public Telemetry(String name, String version, String core) {
+    public Telemetry(String name, String version, String libraryVersion) {
         this.name = name;
         this.version = version;
+        if (TextUtils.isEmpty(name)) {
+            env = Collections.emptyMap();
+            value = null;
+            return;
+        }
         Map<String, String> tmpEnv = new HashMap<>();
         tmpEnv.put(ANDROID_KEY, String.valueOf(android.os.Build.VERSION.SDK_INT));
-        if (core != null) {
-            tmpEnv.put(CORE_KEY, core);
+        if (!TextUtils.isEmpty(libraryVersion)) {
+            tmpEnv.put(LIBRARY_VERSION_KEY, libraryVersion);
         }
         this.env = Collections.unmodifiableMap(tmpEnv);
 
         Map<String, Object> values = new HashMap<>();
-        if (name != null) {
-            values.put(NAME_KEY, name);
-        }
-        if (version != null) {
+        values.put(NAME_KEY, name);
+        if (!TextUtils.isEmpty(version)) {
             values.put(VERSION_KEY, version);
         }
         values.put(ENV_KEY, env);
@@ -62,7 +66,7 @@ public class Telemetry {
     }
 
     public String getLibraryVersion() {
-        return env.get(CORE_KEY);
+        return env.get(LIBRARY_VERSION_KEY);
     }
 
     @VisibleForTesting

--- a/auth0/src/test/java/com/auth0/android/util/TelemetryTest.java
+++ b/auth0/src/test/java/com/auth0/android/util/TelemetryTest.java
@@ -26,7 +26,7 @@ public class TelemetryTest {
     @Test
     @Config(sdk = 21)
     public void shouldAlwaysIncludeAndroidVersionAPI21() throws Exception {
-        Telemetry telemetry = new Telemetry(null, null);
+        Telemetry telemetry = new Telemetry("auth0-java", null);
         assertThat(telemetry.getEnvironment(), is(notNullValue()));
         assertThat(telemetry.getEnvironment().get("android"), is("21"));
     }
@@ -34,16 +34,23 @@ public class TelemetryTest {
     @Test
     @Config(sdk = 23)
     public void shouldAlwaysIncludeAndroidVersionAPI23() throws Exception {
-        Telemetry telemetry = new Telemetry(null, null);
+        Telemetry telemetry = new Telemetry("auth0-java", null);
         assertThat(telemetry.getEnvironment(), is(notNullValue()));
         assertThat(telemetry.getEnvironment().get("android"), is("23"));
     }
 
     @Test
-    public void shouldNotIncludeCoreIfNotProvided() throws Exception {
+    public void shouldNotAcceptNullName() throws Exception {
+        Telemetry telemetry = new Telemetry(null, null);
+        assertThat(telemetry.getValue(), is(nullValue()));
+        assertThat(telemetry.getEnvironment(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldNotIncludeLibraryVersionIfNotProvided() throws Exception {
         Telemetry telemetry = new Telemetry(null, null);
         assertThat(telemetry.getEnvironment(), is(notNullValue()));
-        assertThat(telemetry.getEnvironment().containsKey("core"), is(false));
+        assertThat(telemetry.getEnvironment().containsKey("auth0.android"), is(false));
     }
 
     @Test
@@ -62,7 +69,7 @@ public class TelemetryTest {
     public void shouldGetLibraryVersion() throws Exception {
         Telemetry telemetry = new Telemetry("auth0-java", "1.0.0", "1.2.3");
         assertThat(telemetry.getLibraryVersion(), is("1.2.3"));
-        assertThat(telemetry.getEnvironment().get("core"), is("1.2.3"));
+        assertThat(telemetry.getEnvironment().get("auth0.android"), is("1.2.3"));
     }
 
     @Test
@@ -74,13 +81,13 @@ public class TelemetryTest {
 
         Telemetry telemetryComplete = new Telemetry("auth0-java", "1.0.0", "1.2.3");
         String value = telemetryComplete.getValue();
-        assertThat(value, is("eyJuYW1lIjoiYXV0aDAtamF2YSIsImVudiI6eyJjb3JlIjoiMS4yLjMiLCJhbmRyb2lkIjoiMjMifSwidmVyc2lvbiI6IjEuMC4wIn0="));
+        assertThat(value, is("eyJuYW1lIjoiYXV0aDAtamF2YSIsImVudiI6eyJhbmRyb2lkIjoiMjMiLCJhdXRoMC5hbmRyb2lkIjoiMS4yLjMifSwidmVyc2lvbiI6IjEuMC4wIn0="));
         String completeString = new String(Base64.decode(value, Base64.URL_SAFE | Base64.NO_WRAP), "UTF-8");
         Map<String, Object> complete = gson.fromJson(completeString, mapType);
         assertThat((String) complete.get("name"), is("auth0-java"));
         assertThat((String) complete.get("version"), is("1.0.0"));
         Map<String, Object> completeEnv = (Map<String, Object>) complete.get("env");
-        assertThat((String) completeEnv.get("core"), is("1.2.3"));
+        assertThat((String) completeEnv.get("auth0.android"), is("1.2.3"));
         assertThat((String) completeEnv.get("android"), is("23"));
     }
 
@@ -99,26 +106,7 @@ public class TelemetryTest {
         assertThat((String) basic.get("name"), is("auth0-python"));
         assertThat((String) basic.get("version"), is("99.3.1"));
         Map<String, Object> basicEnv = (Map<String, Object>) basic.get("env");
-        assertThat(basicEnv.get("core"), is(nullValue()));
+        assertThat(basicEnv.get("auth0.android"), is(nullValue()));
         assertThat((String) basicEnv.get("android"), is("23"));
-    }
-
-    @Test
-    @Config(sdk = 21)
-    public void shouldGenerateRegularTelemetryBase64Value() throws Exception {
-        Gson gson = new Gson();
-        Type mapType = new TypeToken<Map<String, Object>>() {
-        }.getType();
-
-        Telemetry telemetryRegular = new Telemetry(null, null);
-        String value = telemetryRegular.getValue();
-        assertThat(value, is("eyJlbnYiOnsiYW5kcm9pZCI6IjIxIn19"));
-        String defaultString = new String(Base64.decode(value, Base64.URL_SAFE | Base64.NO_WRAP), "UTF-8");
-        Map<String, Object> regular = gson.fromJson(defaultString, mapType);
-        assertThat(regular.get("name"), is(nullValue()));
-        assertThat(regular.get("version"), is(nullValue()));
-        Map<String, Object> regularEnv = (Map<String, Object>) regular.get("env");
-        assertThat(regularEnv.get("core"), is(nullValue()));
-        assertThat((String) regularEnv.get("android"), is("21"));
     }
 }


### PR DESCRIPTION
### Changes

- `core` key is now called `auth0.android` and still represents the library version value.
- Telemetry will return null when created without a valid name.

### References
OLD > SDK-503


### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

[x] This change adds unit test coverage

[x] This change adds integration test coverage

[x] This change has been tested on the latest version of the platform/language or why not

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
