### PR TITLE
Support Web authentication cancel scenario

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -166,6 +166,11 @@ public class AuthenticationException extends Auth0Exception {
         return "a0.invalid_configuration".equals(code);
     }
 
+    // When a user closes the browser app and in turn, cancels the authentication
+    public boolean isAuthenticationCanceled() {
+        return "a0.authentication_canceled".equals(code);
+    }
+
     /// When MFA code is required to authenticate
     public boolean isMultifactorRequired() {
         return "mfa_required".equals(code) || "a0.mfa_required".equals(code);

--- a/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.java
@@ -48,9 +48,10 @@ public class AuthenticationActivity extends Activity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (resultCode == RESULT_OK) {
-            deliverSuccessfulAuthenticationResult(data);
+        if (resultCode == RESULT_CANCELED) {
+            data = new Intent();
         }
+        deliverAuthenticationResult(data);
         finish();
     }
 
@@ -71,7 +72,8 @@ public class AuthenticationActivity extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
-        if (!intentLaunched && getIntent().getExtras() == null) {
+        final Intent authenticationIntent = getIntent();
+        if (!intentLaunched && authenticationIntent.getExtras() == null) {
             //Activity was launched in an unexpected way
             finish();
             return;
@@ -81,10 +83,11 @@ public class AuthenticationActivity extends Activity {
             return;
         }
 
-        if (getIntent().getData() != null) {
-            deliverSuccessfulAuthenticationResult(getIntent());
+        boolean resultMissing = authenticationIntent.getData() == null;
+        if (resultMissing) {
+            setResult(RESULT_CANCELED);
         }
-        setResult(RESULT_CANCELED);
+        deliverAuthenticationResult(authenticationIntent);
         finish();
     }
 
@@ -122,7 +125,7 @@ public class AuthenticationActivity extends Activity {
     }
 
     @VisibleForTesting
-    void deliverSuccessfulAuthenticationResult(Intent result) {
+    void deliverAuthenticationResult(Intent result) {
         WebAuthProvider.resume(result);
     }
 

--- a/auth0/src/main/java/com/auth0/android/provider/CallbackHelper.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CallbackHelper.java
@@ -30,6 +30,7 @@ import android.support.annotation.Nullable;
 import android.util.Log;
 import android.webkit.URLUtil;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -60,7 +61,11 @@ abstract class CallbackHelper {
         return uri.toString();
     }
 
-    public static Map<String, String> getValuesFromUri(@NonNull Uri uri) {
+    @NonNull
+    public static Map<String, String> getValuesFromUri(@Nullable Uri uri) {
+        if (uri == null) {
+            return Collections.emptyMap();
+        }
         return asMap(uri.getQuery() != null ? uri.getQuery() : uri.getFragment());
     }
 

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -90,8 +90,7 @@ class OAuthManager {
         this.pkce = pkce;
     }
 
-    //TODO: Internal class. Rename to "authentication"
-    void startAuthorization(Activity activity, String redirectUri, int requestCode) {
+    void startAuthentication(Activity activity, String redirectUri, int requestCode) {
         addPKCEParameters(parameters, redirectUri);
         addClientParameters(parameters, redirectUri);
         addValidationParameters(parameters);
@@ -105,8 +104,7 @@ class OAuthManager {
         }
     }
 
-    //TODO: Internal class. Rename to "authentication"
-    boolean resumeAuthorization(AuthorizeResult result) {
+    boolean resumeAuthentication(AuthorizeResult result) {
         if (!result.isValid(requestCode)) {
             Log.w(TAG, "The Authorize Result is invalid.");
             return false;

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -307,7 +307,7 @@ public class WebAuthProvider {
             managerInstance = manager;
 
             String redirectUri = CallbackHelper.getCallbackUri(scheme, activity.getApplicationContext().getPackageName(), account.getDomainUrl());
-            manager.startAuthorization(activity, redirectUri, requestCode);
+            manager.startAuthentication(activity, redirectUri, requestCode);
         }
 
         /**
@@ -364,7 +364,7 @@ public class WebAuthProvider {
             return false;
         }
         final AuthorizeResult result = new AuthorizeResult(requestCode, resultCode, intent);
-        boolean success = managerInstance.resumeAuthorization(result);
+        boolean success = managerInstance.resumeAuthentication(result);
         if (success) {
             managerInstance = null;
         }
@@ -386,7 +386,7 @@ public class WebAuthProvider {
             return false;
         }
         final AuthorizeResult result = new AuthorizeResult(intent);
-        boolean success = managerInstance.resumeAuthorization(result);
+        boolean success = managerInstance.resumeAuthentication(result);
         if (success) {
             managerInstance = null;
         }

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -354,7 +354,7 @@ public class WebAuthProvider {
      * @param requestCode the request code received on the onActivityResult() call
      * @param resultCode  the result code received on the onActivityResult() call
      * @param intent      the data received on the onActivityResult() call
-     * @return true if a result was expected and has a valid format, or false if not.
+     * @return true if a result was expected and has a valid format, or false if not. When true is returned a call on the callback is expected.
      * @deprecated This method has been deprecated since it only applied to WebView authentication and Google is no longer supporting it. Please use {@link WebAuthProvider#resume(Intent)}
      */
     @Deprecated
@@ -363,8 +363,8 @@ public class WebAuthProvider {
             Log.w(TAG, "There is no previous instance of this provider.");
             return false;
         }
-        final AuthorizeResult data = new AuthorizeResult(requestCode, resultCode, intent);
-        boolean success = managerInstance.resumeAuthorization(data);
+        final AuthorizeResult result = new AuthorizeResult(requestCode, resultCode, intent);
+        boolean success = managerInstance.resumeAuthorization(result);
         if (success) {
             managerInstance = null;
         }
@@ -377,16 +377,16 @@ public class WebAuthProvider {
      * <p>
      * This is no longer required to be called, the authentication is handled internally as long as you've correctly setup the intent-filter.
      *
-     * @param intent the data received on the onNewIntent() call
-     * @return true if a result was expected and has a valid format, or false if not.
+     * @param intent the data received on the onNewIntent() call. When null is passed, the authentication will be considered canceled.
+     * @return true if a result was expected and has a valid format, or false if not. When true is returned a call on the callback is expected.
      */
     public static boolean resume(@Nullable Intent intent) {
         if (managerInstance == null) {
             Log.w(TAG, "There is no previous instance of this provider.");
             return false;
         }
-        final AuthorizeResult data = new AuthorizeResult(intent);
-        boolean success = managerInstance.resumeAuthorization(data);
+        final AuthorizeResult result = new AuthorizeResult(intent);
+        boolean success = managerInstance.resumeAuthorization(result);
         if (success) {
             managerInstance = null;
         }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
@@ -289,6 +289,13 @@ public class AuthenticationExceptionTest {
     }
 
     @Test
+    public void shouldHaveAuthenticationCanceled() throws Exception {
+        values.put(CODE_KEY, "a0.authentication_canceled");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isAuthenticationCanceled(), is(true));
+    }
+
+    @Test
     public void shouldHavePasswordLeaked() throws Exception {
         values.put(CODE_KEY, "password_leaked");
         AuthenticationException ex = new AuthenticationException(values);

--- a/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityMock.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityMock.java
@@ -19,9 +19,9 @@ public class AuthenticationActivityMock extends AuthenticationActivity {
     }
 
     @Override
-    protected void deliverSuccessfulAuthenticationResult(Intent result) {
+    protected void deliverAuthenticationResult(Intent result) {
         this.deliveredIntent = result;
-        super.deliverSuccessfulAuthenticationResult(result);
+        super.deliverAuthenticationResult(result);
     }
 
     public void setCustomTabsController(CustomTabsController customTabsController) {

--- a/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
@@ -163,7 +163,8 @@ public class AuthenticationActivityTest {
 
         activityController.start().resume();
 
-        assertThat(activity.getDeliveredIntent(), is(nullValue()));
+        assertThat(activity.getDeliveredIntent(), is(notNullValue()));
+        assertThat(activity.getDeliveredIntent().getData(), is(nullValue())); //null data == canceled
         assertThat(activity.isFinishing(), is(true));
 
         activityController.destroy();
@@ -230,6 +231,7 @@ public class AuthenticationActivityTest {
         assertThat(webViewIntent.requestCode, is(greaterThan(0)));
         assertThat(activity.getDeliveredIntent(), is(nullValue()));
         //WebViewActivity is shown
+
         //Memory needed. Let's kill the activity
         Intent authenticationResultIntent = new Intent();
         authenticationResultIntent.setData(resultUri);
@@ -269,8 +271,10 @@ public class AuthenticationActivityTest {
         //WebViewActivity is shown
 
         shadowOf(activity).receiveResult(webViewIntent.intent, Activity.RESULT_CANCELED, null);
+        activityController.resume();
 
-        assertThat(activity.getDeliveredIntent(), is(nullValue()));
+        assertThat(activity.getDeliveredIntent(), is(notNullValue()));
+        assertThat(activity.getDeliveredIntent().getData(), is(nullValue()));
         assertThat(activity.isFinishing(), is(true));
 
         activityController.destroy();
@@ -345,6 +349,8 @@ public class AuthenticationActivityTest {
         createActivity(null);
         activityController.create(outState).start().restoreInstanceState(outState);
         activity.onActivityResult(reqCode, Activity.RESULT_OK, data);
-        activityController.resume();
+        if (!activity.isFinishing()) {
+            activityController.resume();
+        }
     }
 }

--- a/auth0/src/test/java/com/auth0/android/provider/CallbackHelperTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CallbackHelperTest.java
@@ -191,4 +191,12 @@ public class CallbackHelperTest {
         assertThat(values, notNullValue());
         assertThat(values, IsMapWithSize.<String, String>anEmptyMap());
     }
+
+    @Test
+    public void shouldGetEmptyValuesWhenUriIsNull() throws Exception {
+        Uri uri = null;
+        final Map<String, String> values = CallbackHelper.getValuesFromUri(uri);
+        assertThat(values, notNullValue());
+        assertThat(values, IsMapWithSize.<String, String>anEmptyMap());
+    }
 }


### PR DESCRIPTION
### Changes

Now when pressing the back key (or closing the browser/webview activity) the callback will receive a call to `onFailure` with an `AuthenticationException`.
On this exception one could call `isAuthenticationCanceled()` to determine if the error was caused because of the user canceling an authentication process.

The change is compatible with browser authentication and also with webview authentication (deprecated).

### References

Closes https://github.com/auth0/Auth0.Android/issues/127

### Testing

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
