### PR TITLE
Add method to specify scope when renewing a token in CredentialsManager

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -1,17 +1,19 @@
 package com.auth0.android.authentication.storage;
 
-import static android.text.TextUtils.isEmpty;
-
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+
 import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.AuthenticationCallback;
 import com.auth0.android.callback.BaseCallback;
 import com.auth0.android.request.ParameterizableRequest;
 import com.auth0.android.result.Credentials;
+
 import java.util.Date;
+
+import static android.text.TextUtils.isEmpty;
 
 /**
  * Class that handles credentials and allows to save and retrieve them.


### PR DESCRIPTION
### Changes
- Added a method to CredentialsManager to optionally include the scope when renewing a token
```java
public void getCredentials(@Nullable final String scope,
                           @NonNull final BaseCallback<Credentials, CredentialsManagerException> callback)
```
- Added unit test for new method

### References
- Closes #232 which causes renewed tokens to not have the right scope for accessing the user profile

### Testing
Added unit test, `./gradlew test` passes