### PR TITLE
Update PKCE usage requirements and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ WebAuthProvider.init(account)
 
 #### Use Code grant with PKCE
 
-> Before you can use `Code Grant` in Android, make sure to go to your [application's section](https://manage.auth0.com/#/applications) in dashboard and check in the Settings that `Client Type` is `Native`.
+> Before you can use `Code Grant` in Android, make sure to go to your [application's section](https://manage.auth0.com/#/applications) in the dashboard and check in the Settings that `Token Endpoint Authentication Method` is set to `None` and `Application Type` is set to `Native`.
 
 
 ```java

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ WebAuthProvider.init(account)
 
 #### Use Code grant with PKCE
 
-> Before you can use `Code Grant` in Android, make sure to go to your [application's section](https://manage.auth0.com/#/applications) in the dashboard and check in the Settings that `Token Endpoint Authentication Method` is set to `None` and `Application Type` is set to `Native`.
+> To use the `Code Grant` in Android, go to your [Application](https://manage.auth0.com/#/applications) in the dashboard, Settings tab, set `Application Type` to `Native` and `Token Endpoint Authentication Method` to `None`.
 
 
 ```java

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -661,7 +661,7 @@ public class AuthenticationAPIClient {
 
     /**
      * Request the revoke of a given refresh_token. Once revoked, the refresh_token cannot be used to obtain new tokens.
-     * The client must be of type 'Native' or have the 'Token Endpoint Authentication Method' set to 'none' for this endpoint to work.
+     * The application must be of type 'Native' and have the 'Token Endpoint Authentication Method' set to 'None' for this endpoint to work.
      * Example usage:
      * <pre>
      * {@code

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -661,7 +661,7 @@ public class AuthenticationAPIClient {
 
     /**
      * Request the revoke of a given refresh_token. Once revoked, the refresh_token cannot be used to obtain new tokens.
-     * The application must be of type 'Native' and have the 'Token Endpoint Authentication Method' set to 'None' for this endpoint to work.
+     * Your Auth0 Application Type should be set to 'Native' and Token Endpoint Authentication Method must be set to 'None'.
      * Example usage:
      * <pre>
      * {@code

--- a/auth0/src/main/java/com/auth0/android/provider/PKCE.java
+++ b/auth0/src/main/java/com/auth0/android/provider/PKCE.java
@@ -93,7 +93,7 @@ class PKCE {
                     @Override
                     public void onFailure(AuthenticationException error) {
                         if ("Unauthorized".equals(error.getDescription())) {
-                            Log.e(TAG, "Please go to 'https://manage.auth0.com/#/applications/" + apiClient.getClientId() + "/settings' and set 'Client Type' to 'Native' to enable PKCE.");
+                            Log.e(TAG, "Please go to 'https://manage.auth0.com/#/applications/" + apiClient.getClientId() + "/settings' and set 'Token Endpoint Authentication Method' to 'None' and 'Application Type' to 'Native' to enable PKCE.");
                         }
                         callback.onFailure(error);
                     }

--- a/auth0/src/main/java/com/auth0/android/provider/PKCE.java
+++ b/auth0/src/main/java/com/auth0/android/provider/PKCE.java
@@ -93,7 +93,7 @@ class PKCE {
                     @Override
                     public void onFailure(AuthenticationException error) {
                         if ("Unauthorized".equals(error.getDescription())) {
-                            Log.e(TAG, "Please go to 'https://manage.auth0.com/#/applications/" + apiClient.getClientId() + "/settings' and set 'Token Endpoint Authentication Method' to 'None' and 'Application Type' to 'Native' to enable PKCE.");
+                            Log.e(TAG, "Unable to complete authentication with PKCE. PKCE support can be enabled by setting Application Type to 'Native' and Token Endpoint Authentication Method to 'None' for this app at 'https://manage.auth0.com/#/applications/" + apiClient.getClientId() + "/settings'.");
                         }
                         callback.onFailure(error);
                     }


### PR DESCRIPTION
### Changes

The current requirements state that the application should be of type "native". Normally that's enough, but some users had the token endpoint authentication method set to other than "none", making the whole flow fail. 
This PR attempts to prevent this by clarifying that both settings should have a given value for PKCE to work.

### Testing

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
