### PR TITLE
Make connection_scope separate values with comma

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -183,7 +183,7 @@ public class WebAuthProvider {
         public Builder withConnectionScope(@NonNull String... connectionScope) {
             StringBuilder sb = new StringBuilder();
             for (String s : connectionScope) {
-                sb.append(s.trim()).append(" ");
+                sb.append(s.trim()).append(",");
             }
             if (sb.length() > 0) {
                 sb.deleteCharAt(sb.length() - 1);

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -407,9 +407,9 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldSetConnectionScopeFromParameters() throws Exception {
-        Map<String, Object> parameters = Collections.singletonMap("connection_scope", (Object) "openid email contacts");
+        Map<String, Object> parameters = Collections.singletonMap("connection_scope", (Object) "openid,email,contacts");
         WebAuthProvider.init(account)
-                .withConnectionScope("profile super_scope")
+                .withConnectionScope("profile", "super_scope")
                 .withParameters(parameters)
                 .start(activity, callback);
 
@@ -417,27 +417,27 @@ public class WebAuthProviderTest {
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
-        assertThat(uri, hasParamWithValue("connection_scope", "openid email contacts"));
+        assertThat(uri, hasParamWithValue("connection_scope", "openid,email,contacts"));
     }
 
     @Test
     public void shouldSetConnectionScopeFromSetter() throws Exception {
-        Map<String, Object> parameters = Collections.singletonMap("connection_scope", (Object) "openid email contacts");
+        Map<String, Object> parameters = Collections.singletonMap("connection_scope", (Object) "openid,email,contacts");
         WebAuthProvider.init(account)
                 .withParameters(parameters)
-                .withConnectionScope("profile super_scope")
+                .withConnectionScope("profile", "super_scope")
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
-        assertThat(uri, hasParamWithValue("connection_scope", "profile super_scope"));
+        assertThat(uri, hasParamWithValue("connection_scope", "profile,super_scope"));
     }
 
     @Test
     public void shouldNotOverrideConnectionScopeValueWithDefaultConnectionScope() throws Exception {
-        Map<String, Object> parameters = Collections.singletonMap("connection_scope", (Object) "openid email contacts");
+        Map<String, Object> parameters = Collections.singletonMap("connection_scope", (Object) "openid,email,contacts");
         WebAuthProvider.init(account)
                 .withParameters(parameters)
                 .start(activity, callback);
@@ -446,7 +446,7 @@ public class WebAuthProviderTest {
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
-        assertThat(uri, hasParamWithValue("connection_scope", "openid email contacts"));
+        assertThat(uri, hasParamWithValue("connection_scope", "openid,email,contacts"));
     }
 
     @Test
@@ -459,7 +459,7 @@ public class WebAuthProviderTest {
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
 
-        assertThat(uri, hasParamWithValue("connection_scope", "the scope of my connection"));
+        assertThat(uri, hasParamWithValue("connection_scope", "the,scope,of,my,connection"));
     }
 
 


### PR DESCRIPTION
### Changes

The server expects the `connection_scope` value to be a comma separated string, rather than a whitespace separated string.

### Testing

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
