### PR TITLE
Add WebAuth Logout feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Those using this library from version `1.14.0` and up should start targeting lat
 
 ```groovy
 apply plugin: 'com.android.application'
- android {
+android {
     //...
 }
- dependencies {
+dependencies {
     implementation ('com.auth0.android:lock:1.14.1'){
         exclude group: 'com.android.support', module: 'appcompat-v7'
         exclude group: 'com.android.support', module: 'customtabs'
@@ -93,7 +93,7 @@ Passwordless authentication *cannot be used* with this flag set to `true`. For m
 
 ### Authentication with Universal Login
 
-First go to the [Auth0 Dashboard](https://manage.auth0.com/#/applications) and go to your application's settings. Make sure you have in *Allowed Callback URLs* a URL with the following format:
+First go to the [Auth0 Dashboard](https://manage.auth0.com/#/applications) and go to your application's settings. Make sure you have in **Allowed Callback URLs** a URL with the following format:
 
 ```
 https://{YOUR_AUTH0_DOMAIN}/android/{YOUR_APP_PACKAGE_NAME}/callback
@@ -176,7 +176,7 @@ Finally, authenticate by showing the **Auth0 Universal Login**:
 ```java
 //Configure and launch the authentication
 WebAuthProvider.init(account)
-                .start(MainActivity.this, authCallback);
+    .start(MainActivity.this, authCallback);
 
 // Define somewhere in the code the callback
 AuthCallback authCallback = new AuthCallback() {
@@ -222,14 +222,14 @@ If you don't plan to use the _Web Authentication_ feature you will still be prom
 If you've followed this documents' configuration steps you've noticed that the default scheme used in the Callback URI is `https`. This works best for Android API 23 or newer if you're using [Android App Links](https://auth0.com/docs/applications/enable-android-app-links), but in previous Android versions this may show the intent chooser dialog prompting the user to choose either your application or the browser. You can change this behaviour by using a custom unique scheme so that the OS opens directly the link with your app.
 
 1. Update the `auth0Scheme` Manifest Placeholder on the `app/build.gradle` file or update the intent-filter declaration in the `AndroidManifest.xml` to use the new scheme.
-2. Update the allowed callback urls in your [Auth0 Dashboard](https://manage.auth0.com/#/applications) application's settings.
+2. Update the **Allowed Callback URLs** in your [Auth0 Dashboard](https://manage.auth0.com/#/applications) application's settings.
 3. Call `withScheme()` passing the custom scheme you want to use.
 
 
 ```java
 WebAuthProvider.init(account)
-                .withScheme("myapp")
-                .start(MainActivity.this, authCallback);
+    .withScheme("myapp")
+    .start(MainActivity.this, authCallback);
 ```
 
 
@@ -237,8 +237,8 @@ WebAuthProvider.init(account)
 
 ```java
 WebAuthProvider.init(account)
-                .withConnection("twitter")
-                .start(MainActivity.this, authCallback);
+    .withConnection("twitter")
+    .start(MainActivity.this, authCallback);
 ```
 
 #### Use Code grant with PKCE
@@ -248,8 +248,8 @@ WebAuthProvider.init(account)
 
 ```java
 WebAuthProvider.init(account)
-                .useCodeGrant(true)
-                .start(MainActivity.this, authCallback);
+    .useCodeGrant(true)
+    .start(MainActivity.this, authCallback);
 ```
 
 #### Specify audience
@@ -258,8 +258,8 @@ The snippet below requests the "userinfo" audience in order to guarantee OIDC co
 
 ```java
 WebAuthProvider.init(account)
-                .withAudience("https://{YOUR_AUTH0_DOMAIN}/userinfo")
-                .start(MainActivity.this, authCallback);
+    .withAudience("https://{YOUR_AUTH0_DOMAIN}/userinfo")
+    .start(MainActivity.this, authCallback);
 ```
 
 > Replace `{YOUR_AUTH0_DOMAIN}` with your actual Auth0 domain (i.e. `mytenant.auth0.com`).
@@ -268,8 +268,8 @@ WebAuthProvider.init(account)
 
 ```java
 WebAuthProvider.init(account)
-                .withScope("openid profile email")
-                .start(MainActivity.this, authCallback);
+    .withScope("openid profile email")
+    .start(MainActivity.this, authCallback);
 ```
 
 > The default scope used is `openid`
@@ -278,8 +278,8 @@ WebAuthProvider.init(account)
 
 ```java
 WebAuthProvider.init(account)
-                .withConnectionScope("email", "profile", "calendar:read")
-                .start(MainActivity.this, authCallback);
+    .withConnectionScope("email", "profile", "calendar:read")
+    .start(MainActivity.this, authCallback);
 ```
 
 
@@ -288,14 +288,14 @@ WebAuthProvider.init(account)
 If the device where the app is running has a Custom Tabs compatible Browser, a Custom Tab will be preferred for the authentication flow. You can customize the Page Title visibility and the Toolbar color by using the `CustomTabsOptions` class.
  
 ```java
- CustomTabsOptions options = CustomTabsOptions.newBuilder()
+CustomTabsOptions options = CustomTabsOptions.newBuilder()
     .withToolbarColor(R.color.ct_toolbar_color)
     .showTitle(true)
     .build();
  
-  WebAuthProvider.init(account)
-                  .withCustomTabsOptions(options)
-                  .start(MainActivity.this, authCallback);
+WebAuthProvider.init(account)
+    .withCustomTabsOptions(options)
+    .start(MainActivity.this, authCallback);
 ```
 
 
@@ -305,7 +305,7 @@ To log the user out and clear the SSO cookies that the Auth0 Server keeps attac
 
 Make sure to [revisit that section](#authentication-with-universal-login) to configure the Manifest Placeholders if you still cannot authenticate successfully. The values set there are used to generate the URL that the server will redirect the user back to after a successful log out.
 
-In order for this redirection to happen, you must copy the *Allowed Callback URLs* value you added for authentication into the *Allowed Logout URLs* field in your [application settings](https://manage.auth0.com/#/applications). Both fields should have an URL with the following format:
+In order for this redirection to happen, you must copy the **Allowed Callback URLs** value you added for authentication into the **Allowed Logout URLs** field in your [application settings](https://manage.auth0.com/#/applications). Both fields should have an URL with the following format:
 
 
 ```
@@ -316,12 +316,12 @@ Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's pac
 
 
 
-Initialize the provider, this time calling the static method `clearSession`.
+Initialize the provider, this time calling the static method `logout`.
 
 ```java
 //Configure and launch the log out
-WebAuthProvider.clearSession(account)
-                .start(MainActivity.this, logoutCallback);
+WebAuthProvider.logout(account)
+    .start(MainActivity.this, logoutCallback);
 
 //Declare the callback that will receive the result
 BaseCallback logoutCallback = new BaseCallback<Void, Auth0Exception>() {
@@ -341,32 +341,32 @@ BaseCallback logoutCallback = new BaseCallback<Void, Auth0Exception>() {
 The callback will get invoked when the user returns to your application. If this is the result of being redirected back by the server, that would be considered a success. There are some scenarios in which this can fail:
 * When there is no browser application that can open a URL. The cause of the exception will be an instance of `ActivityNotFoundException`.
 * When the user closes the browser manually, e.g. by pressing the back key on their device.
-* When the `returnTo` URL is not whitelisted in your application settings.
+* When the `returnTo` URL is not found in the **Allowed Logout URLs** in your Auth0 application settings.
 
 
 #### Customize the Custom Tabs UI
 
-Similarly to when you authenticated your users, for log out you can also customize the styling of the Custom Tabs browser. However, do note the browser is briefly shown to the user.
+If the device where the app is running has a Custom Tabs compatible Browser, a Custom Tab will be preferred for the logout flow. You can customize the Page Title visibility and the Toolbar color by using the `CustomTabsOptions` class.
 
 ```java
- CustomTabsOptions options = CustomTabsOptions.newBuilder()
+CustomTabsOptions options = CustomTabsOptions.newBuilder()
     .withToolbarColor(R.color.ct_toolbar_color)
     .showTitle(true)
     .build();
 
-  WebAuthProvider.clearSession(account)
-                  .withCustomTabsOptions(options)
-                  .start(MainActivity.this, logoutCallback);
+WebAuthProvider.logout(account)
+    .withCustomTabsOptions(options)
+    .start(MainActivity.this, logoutCallback);
 ```
 
 
-#### Changing the scheme
-The scheme used can be changed as well. This configuration will probably match what you've done for the [authentication setup](#a-note-about-app-deep-linking).
+#### Changing the Return To URL scheme
+This configuration will probably match what you've done for the [authentication setup](#a-note-about-app-deep-linking).
 
 ```java
-WebAuthProvider.clearSession(account)
-                .withScheme("myapp")
-                .start(MainActivity.this, logoutCallback);
+WebAuthProvider.logout(account)
+    .withScheme("myapp")
+    .start(MainActivity.this, logoutCallback);
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,6 @@ BaseCallback logoutCallback = new BaseCallback<Void, Auth0Exception>() {
 
 
 The callback will get invoked when the user returns to your application. If this is the result of being redirected back by the server, that would be considered a success. There are some scenarios in which this can fail:
-* When the domain is not [correctly set up](#usage) in the Auth0 instance. The cause of the exception will be an instance of `IllegalArgumentException`.
 * When there is no browser application that can open a URL. The cause of the exception will be an instance of `ActivityNotFoundException`.
 * When the user closes the browser manually, e.g. by pressing the back key on their device.
 * When the `returnTo` URL is not whitelisted in your application settings.

--- a/README.md
+++ b/README.md
@@ -303,9 +303,16 @@ If the device where the app is running has a Custom Tabs compatible Browser, a C
 
 To log the user out and clear the SSO cookies that the Auth0 Server keeps attached to your browser app, you need to call the [logout endpoint](https://auth0.com/docs/api/authentication?#logout). This can be done is a similar fashion to how you authenticated before: using the `WebAuthProvider` class.
 
-Note that the Manifest Placeholders must be set in order for the redirection to work, just like you were required to do so for the authentication flow. Make sure to [revisit that section](#authentication-with-universal-login) first if you still cannot authenticate successfully.
+Make sure to [revisit that section](#authentication-with-universal-login) to configure the Manifest Placeholders if you still cannot authenticate successfully. The values set there are used to generate the URL that the server will redirect the user back to after a successful log out.
 
-In addition, you need to whitelist in the [Auth0 Dashboard](https://manage.auth0.com/#/applications) the "return to" URL for your application settings, right into the *Allowed Logout URLs* The value of this URL is the very same of the Allowed Callback URL you've whitelisted when setting up the authentication. Remember, you must **save** the settings in the dashboard for them to apply.
+In order for this redirection to happen, you must copy the *Allowed Callback URLs* value you added for authentication into the *Allowed Logout URLs* field in your [application settings](https://manage.auth0.com/#/applications). Both fields should have an URL with the following format:
+
+
+```
+https://{YOUR_AUTH0_DOMAIN}/android/{YOUR_APP_PACKAGE_NAME}/callback
+```
+
+Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name, available in your `app/build.gradle` file as the `applicationId` value.
 
 
 
@@ -316,7 +323,7 @@ Initialize the provider, this time calling the static method `clearSession`.
 WebAuthProvider.clearSession(account)
                 .start(MainActivity.this, logoutCallback);
 
-// Define somewhere in the code the callback
+//Declare the callback that will receive the result
 BaseCallback logoutCallback = new BaseCallback<Void, Auth0Exception>() {
     @Override
     public void onFailure(Auth0Exception exception) {
@@ -334,7 +341,7 @@ BaseCallback logoutCallback = new BaseCallback<Void, Auth0Exception>() {
 The callback will get invoked when the user returns to your application. If this is the result of being redirected back by the server, that would be considered a success. There are some scenarios in which this can fail:
 * When the domain is not [correctly set up](#usage) in the Auth0 instance. The cause of the exception will be an instance of `IllegalArgumentException`.
 * When there is no browser application that can open a URL. The cause of the exception will be an instance of `ActivityNotFoundException`.
-* When the user closes the browser manually.
+* When the user closes the browser manually, e.g. by pressing the back key on their device.
 * When the `returnTo` URL is not whitelisted in your application settings.
 
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,71 @@ If the device where the app is running has a Custom Tabs compatible Browser, a C
 ```
 
 
+### Clearing the session
+
+To log the user out and clear the SSO cookies that the Auth0 Server keeps attached to your browser app, you need to call the [logout endpoint](https://auth0.com/docs/api/authentication?#logout). This can be done is a similar fashion to how you authenticated before: using the `WebAuthProvider` class.
+
+Note that the Manifest Placeholders must be set in order for the redirection to work, just like you were required to do so for the authentication flow. Make sure to [revisit that section](#authentication-with-universal-login) first if you still cannot authenticate successfully.
+
+In addition, you need to whitelist in the [Auth0 Dashboard](https://manage.auth0.com/#/applications) the "return to" URL for your application settings, right into the *Allowed Logout URLs* The value of this URL is the very same of the Allowed Callback URL you've whitelisted when setting up the authentication. Remember, you must **save** the settings in the dashboard for them to apply.
+
+
+
+Initialize the provider, this time calling the static method `clearSession`.
+
+```java
+//Configure and launch the log out
+WebAuthProvider.clearSession(account)
+                .start(MainActivity.this, logoutCallback);
+
+// Define somewhere in the code the callback
+BaseCallback logoutCallback = new BaseCallback<Void, Auth0Exception>() {
+    @Override
+    public void onFailure(Auth0Exception exception) {
+        //failed with an exception
+    }
+
+    @Override
+    public void onSuccess(@NonNull Void payload) {
+        //succeeded!
+    }
+};
+```
+
+
+The callback will get invoked when the user returns to your application. If this is the result of being redirected back by the server, that would be considered a success. There are some scenarios in which this can fail:
+* When the domain is not [correctly set up](#usage) in the Auth0 instance. The cause of the exception will be an instance of `IllegalArgumentException`.
+* When there is no browser application that can open a URL. The cause of the exception will be an instance of `ActivityNotFoundException`.
+* When the user closes the browser manually.
+* When the `returnTo` URL is not whitelisted in your application settings.
+
+
+#### Customize the Custom Tabs UI
+
+Similarly to when you authenticated your users, for log out you can also customize the styling of the Custom Tabs browser. However, do note the browser is briefly shown to the user.
+
+```java
+ CustomTabsOptions options = CustomTabsOptions.newBuilder()
+    .withToolbarColor(R.color.ct_toolbar_color)
+    .showTitle(true)
+    .build();
+
+  WebAuthProvider.clearSession(account)
+                  .withCustomTabsOptions(options)
+                  .start(MainActivity.this, logoutCallback);
+```
+
+
+#### Changing the scheme
+The scheme used can be changed as well. This configuration will probably match what you've done for the [authentication setup](#a-note-about-app-deep-linking).
+
+```java
+WebAuthProvider.clearSession(account)
+                .withScheme("myapp")
+                .start(MainActivity.this, logoutCallback);
+```
+
+
 ## Next steps
 
 ### Learning resources

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -128,7 +128,9 @@ public class Auth0 {
     }
 
     /**
-     * @return Url to perform the web flow of OAuth
+     * Obtain the authorize URL for the current domain
+     *
+     * @return Url to call to perform the web flow of OAuth
      */
     public String getAuthorizeUrl() {
         return domainUrl.newBuilder()
@@ -138,7 +140,9 @@ public class Auth0 {
     }
 
     /**
-     * @return Url to perform the web logout
+     * Obtain the logout URL for the current domain
+     *
+     * @return Url to call to perform the web logout
      */
     public String getLogoutUrl() {
         return domainUrl.newBuilder()

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -138,6 +138,17 @@ public class Auth0 {
     }
 
     /**
+     * @return Url to perform the web logout
+     */
+    public String getLogoutUrl() {
+        return domainUrl.newBuilder()
+                .addEncodedPathSegment("v2")
+                .addEncodedPathSegment("logout")
+                .build()
+                .toString();
+    }
+
+    /**
      * @return Auth0 telemetry info sent in every request
      */
     public Telemetry getTelemetry() {

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
@@ -9,7 +9,6 @@ import android.util.Log;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.Auth0Exception;
-import com.auth0.android.callback.BaseCallback;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,12 +23,12 @@ class LogoutManager extends ResumableManager {
     private static final String KEY_RETURN_TO_URL = "returnTo";
 
     private final Auth0 account;
-    private final BaseCallback<Void, Auth0Exception> callback;
+    private final VoidCallback callback;
     private final Map<String, String> parameters;
 
     private CustomTabsOptions ctOptions;
 
-    LogoutManager(@NonNull Auth0 account, @NonNull BaseCallback<Void, Auth0Exception> callback, @NonNull String returnToUrl) {
+    LogoutManager(@NonNull Auth0 account, @NonNull VoidCallback callback, @NonNull String returnToUrl) {
         this.account = account;
         this.callback = callback;
         this.parameters = new HashMap<>();

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
@@ -49,7 +49,7 @@ class LogoutManager extends ResumableManager {
     @Override
     boolean resume(AuthorizeResult result) {
         if (result.isCanceled()) {
-            Auth0Exception exception = new Auth0Exception("The user closed the browser app and the logout was cancelled.");
+            Auth0Exception exception = new Auth0Exception("The user closed the browser app so the logout was cancelled.");
             callback.onFailure(exception);
         } else {
             callback.onSuccess(null);
@@ -64,7 +64,7 @@ class LogoutManager extends ResumableManager {
             builder.appendQueryParameter(entry.getKey(), entry.getValue());
         }
         Uri uri = builder.build();
-        logDebug("Using the following LogoutURI: " + uri.toString());
+        logDebug("Using the following Logout URI: " + uri.toString());
         return uri;
     }
 

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
@@ -21,6 +21,7 @@ class LogoutManager extends ResumableManager {
 
     private static final String KEY_CLIENT_ID = "client_id";
     private static final String KEY_TELEMETRY = "auth0Client";
+    private static final String KEY_RETURN_TO_URL = "returnTo";
 
     private final Auth0 account;
     private final BaseCallback<Void, Auth0Exception> callback;
@@ -28,10 +29,11 @@ class LogoutManager extends ResumableManager {
 
     private CustomTabsOptions ctOptions;
 
-    LogoutManager(@NonNull Auth0 account, @NonNull BaseCallback<Void, Auth0Exception> callback, @NonNull Map<String, String> parameters) {
+    LogoutManager(@NonNull Auth0 account, @NonNull BaseCallback<Void, Auth0Exception> callback, @NonNull String returnToUrl) {
         this.account = account;
         this.callback = callback;
-        this.parameters = new HashMap<>(parameters);
+        this.parameters = new HashMap<>();
+        this.parameters.put(KEY_RETURN_TO_URL, returnToUrl);
     }
 
     void setCustomTabsOptions(@Nullable CustomTabsOptions options) {

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @SuppressWarnings("WeakerAccess")
-class LogoutManager {
+class LogoutManager extends ResumableManager {
 
     private static final String TAG = LogoutManager.class.getSimpleName();
 
@@ -38,20 +38,22 @@ class LogoutManager {
         this.ctOptions = options;
     }
 
-    void launchLogout(Context context) {
+    void startLogout(Context context) {
         addClientParameters(parameters);
         Uri uri = buildLogoutUri();
 
         AuthenticationActivity.authenticateUsingBrowser(context, uri, ctOptions);
     }
 
-    void resume(AuthorizeResult result) {
+    @Override
+    boolean resume(AuthorizeResult result) {
         if (result.isCanceled()) {
             Auth0Exception exception = new Auth0Exception("The user closed the browser app and the log out was cancelled.");
             callback.onFailure(exception);
-            return;
+        } else {
+            callback.onSuccess(null);
         }
-        callback.onSuccess(null);
+        return true;
     }
 
     private Uri buildLogoutUri() {

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
@@ -50,7 +50,7 @@ class LogoutManager extends ResumableManager {
     @Override
     boolean resume(AuthorizeResult result) {
         if (result.isCanceled()) {
-            Auth0Exception exception = new Auth0Exception("The user closed the browser app and the log out was cancelled.");
+            Auth0Exception exception = new Auth0Exception("The user closed the browser app and the logout was cancelled.");
             callback.onFailure(exception);
         } else {
             callback.onSuccess(null);

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
@@ -1,0 +1,85 @@
+package com.auth0.android.provider;
+
+import android.content.Context;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+import android.util.Log;
+
+import com.auth0.android.Auth0;
+import com.auth0.android.Auth0Exception;
+import com.auth0.android.callback.BaseCallback;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@SuppressWarnings("WeakerAccess")
+class LogoutManager {
+
+    private static final String TAG = LogoutManager.class.getSimpleName();
+
+    private static final String KEY_CLIENT_ID = "client_id";
+    private static final String KEY_TELEMETRY = "auth0Client";
+
+    private final Auth0 account;
+    private final BaseCallback<Void, Auth0Exception> callback;
+    private final Map<String, String> parameters;
+
+    private CustomTabsOptions ctOptions;
+
+    LogoutManager(@NonNull Auth0 account, @NonNull BaseCallback<Void, Auth0Exception> callback, @NonNull Map<String, String> parameters) {
+        this.account = account;
+        this.callback = callback;
+        this.parameters = new HashMap<>(parameters);
+    }
+
+    void setCustomTabsOptions(@Nullable CustomTabsOptions options) {
+        this.ctOptions = options;
+    }
+
+    void launchLogout(Context context) {
+        addClientParameters(parameters);
+        Uri uri = buildLogoutUri();
+
+        AuthenticationActivity.authenticateUsingBrowser(context, uri, ctOptions);
+    }
+
+    void resume(AuthorizeResult result) {
+        if (result.isCanceled()) {
+            Auth0Exception exception = new Auth0Exception("The user closed the browser app and the log out was cancelled.");
+            callback.onFailure(exception);
+            return;
+        }
+        callback.onSuccess(null);
+    }
+
+    private Uri buildLogoutUri() {
+        Uri logoutUri = Uri.parse(account.getLogoutUrl());
+        Uri.Builder builder = logoutUri.buildUpon();
+        for (Map.Entry<String, String> entry : parameters.entrySet()) {
+            builder.appendQueryParameter(entry.getKey(), entry.getValue());
+        }
+        Uri uri = builder.build();
+        logDebug("Using the following LogoutURI: " + uri.toString());
+        return uri;
+    }
+
+    private void addClientParameters(Map<String, String> parameters) {
+        if (account.getTelemetry() != null) {
+            parameters.put(KEY_TELEMETRY, account.getTelemetry().getValue());
+        }
+        parameters.put(KEY_CLIENT_ID, account.getClientId());
+    }
+
+    @VisibleForTesting
+    CustomTabsOptions customTabsOptions() {
+        return ctOptions;
+    }
+
+    private void logDebug(String message) {
+        if (account.isLoggingEnabled()) {
+            Log.d(TAG, message);
+        }
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @SuppressWarnings("WeakerAccess")
-class OAuthManager {
+class OAuthManager extends ResumableManager {
 
     private static final String TAG = OAuthManager.class.getSimpleName();
 
@@ -104,7 +104,8 @@ class OAuthManager {
         }
     }
 
-    boolean resumeAuthentication(AuthorizeResult result) {
+    @Override
+    boolean resume(AuthorizeResult result) {
         if (!result.isValid(requestCode)) {
             Log.w(TAG, "The Authorize Result is invalid.");
             return false;

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -221,7 +221,7 @@ class OAuthManager extends ResumableManager {
             builder.appendQueryParameter(entry.getKey(), entry.getValue());
         }
         Uri uri = builder.build();
-        logDebug("Using the following AuthorizeURI: " + uri.toString());
+        logDebug("Using the following Authorize URI: " + uri.toString());
         return uri;
     }
 

--- a/auth0/src/main/java/com/auth0/android/provider/ResumableManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/ResumableManager.java
@@ -1,0 +1,16 @@
+package com.auth0.android.provider;
+
+/**
+ * Internal class, used to generify the handling of different Web Auth flows.
+ * See {@link WebAuthProvider}
+ */
+abstract class ResumableManager {
+
+    /**
+     * Invoked when the result is available
+     *
+     * @param result the result created from an {@link android.content.Intent}
+     * @return whether the result was expected and valid or not. Error or cancel scenarios are also considered valid.
+     */
+    abstract boolean resume(AuthorizeResult result);
+}

--- a/auth0/src/main/java/com/auth0/android/provider/ResumableManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/ResumableManager.java
@@ -7,10 +7,11 @@ package com.auth0.android.provider;
 abstract class ResumableManager {
 
     /**
-     * Invoked when the result is available
+     * Invoked when a result of a Web Auth flow is available
      *
-     * @param result the result created from an {@link android.content.Intent}
+     * @param result a result created from an {@link android.content.Intent}.
      * @return whether the result was expected and valid or not. Error or cancel scenarios are also considered valid.
+     * @see AuthorizeResult
      */
     abstract boolean resume(AuthorizeResult result);
 }

--- a/auth0/src/main/java/com/auth0/android/provider/VoidCallback.java
+++ b/auth0/src/main/java/com/auth0/android/provider/VoidCallback.java
@@ -1,0 +1,35 @@
+/*
+ * AuthCallback.java
+ *
+ * Copyright (c) 2016 Auth0 (http://auth0.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.auth0.android.provider;
+
+import com.auth0.android.Auth0Exception;
+import com.auth0.android.callback.BaseCallback;
+
+/**
+ * Generic callback called on success/failure, that receives no payload when succeeds.
+ */
+@SuppressWarnings("WeakerAccess")
+public interface VoidCallback extends BaseCallback<Void, Auth0Exception> {
+}

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -76,7 +76,7 @@ public class WebAuthProvider {
         }
 
         /**
-         * When using a Custom Tabs compatible Browser, apply this customization options.
+         * When using a Custom Tabs compatible Browser, apply these customization options.
          *
          * @param options the Custom Tabs customization options
          * @return the current builder instance
@@ -95,7 +95,7 @@ public class WebAuthProvider {
         public LogoutBuilder withScheme(@NonNull String scheme) {
             String lowerCase = scheme.toLowerCase();
             if (!scheme.equals(lowerCase)) {
-                Log.w(TAG, "Please provide the scheme in lowercase and make sure it's the same configured in the intent filter. Android expects the scheme in lowercase");
+                Log.w(TAG, "Please provide the scheme in lowercase and make sure it's the same configured in the intent filter. Android expects the scheme to be lowercase.");
             }
             this.scheme = scheme;
             return this;
@@ -224,7 +224,7 @@ public class WebAuthProvider {
         public Builder withScheme(@NonNull String scheme) {
             String lowerCase = scheme.toLowerCase();
             if (!scheme.equals(lowerCase)) {
-                Log.w(TAG, "Please provide the scheme in lowercase and make sure it's the same configured in the intent filter. Android expects the scheme in lowercase");
+                Log.w(TAG, "Please provide the scheme in lowercase and make sure it's the same configured in the intent filter. Android expects the scheme to be lowercase.");
             }
             this.scheme = scheme;
             return this;
@@ -320,7 +320,7 @@ public class WebAuthProvider {
         }
 
         /**
-         * When using a Custom Tabs compatible Browser, apply this customization options.
+         * When using a Custom Tabs compatible Browser, apply these customization options.
          *
          * @param options the Custom Tabs customization options
          * @return the current builder instance
@@ -386,10 +386,7 @@ public class WebAuthProvider {
      * @param account to use for authentication
      * @return a new Builder instance to customize.
      */
-    public static LogoutBuilder clearSession(@NonNull Auth0 account) {
-        //TODO: Should this method be named "logOut" or similar?
-        // given that the "authentication" method is called "init" it might be
-        // confusing whether init should be called always before a log out.
+    public static LogoutBuilder logout(@NonNull Auth0 account) {
         return new LogoutBuilder(account);
     }
 

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -108,6 +108,7 @@ public class WebAuthProvider {
          * @param callback to invoke when log out is successful
          */
         public void start(Context context, BaseCallback<Void, Auth0Exception> callback) {
+
             managerInstance = null;
             if (account.getLogoutUrl() == null) {
                 Throwable cause = new IllegalArgumentException("Auth0 logout URL not properly set. This can be related to an invalid domain.");

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -64,11 +64,7 @@ public class WebAuthProvider {
 
     public static class LogoutBuilder {
 
-        private static final String KEY_FEDERATED = "federated";
-        private static final String KEY_RETURN_TO_URL = "returnTo";
-
         private final Auth0 account;
-        private final Map<String, String> values;
         private String scheme;
         private CustomTabsOptions ctOptions;
 
@@ -77,7 +73,6 @@ public class WebAuthProvider {
 
             //Default values
             this.scheme = "https";
-            this.values = new HashMap<>();
         }
 
         /**
@@ -107,21 +102,6 @@ public class WebAuthProvider {
         }
 
         /**
-         * Whether to also clear the session from the identity provider when possible or not.
-         *
-         * @param federatedLogout true to clear the session on the identity provider's site.
-         * @return the current builder instance
-         */
-        public LogoutBuilder useFederatedLogout(@NonNull boolean federatedLogout) {
-            if (federatedLogout) {
-                this.values.put(KEY_FEDERATED, "1");
-            } else {
-                this.values.remove(KEY_FEDERATED);
-            }
-            return this;
-        }
-
-        /**
          * Request the user session to be cleared. When successful, the callback will get invoked
          *
          * @param context  to run the log out
@@ -144,8 +124,7 @@ public class WebAuthProvider {
             }
 
             String returnToUrl = CallbackHelper.getCallbackUri(scheme, context.getApplicationContext().getPackageName(), account.getDomainUrl());
-            this.values.put(KEY_RETURN_TO_URL, returnToUrl);
-            LogoutManager logoutManager = new LogoutManager(this.account, callback, this.values);
+            LogoutManager logoutManager = new LogoutManager(this.account, callback, returnToUrl);
             logoutManager.setCustomTabsOptions(ctOptions);
 
             managerInstance = logoutManager;
@@ -412,7 +391,7 @@ public class WebAuthProvider {
 
     /**
      * Initialize the WebAuthProvider instance for logging out the user using an account. Additional settings can be configured
-     * in the LogoutBuilder, like setting the federated parameter.
+     * in the LogoutBuilder, like changing the scheme of the return to URL.
      *
      * @param account to use for authentication
      * @return a new Builder instance to customize.

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -110,12 +110,6 @@ public class WebAuthProvider {
         public void start(Context context, BaseCallback<Void, Auth0Exception> callback) {
 
             managerInstance = null;
-            if (account.getLogoutUrl() == null) {
-                Throwable cause = new IllegalArgumentException("Auth0 logout URL not properly set. This can be related to an invalid domain.");
-                final Auth0Exception ex = new Auth0Exception("Cannot perform web log out", cause);
-                callback.onFailure(ex);
-                return;
-            }
 
             if (!hasBrowserAppInstalled(context.getPackageManager())) {
                 Throwable cause = new ActivityNotFoundException("No Browser application installed.");
@@ -353,11 +347,6 @@ public class WebAuthProvider {
         @Deprecated
         public void start(@NonNull Activity activity, @NonNull AuthCallback callback, int requestCode) {
             managerInstance = null;
-            if (account.getAuthorizeUrl() == null) {
-                final AuthenticationException ex = new AuthenticationException("a0.invalid_authorize_url", "Auth0 authorize URL not properly set. This can be related to an invalid domain.");
-                callback.onFailure(ex);
-                return;
-            }
 
             if (useBrowser && !hasBrowserAppInstalled(activity.getPackageManager())) {
                 AuthenticationException ex = new AuthenticationException("a0.browser_not_available", "No Browser application installed to perform web authentication.");

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -107,7 +107,7 @@ public class WebAuthProvider {
          * @param context  to run the log out
          * @param callback to invoke when log out is successful
          */
-        public void start(Context context, BaseCallback<Void, Auth0Exception> callback) {
+        public void start(Context context, VoidCallback callback) {
 
             managerInstance = null;
 

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -271,6 +271,16 @@ public class Auth0Test {
     }
 
     @Test
+    public void shouldReturnLogoutUrl() throws Exception {
+        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
+
+        final HttpUrl url = HttpUrl.parse(auth0.getLogoutUrl());
+        assertThat(url, hasScheme("https"));
+        assertThat(url, hasHost(DOMAIN));
+        assertThat(url, hasPath("v2", "logout"));
+    }
+
+    @Test
     public void shouldNotReturnTelemetryWhenExplicitlyDisabledThem() throws Exception {
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
         auth0.doNotSendTelemetry();

--- a/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
@@ -2,7 +2,6 @@ package com.auth0.android.provider;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.Auth0Exception;
-import com.auth0.android.callback.BaseCallback;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,7 +34,7 @@ public class LogoutManagerTest {
     @Mock
     Auth0 account;
     @Mock
-    BaseCallback<Void, Auth0Exception> callback;
+    VoidCallback callback;
 
     @Before
     public void setUp() throws Exception {
@@ -65,7 +64,7 @@ public class LogoutManagerTest {
         ArgumentCaptor<Auth0Exception> exceptionCaptor = ArgumentCaptor.forClass(Auth0Exception.class);
         verify(callback).onFailure(exceptionCaptor.capture());
         assertThat(exceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(exceptionCaptor.getValue().getMessage(), is("The user closed the browser app and the log out was cancelled."));
+        assertThat(exceptionCaptor.getValue().getMessage(), is("The user closed the browser app and the logout was cancelled."));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
@@ -43,33 +43,33 @@ public class LogoutManagerTest {
 
     @Test
     public void shouldNotHaveCustomTabsOptionsByDefault() throws Exception {
-        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/callback");
+        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/android/my.app.name/callback");
         assertThat(manager.customTabsOptions(), is(nullValue()));
     }
 
     @Test
     public void shouldSetCustomTabsOptions() throws Exception {
         CustomTabsOptions options = mock(CustomTabsOptions.class);
-        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/callback");
+        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/android/my.app.name/callback");
         manager.setCustomTabsOptions(options);
         assertThat(manager.customTabsOptions(), is(options));
     }
 
     @Test
     public void shouldCallOnFailureWhenResumedWithCanceledResult() throws Exception {
-        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/callback");
+        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/android/my.app.name/callback");
         AuthorizeResult result = mock(AuthorizeResult.class);
         when(result.isCanceled()).thenReturn(true);
         manager.resume(result);
         ArgumentCaptor<Auth0Exception> exceptionCaptor = ArgumentCaptor.forClass(Auth0Exception.class);
         verify(callback).onFailure(exceptionCaptor.capture());
         assertThat(exceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(exceptionCaptor.getValue().getMessage(), is("The user closed the browser app and the logout was cancelled."));
+        assertThat(exceptionCaptor.getValue().getMessage(), is("The user closed the browser app so the logout was cancelled."));
     }
 
     @Test
     public void shouldCallOnSuccessWhenResumedWithValidResult() throws Exception {
-        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/callback");
+        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/android/my.app.name/callback");
         AuthorizeResult result = mock(AuthorizeResult.class);
         when(result.isCanceled()).thenReturn(false);
         manager.resume(result);

--- a/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
@@ -15,8 +15,6 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.HashMap;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -46,21 +44,21 @@ public class LogoutManagerTest {
 
     @Test
     public void shouldNotHaveCustomTabsOptionsByDefault() throws Exception {
-        LogoutManager manager = new LogoutManager(account, callback, new HashMap<String, String>());
+        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/callback");
         assertThat(manager.customTabsOptions(), is(nullValue()));
     }
 
     @Test
     public void shouldSetCustomTabsOptions() throws Exception {
         CustomTabsOptions options = mock(CustomTabsOptions.class);
-        LogoutManager manager = new LogoutManager(account, callback, new HashMap<String, String>());
+        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/callback");
         manager.setCustomTabsOptions(options);
         assertThat(manager.customTabsOptions(), is(options));
     }
 
     @Test
     public void shouldCallOnFailureWhenResumedWithCanceledResult() throws Exception {
-        LogoutManager manager = new LogoutManager(account, callback, new HashMap<String, String>());
+        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/callback");
         AuthorizeResult result = mock(AuthorizeResult.class);
         when(result.isCanceled()).thenReturn(true);
         manager.resume(result);
@@ -72,7 +70,7 @@ public class LogoutManagerTest {
 
     @Test
     public void shouldCallOnSuccessWhenResumedWithValidResult() throws Exception {
-        LogoutManager manager = new LogoutManager(account, callback, new HashMap<String, String>());
+        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/callback");
         AuthorizeResult result = mock(AuthorizeResult.class);
         when(result.isCanceled()).thenReturn(false);
         manager.resume(result);

--- a/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
@@ -1,0 +1,83 @@
+package com.auth0.android.provider;
+
+import com.auth0.android.Auth0;
+import com.auth0.android.Auth0Exception;
+import com.auth0.android.callback.BaseCallback;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 18)
+public class LogoutManagerTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Mock
+    Auth0 account;
+    @Mock
+    BaseCallback<Void, Auth0Exception> callback;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldNotHaveCustomTabsOptionsByDefault() throws Exception {
+        LogoutManager manager = new LogoutManager(account, callback, new HashMap<String, String>());
+        assertThat(manager.customTabsOptions(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetCustomTabsOptions() throws Exception {
+        CustomTabsOptions options = mock(CustomTabsOptions.class);
+        LogoutManager manager = new LogoutManager(account, callback, new HashMap<String, String>());
+        manager.setCustomTabsOptions(options);
+        assertThat(manager.customTabsOptions(), is(options));
+    }
+
+    @Test
+    public void shouldCallOnFailureWhenResumedWithCanceledResult() throws Exception {
+        LogoutManager manager = new LogoutManager(account, callback, new HashMap<String, String>());
+        AuthorizeResult result = mock(AuthorizeResult.class);
+        when(result.isCanceled()).thenReturn(true);
+        manager.resume(result);
+        ArgumentCaptor<Auth0Exception> exceptionCaptor = ArgumentCaptor.forClass(Auth0Exception.class);
+        verify(callback).onFailure(exceptionCaptor.capture());
+        assertThat(exceptionCaptor.getValue(), is(notNullValue()));
+        assertThat(exceptionCaptor.getValue().getMessage(), is("The user closed the browser app and the log out was cancelled."));
+    }
+
+    @Test
+    public void shouldCallOnSuccessWhenResumedWithValidResult() throws Exception {
+        LogoutManager manager = new LogoutManager(account, callback, new HashMap<String, String>());
+        AuthorizeResult result = mock(AuthorizeResult.class);
+        when(result.isCanceled()).thenReturn(false);
+        manager.resume(result);
+        verify(callback).onSuccess(any(Void.class));
+
+    }
+
+}

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -22,7 +22,6 @@ import android.webkit.URLUtil;
 import com.auth0.android.Auth0;
 import com.auth0.android.Auth0Exception;
 import com.auth0.android.authentication.AuthenticationException;
-import com.auth0.android.callback.BaseCallback;
 import com.auth0.android.result.Credentials;
 
 import org.hamcrest.CoreMatchers;
@@ -1771,7 +1770,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldInitLogoutWithAccount() throws Exception {
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .start(activity, voidCallback);
 
         assertNotNull(WebAuthProvider.getManagerInstance());
@@ -1781,7 +1780,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldHaveDefaultSchemeOnLogout() throws Exception {
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .start(activity, voidCallback);
         verify(activity).startActivity(intentCaptor.capture());
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
@@ -1794,7 +1793,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldSetSchemeOnLogout() throws Exception {
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .withScheme("myapp")
                 .start(activity, voidCallback);
 
@@ -1811,7 +1810,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldAlwaysSetClientIdOnLogout() throws Exception {
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
@@ -1825,7 +1824,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldHaveTelemetryInfoOnLogout() throws Exception {
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
@@ -1837,7 +1836,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldHaveReturnToUriOnLogout() throws Exception {
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
@@ -1854,7 +1853,7 @@ public class WebAuthProviderTest {
     @SuppressWarnings("deprecation")
     @Test
     public void shouldStartLogout() throws Exception {
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
@@ -1878,7 +1877,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldStartLogoutWithCustomTabsOptions() throws Exception {
         CustomTabsOptions options = mock(CustomTabsOptions.class);
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .withCustomTabsOptions(options)
                 .start(activity, voidCallback);
 
@@ -1903,7 +1902,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldFailToStartLogoutWhenNoBrowserAppIsInstalled() throws Exception {
         prepareBrowserApp(false, null);
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .start(activity, voidCallback);
 
         verify(voidCallback).onFailure(auth0ExceptionCaptor.capture());
@@ -1918,7 +1917,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldResumeLogoutSuccessfullyWithIntent() throws Exception {
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
@@ -1933,7 +1932,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldResumeLogoutFailingWithIntent() throws Exception {
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
@@ -1947,13 +1946,13 @@ public class WebAuthProviderTest {
         verify(voidCallback).onFailure(auth0ExceptionCaptor.capture());
 
         assertThat(auth0ExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(auth0ExceptionCaptor.getValue().getMessage(), is("The user closed the browser app and the logout was cancelled."));
+        assertThat(auth0ExceptionCaptor.getValue().getMessage(), is("The user closed the browser app so the logout was cancelled."));
         assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
     }
 
     @Test
     public void shouldClearLogoutManagerInstanceAfterSuccessfulLogout() throws Exception {
-        WebAuthProvider.clearSession(account)
+        WebAuthProvider.logout(account)
                 .start(activity, voidCallback);
 
         assertThat(WebAuthProvider.getManagerInstance(), is(notNullValue()));

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -1986,7 +1986,7 @@ public class WebAuthProviderTest {
         verify(baseCallback).onFailure(auth0ExceptionCaptor.capture());
 
         assertThat(auth0ExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(auth0ExceptionCaptor.getValue().getMessage(), is("The user closed the browser app and the log out was cancelled."));
+        assertThat(auth0ExceptionCaptor.getValue().getMessage(), is("The user closed the browser app and the logout was cancelled."));
         assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
     }
 

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -2,6 +2,7 @@ package com.auth0.android.provider;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
@@ -19,9 +20,12 @@ import android.util.Base64;
 import android.webkit.URLUtil;
 
 import com.auth0.android.Auth0;
+import com.auth0.android.Auth0Exception;
 import com.auth0.android.authentication.AuthenticationException;
+import com.auth0.android.callback.BaseCallback;
 import com.auth0.android.result.Credentials;
 
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.Is;
 import org.junit.Before;
@@ -89,6 +93,8 @@ public class WebAuthProviderTest {
     private Auth0 account;
 
     @Captor
+    private ArgumentCaptor<Auth0Exception> auth0ExceptionCaptor;
+    @Captor
     private ArgumentCaptor<AuthenticationException> authExceptionCaptor;
     @Captor
     private ArgumentCaptor<Intent> intentCaptor;
@@ -110,13 +116,19 @@ public class WebAuthProviderTest {
         prepareBrowserApp(true, null);
     }
 
+    //** ** ** ** ** **  **//
+    //** ** ** ** ** **  **//
+    //** LOG IN  FEATURE **//
+    //** ** ** ** ** **  **//
+    //** ** ** ** ** **  **//
+
     @SuppressWarnings("deprecation")
     @Test
     public void shouldInitWithAccount() throws Exception {
         WebAuthProvider.init(account)
                 .start(activity, callback, REQUEST_CODE);
 
-        assertNotNull(WebAuthProvider.getInstance());
+        assertNotNull(WebAuthProvider.getManagerInstance());
     }
 
     @Test
@@ -133,16 +145,22 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(context)
                 .start(activity, callback);
 
-        assertNotNull(WebAuthProvider.getInstance());
+        assertNotNull(WebAuthProvider.getManagerInstance());
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void shouldNotResumeWhenNotInit() throws Exception {
+    public void shouldNotResumeWithRequestCodeWhenNotInit() throws Exception {
+        Intent intentMock = Mockito.mock(Intent.class);
+
+        assertFalse(WebAuthProvider.resume(0, 0, intentMock));
+    }
+
+    @Test
+    public void shouldNotResumeWithIntentWhenNotInit() throws Exception {
         Intent intentMock = Mockito.mock(Intent.class);
 
         assertFalse(WebAuthProvider.resume(intentMock));
-        assertFalse(WebAuthProvider.resume(0, 0, intentMock));
     }
 
     //scheme
@@ -1086,7 +1104,7 @@ public class WebAuthProviderTest {
         assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
         assertThat(authExceptionCaptor.getValue().getCode(), is("a0.invalid_authorize_url"));
         assertThat(authExceptionCaptor.getValue().getDescription(), is("Auth0 authorize URL not properly set. This can be related to an invalid domain."));
-        assertThat(WebAuthProvider.getInstance(), is(nullValue()));
+        assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
     }
 
     @SuppressWarnings("deprecation")
@@ -1324,7 +1342,8 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .useCodeGrant(false)
                 .start(activity, callback, REQUEST_CODE);
-        WebAuthProvider.getInstance().setCurrentTimeInMillis(CURRENT_TIME_MS);
+        OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
+        managerInstance.setCurrentTimeInMillis(CURRENT_TIME_MS);
 
         verify(activity).startActivity(intentCaptor.capture());
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
@@ -1684,10 +1703,10 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .start(activity, callback);
 
-        assertThat(WebAuthProvider.getInstance(), is(notNullValue()));
+        assertThat(WebAuthProvider.getManagerInstance(), is(notNullValue()));
         Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", null, null));
         assertTrue(WebAuthProvider.resume(intent));
-        assertThat(WebAuthProvider.getInstance(), is(nullValue()));
+        assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
     }
 
     @SuppressWarnings("deprecation")
@@ -1696,10 +1715,10 @@ public class WebAuthProviderTest {
         WebAuthProvider.init(account)
                 .start(activity, callback, REQUEST_CODE);
 
-        assertThat(WebAuthProvider.getInstance(), is(notNullValue()));
+        assertThat(WebAuthProvider.getManagerInstance(), is(notNullValue()));
         Intent intent = createAuthIntent(createHash("iToken", "aToken", null, "refresh_token", null, "1234567890", null, null));
         assertTrue(WebAuthProvider.resume(REQUEST_CODE, Activity.RESULT_OK, intent));
-        assertThat(WebAuthProvider.getInstance(), is(nullValue()));
+        assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
     }
 
     @Test
@@ -1714,7 +1733,7 @@ public class WebAuthProviderTest {
         assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
         assertThat(authExceptionCaptor.getValue().getCode(), is("a0.browser_not_available"));
         assertThat(authExceptionCaptor.getValue().getDescription(), is("No Browser application installed to perform web authentication."));
-        assertThat(WebAuthProvider.getInstance(), is(nullValue()));
+        assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
     }
 
     @SuppressWarnings("deprecation")
@@ -1741,7 +1760,7 @@ public class WebAuthProviderTest {
         ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
         prepareBrowserApp(true, intentCaptor);
 
-        boolean hasBrowserApp = WebAuthProvider.Builder.hasBrowserAppInstalled(activity.getPackageManager());
+        boolean hasBrowserApp = WebAuthProvider.hasBrowserAppInstalled(activity.getPackageManager());
         MatcherAssert.assertThat(hasBrowserApp, Is.is(true));
         MatcherAssert.assertThat(intentCaptor.getValue(), Is.is(IntentMatchers.hasAction(Intent.ACTION_VIEW)));
         MatcherAssert.assertThat(URLUtil.isValidUrl(intentCaptor.getValue().getDataString()), Is.is(true));
@@ -1752,12 +1771,278 @@ public class WebAuthProviderTest {
         ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
         prepareBrowserApp(false, intentCaptor);
 
-        boolean hasBrowserApp = WebAuthProvider.Builder.hasBrowserAppInstalled(activity.getPackageManager());
+        boolean hasBrowserApp = WebAuthProvider.hasBrowserAppInstalled(activity.getPackageManager());
         MatcherAssert.assertThat(hasBrowserApp, Is.is(false));
         MatcherAssert.assertThat(intentCaptor.getValue(), Is.is(IntentMatchers.hasAction(Intent.ACTION_VIEW)));
         MatcherAssert.assertThat(URLUtil.isValidUrl(intentCaptor.getValue().getDataString()), Is.is(true));
     }
 
+
+    //** ** ** ** ** **  **//
+    //** ** ** ** ** **  **//
+    //** LOG OUT FEATURE **//
+    //** ** ** ** ** **  **//
+    //** ** ** ** ** **  **//
+
+    @Mock
+    private BaseCallback<Void, Auth0Exception> baseCallback;
+
+    @Captor
+    private ArgumentCaptor<BaseCallback> baseCallbackCaptor;
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldInitLogoutWithAccount() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+
+        assertNotNull(WebAuthProvider.getManagerInstance());
+    }
+
+    //scheme
+
+    @Test
+    public void shouldHaveDefaultSchemeOnLogout() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        assertThat(uri, hasParamWithName("returnTo"));
+        Uri returnToUri = Uri.parse(uri.getQueryParameter("returnTo"));
+        assertThat(returnToUri, hasScheme("https"));
+    }
+
+    @Test
+    public void shouldSetSchemeOnLogout() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .withScheme("myapp")
+                .start(activity, baseCallback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        assertThat(uri, hasParamWithName("returnTo"));
+        Uri returnToUri = Uri.parse(uri.getQueryParameter("returnTo"));
+        assertThat(returnToUri, hasScheme("myapp"));
+    }
+
+    // client id
+
+    @Test
+    public void shouldAlwaysSetClientIdOnLogout() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        assertThat(uri, hasParamWithValue("client_id", "clientId"));
+    }
+
+    // federated
+
+    @Test
+    public void shouldNotSendFederatedByDefaultOnLogout() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        assertThat(uri, not(hasParamWithName("federated")));
+    }
+
+    @Test
+    public void shouldNotSendFederatedWhenRequestedOnLogout() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .useFederatedLogout(false)
+                .start(activity, baseCallback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        assertThat(uri, not(hasParamWithName("federated")));
+    }
+
+    @Test
+    public void shouldSetFederatedWhenRequestedOnLogout() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .useFederatedLogout(true)
+                .start(activity, baseCallback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        assertThat(uri, hasParamWithValue("federated", "1"));
+    }
+
+
+    // auth0 related
+
+    @Test
+    public void shouldHaveTelemetryInfoOnLogout() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        assertThat(uri, hasParamWithValue(is("auth0Client"), not(isEmptyOrNullString())));
+    }
+
+    @Test
+    public void shouldHaveReturnToUriOnLogout() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        assertThat(uri.getQueryParameter("returnTo"), is("https://domain/android/com.auth0.android.auth0.test/callback"));
+    }
+
+
+    // Launch log out
+
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldStartLogout() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+
+        Intent intent = intentCaptor.getValue();
+        assertThat(intent, is(notNullValue()));
+        assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
+        assertThat(intent, hasFlag(Intent.FLAG_ACTIVITY_CLEAR_TOP));
+        assertThat(intent.getData(), is(nullValue()));
+
+        Bundle extras = intentCaptor.getValue().getExtras();
+        assertThat(extras.getParcelable(AuthenticationActivity.EXTRA_AUTHORIZE_URI), is(notNullValue()));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CONNECTION_NAME), is(false));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(false));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CT_OPTIONS), is(true));
+        assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
+        assertThat(extras.getParcelable(AuthenticationActivity.EXTRA_CT_OPTIONS), is(nullValue()));
+    }
+
+    @Test
+    public void shouldStartLogoutWithCustomTabsOptions() throws Exception {
+        CustomTabsOptions options = mock(CustomTabsOptions.class);
+        WebAuthProvider.clearSession(account)
+                .withCustomTabsOptions(options)
+                .start(activity, baseCallback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+
+        Intent intent = intentCaptor.getValue();
+        assertThat(intent, is(notNullValue()));
+        assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
+        assertThat(intent, hasFlag(Intent.FLAG_ACTIVITY_CLEAR_TOP));
+        assertThat(intent.getData(), is(nullValue()));
+
+        Bundle extras = intentCaptor.getValue().getExtras();
+        assertThat(extras.getParcelable(AuthenticationActivity.EXTRA_AUTHORIZE_URI), is(notNullValue()));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CONNECTION_NAME), is(false));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_FULL_SCREEN), is(false));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
+        assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CT_OPTIONS), is(true));
+        assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
+        assertThat((CustomTabsOptions) extras.getParcelable(AuthenticationActivity.EXTRA_CT_OPTIONS), is(options));
+    }
+
+    @Test
+    public void shouldFailToStartLogoutWithInvalidLogoutURI() throws Exception {
+        Auth0 account = Mockito.mock(Auth0.class);
+        when(account.getLogoutUrl()).thenReturn(null);
+
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+
+        verify(baseCallback).onFailure(auth0ExceptionCaptor.capture());
+
+        assertThat(auth0ExceptionCaptor.getValue(), is(notNullValue()));
+        assertThat(auth0ExceptionCaptor.getValue().getMessage(), is("Cannot perform web log out"));
+        Throwable cause = auth0ExceptionCaptor.getValue().getCause();
+        assertThat(cause, is(CoreMatchers.<Throwable>instanceOf(IllegalArgumentException.class)));
+        assertThat(cause.getMessage(), is("Auth0 logout URL not properly set. This can be related to an invalid domain."));
+        assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldFailToStartLogoutWhenNoBrowserAppIsInstalled() throws Exception {
+        prepareBrowserApp(false, null);
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+
+        verify(baseCallback).onFailure(auth0ExceptionCaptor.capture());
+
+        assertThat(auth0ExceptionCaptor.getValue(), is(notNullValue()));
+        assertThat(auth0ExceptionCaptor.getValue().getMessage(), is("Cannot perform web log out"));
+        Throwable cause = auth0ExceptionCaptor.getValue().getCause();
+        assertThat(cause, is(CoreMatchers.<Throwable>instanceOf(ActivityNotFoundException.class)));
+        assertThat(cause.getMessage(), is("No Browser application installed."));
+        assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldResumeLogoutSuccessfullyWithIntent() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        Intent intent = createAuthIntent("");
+        assertTrue(WebAuthProvider.resume(intent));
+
+        verify(baseCallback).onSuccess(any(Void.class));
+    }
+
+    @Test
+    public void shouldResumeLogoutFailingWithIntent() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        //null data translates to result canceled
+        Intent intent = createAuthIntent(null);
+        assertTrue(WebAuthProvider.resume(intent));
+
+        verify(baseCallback).onFailure(auth0ExceptionCaptor.capture());
+
+        assertThat(auth0ExceptionCaptor.getValue(), is(notNullValue()));
+        assertThat(auth0ExceptionCaptor.getValue().getMessage(), is("The user closed the browser app and the log out was cancelled."));
+        assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldClearLogoutManagerInstanceAfterSuccessfulLogout() throws Exception {
+        WebAuthProvider.clearSession(account)
+                .start(activity, baseCallback);
+
+        assertThat(WebAuthProvider.getManagerInstance(), is(notNullValue()));
+        Intent intent = createAuthIntent("");
+        assertTrue(WebAuthProvider.resume(intent));
+        assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
+    }
 
     //Test Helper Functions
     private Intent createAuthIntent(@Nullable String hash) {

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -89,6 +89,8 @@ public class WebAuthProviderTest {
 
     @Mock
     private AuthCallback callback;
+    @Mock
+    private VoidCallback voidCallback;
     private Activity activity;
     private Auth0 account;
 
@@ -100,6 +102,8 @@ public class WebAuthProviderTest {
     private ArgumentCaptor<Intent> intentCaptor;
     @Captor
     private ArgumentCaptor<AuthCallback> callbackCaptor;
+    @Captor
+    private ArgumentCaptor<VoidCallback> voidCallbackCaptor;
 
 
     @Before
@@ -1765,16 +1769,10 @@ public class WebAuthProviderTest {
     //** ** ** ** ** **  **//
     //** ** ** ** ** **  **//
 
-    @Mock
-    private BaseCallback<Void, Auth0Exception> baseCallback;
-
-    @Captor
-    private ArgumentCaptor<BaseCallback> baseCallbackCaptor;
-
     @Test
     public void shouldInitLogoutWithAccount() throws Exception {
         WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
 
         assertNotNull(WebAuthProvider.getManagerInstance());
     }
@@ -1784,7 +1782,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldHaveDefaultSchemeOnLogout() throws Exception {
         WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
         verify(activity).startActivity(intentCaptor.capture());
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
         assertThat(uri, is(notNullValue()));
@@ -1798,7 +1796,7 @@ public class WebAuthProviderTest {
     public void shouldSetSchemeOnLogout() throws Exception {
         WebAuthProvider.clearSession(account)
                 .withScheme("myapp")
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
@@ -1814,7 +1812,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldAlwaysSetClientIdOnLogout() throws Exception {
         WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
@@ -1828,7 +1826,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldHaveTelemetryInfoOnLogout() throws Exception {
         WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
@@ -1840,7 +1838,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldHaveReturnToUriOnLogout() throws Exception {
         WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
@@ -1857,7 +1855,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldStartLogout() throws Exception {
         WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
 
@@ -1882,7 +1880,7 @@ public class WebAuthProviderTest {
         CustomTabsOptions options = mock(CustomTabsOptions.class);
         WebAuthProvider.clearSession(account)
                 .withCustomTabsOptions(options)
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
 
@@ -1906,9 +1904,9 @@ public class WebAuthProviderTest {
     public void shouldFailToStartLogoutWhenNoBrowserAppIsInstalled() throws Exception {
         prepareBrowserApp(false, null);
         WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
 
-        verify(baseCallback).onFailure(auth0ExceptionCaptor.capture());
+        verify(voidCallback).onFailure(auth0ExceptionCaptor.capture());
 
         assertThat(auth0ExceptionCaptor.getValue(), is(notNullValue()));
         assertThat(auth0ExceptionCaptor.getValue().getMessage(), is("Cannot perform web log out"));
@@ -1921,7 +1919,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldResumeLogoutSuccessfullyWithIntent() throws Exception {
         WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
@@ -1930,13 +1928,13 @@ public class WebAuthProviderTest {
         Intent intent = createAuthIntent("");
         assertTrue(WebAuthProvider.resume(intent));
 
-        verify(baseCallback).onSuccess(any(Void.class));
+        verify(voidCallback).onSuccess(any(Void.class));
     }
 
     @Test
     public void shouldResumeLogoutFailingWithIntent() throws Exception {
         WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
 
         verify(activity).startActivity(intentCaptor.capture());
         Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
@@ -1946,7 +1944,7 @@ public class WebAuthProviderTest {
         Intent intent = createAuthIntent(null);
         assertTrue(WebAuthProvider.resume(intent));
 
-        verify(baseCallback).onFailure(auth0ExceptionCaptor.capture());
+        verify(voidCallback).onFailure(auth0ExceptionCaptor.capture());
 
         assertThat(auth0ExceptionCaptor.getValue(), is(notNullValue()));
         assertThat(auth0ExceptionCaptor.getValue().getMessage(), is("The user closed the browser app and the logout was cancelled."));
@@ -1956,7 +1954,7 @@ public class WebAuthProviderTest {
     @Test
     public void shouldClearLogoutManagerInstanceAfterSuccessfulLogout() throws Exception {
         WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
+                .start(activity, voidCallback);
 
         assertThat(WebAuthProvider.getManagerInstance(), is(notNullValue()));
         Intent intent = createAuthIntent("");

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -1088,25 +1088,6 @@ public class WebAuthProviderTest {
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CT_OPTIONS), is(false));
     }
 
-    @SuppressWarnings({"deprecation", "ThrowableResultOfMethodCallIgnored"})
-    @Test
-    public void shouldFailToStartWithInvalidAuthorizeURI() throws Exception {
-        Auth0 account = Mockito.mock(Auth0.class);
-        when(account.getAuthorizeUrl()).thenReturn(null);
-
-        WebAuthProvider.init(account)
-                .withState("abcdefghijk")
-                .useCodeGrant(false)
-                .start(activity, callback);
-
-        verify(callback).onFailure(authExceptionCaptor.capture());
-
-        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(authExceptionCaptor.getValue().getCode(), is("a0.invalid_authorize_url"));
-        assertThat(authExceptionCaptor.getValue().getDescription(), is("Auth0 authorize URL not properly set. This can be related to an invalid domain."));
-        assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
-    }
-
     @SuppressWarnings("deprecation")
     @Test
     public void shouldResumeWithRequestCodeWithResponseTypeIdToken() throws Exception {
@@ -1919,24 +1900,6 @@ public class WebAuthProviderTest {
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CT_OPTIONS), is(true));
         assertThat(extras.getBoolean(AuthenticationActivity.EXTRA_USE_BROWSER), is(true));
         assertThat((CustomTabsOptions) extras.getParcelable(AuthenticationActivity.EXTRA_CT_OPTIONS), is(options));
-    }
-
-    @Test
-    public void shouldFailToStartLogoutWithInvalidLogoutURI() throws Exception {
-        Auth0 account = Mockito.mock(Auth0.class);
-        when(account.getLogoutUrl()).thenReturn(null);
-
-        WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
-
-        verify(baseCallback).onFailure(auth0ExceptionCaptor.capture());
-
-        assertThat(auth0ExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(auth0ExceptionCaptor.getValue().getMessage(), is("Cannot perform web log out"));
-        Throwable cause = auth0ExceptionCaptor.getValue().getCause();
-        assertThat(cause, is(CoreMatchers.<Throwable>instanceOf(IllegalArgumentException.class)));
-        assertThat(cause.getMessage(), is("Auth0 logout URL not properly set. This can be related to an invalid domain."));
-        assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -1790,7 +1790,6 @@ public class WebAuthProviderTest {
     @Captor
     private ArgumentCaptor<BaseCallback> baseCallbackCaptor;
 
-    @SuppressWarnings("deprecation")
     @Test
     public void shouldInitLogoutWithAccount() throws Exception {
         WebAuthProvider.clearSession(account)
@@ -1842,47 +1841,6 @@ public class WebAuthProviderTest {
 
         assertThat(uri, hasParamWithValue("client_id", "clientId"));
     }
-
-    // federated
-
-    @Test
-    public void shouldNotSendFederatedByDefaultOnLogout() throws Exception {
-        WebAuthProvider.clearSession(account)
-                .start(activity, baseCallback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, not(hasParamWithName("federated")));
-    }
-
-    @Test
-    public void shouldNotSendFederatedWhenRequestedOnLogout() throws Exception {
-        WebAuthProvider.clearSession(account)
-                .useFederatedLogout(false)
-                .start(activity, baseCallback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, not(hasParamWithName("federated")));
-    }
-
-    @Test
-    public void shouldSetFederatedWhenRequestedOnLogout() throws Exception {
-        WebAuthProvider.clearSession(account)
-                .useFederatedLogout(true)
-                .start(activity, baseCallback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, hasParamWithValue("federated", "1"));
-    }
-
 
     // auth0 related
 
@@ -2032,7 +1990,6 @@ public class WebAuthProviderTest {
         assertThat(WebAuthProvider.getManagerInstance(), is(nullValue()));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void shouldClearLogoutManagerInstanceAfterSuccessfulLogout() throws Exception {
         WebAuthProvider.clearSession(account)


### PR DESCRIPTION
### Changes

This PR adds a static builder to launch a call to the `/v2/logout` endpoint. 
Users can customize the scheme of the `returnTo` URL,  and the _Chrome Custom Tabs_ customization options, although TBH the process is quite fast and you barely notice the browser was open.

#### Usage
```java
//log out method
Auth0 auth0 = getAccount();
WebAuthProvider.logout(auth0)
                .withScheme("demo")
                .start(this, logoutCallback);

//somewhere in the code
private VoidCallback logoutCallback = new VoidCallback() {
    @Override
    public void onFailure(Auth0Exception error) {
        //Browser app not found or logout canceled, check error message.
    }

    @Override
    public void onSuccess(Void payload) {
        //Logged out!
    }
};
```

#### Callback
The call can 
- **succeed:**  when the browser invokes the `returnTo` URL and in turn, re-opens the user application.
- **fail:** 
   - when there is no browser app available, 
   - or the user closes the browser manually. This last scenario is also triggered if the log out URL is not whitelisted in the application or tenant settings.

The log out URL will always include the `client_id` parameter. So the `returnTo` URL **must be whitelisted in the application** allowed logout URLs section on the dashboard. More info in auth0 docs.

### References

- Docs: https://auth0.com/docs/logout/guides/logout-auth0
- Issues: https://github.com/auth0/Auth0.Android/issues/155 

### Testing

Added a bunch of tests for the introduced changes. 

**Will probably rename** some of the previous tests as now we share 2 flows (auth / logout) on the same `WebAuthProvider` class. (On a different PR)

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
