### PR TITLE
Deprecate WebAuthProvider.init()

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ Finally, authenticate by showing the **Auth0 Universal Login**:
 
 ```java
 //Configure and launch the authentication
-WebAuthProvider.init(account)
+WebAuthProvider.login(account)
     .start(MainActivity.this, authCallback);
 
-// Define somewhere in the code the callback
+//Declare the callback that will receive the result
 AuthCallback authCallback = new AuthCallback() {
     @Override
     public void onFailure(@NonNull Dialog dialog) {
@@ -227,7 +227,7 @@ If you've followed this documents' configuration steps you've noticed that the d
 
 
 ```java
-WebAuthProvider.init(account)
+WebAuthProvider.login(account)
     .withScheme("myapp")
     .start(MainActivity.this, authCallback);
 ```
@@ -236,7 +236,7 @@ WebAuthProvider.init(account)
 #### Authenticate with any Auth0 connection
 
 ```java
-WebAuthProvider.init(account)
+WebAuthProvider.login(account)
     .withConnection("twitter")
     .start(MainActivity.this, authCallback);
 ```
@@ -247,7 +247,7 @@ WebAuthProvider.init(account)
 
 
 ```java
-WebAuthProvider.init(account)
+WebAuthProvider.login(account)
     .useCodeGrant(true)
     .start(MainActivity.this, authCallback);
 ```
@@ -257,7 +257,7 @@ WebAuthProvider.init(account)
 The snippet below requests the "userinfo" audience in order to guarantee OIDC compliant responses from the server. This can also be achieved by flipping the "OIDC Conformant" switch on in the OAuth Advanced Settings of your application. For more information check [this documentation](https://auth0.com/docs/api-auth/intro#how-to-use-the-new-flows).
 
 ```java
-WebAuthProvider.init(account)
+WebAuthProvider.login(account)
     .withAudience("https://{YOUR_AUTH0_DOMAIN}/userinfo")
     .start(MainActivity.this, authCallback);
 ```
@@ -267,7 +267,7 @@ WebAuthProvider.init(account)
 #### Specify scope
 
 ```java
-WebAuthProvider.init(account)
+WebAuthProvider.login(account)
     .withScope("openid profile email")
     .start(MainActivity.this, authCallback);
 ```
@@ -277,7 +277,7 @@ WebAuthProvider.init(account)
 #### Specify Connection scope
 
 ```java
-WebAuthProvider.init(account)
+WebAuthProvider.login(account)
     .withConnectionScope("email", "profile", "calendar:read")
     .start(MainActivity.this, authCallback);
 ```
@@ -293,7 +293,7 @@ CustomTabsOptions options = CustomTabsOptions.newBuilder()
     .showTitle(true)
     .build();
  
-WebAuthProvider.init(account)
+WebAuthProvider.login(account)
     .withCustomTabsOptions(options)
     .start(MainActivity.this, authCallback);
 ```

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -38,7 +38,6 @@ import android.util.Log;
 import com.auth0.android.Auth0;
 import com.auth0.android.Auth0Exception;
 import com.auth0.android.authentication.AuthenticationException;
-import com.auth0.android.callback.BaseCallback;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -390,7 +389,6 @@ public class WebAuthProvider {
         return new LogoutBuilder(account);
     }
 
-
     /**
      * Initialize the WebAuthProvider instance for authenticating the user using an account. Additional settings can be configured
      * in the Builder, like setting the connection name or authentication parameters.
@@ -398,19 +396,34 @@ public class WebAuthProvider {
      * @param account to use for authentication
      * @return a new Builder instance to customize.
      */
-    public static Builder init(@NonNull Auth0 account) {
+    public static Builder login(@NonNull Auth0 account) {
         return new Builder(account);
     }
 
     /**
-     * Initialize the WebAuthProvider instance for authenticating the user with an Android Context. Additional settings can be configured
+     * Initialize the WebAuthProvider instance for authenticating the user using an account. Additional settings can be configured
+     * in the Builder, like setting the connection name or authentication parameters.
+     *
+     * @param account to use for authentication
+     * @return a new Builder instance to customize.
+     * @deprecated This method was renamed to reflect an authentication flow. Please use {@link #login(Auth0)}.
+     */
+    @Deprecated
+    public static Builder init(@NonNull Auth0 account) {
+        return login(account);
+    }
+
+    /**
+     * Initialize the WebAuthProvider instance with an Android Context. Additional settings can be configured
      * in the Builder, like setting the connection name or authentication parameters.
      *
      * @param context a valid context.
      * @return a new Builder instance to customize.
+     * @deprecated This method was renamed to reflect an authentication flow. Please use {@link #login(Auth0)}. You can create an Auth0 instance from a Context using {@link Auth0#Auth0(Context)}.
      */
+    @Deprecated
     public static Builder init(@NonNull Context context) {
-        return init(new Auth0(context));
+        return login(new Auth0(context));
     }
 
     /**

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -127,6 +127,15 @@ public class WebAuthProviderTest {
 
     @SuppressWarnings("deprecation")
     @Test
+    public void shouldLoginWithAccount() throws Exception {
+        WebAuthProvider.login(account)
+                .start(activity, callback, REQUEST_CODE);
+
+        assertNotNull(WebAuthProvider.getManagerInstance());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
     public void shouldInitWithAccount() throws Exception {
         WebAuthProvider.init(account)
                 .start(activity, callback, REQUEST_CODE);


### PR DESCRIPTION
### Changes

Now that `WebAuthProvider.logout()` is available, it makes sense to "rename" the existing `init` methods in order to show the intent of authenticating the user.

##### Additions:
- `WebAuthProvider.login(Account)` --> Maintains the old authentication behavior

##### Deprecations:
- `WebAuthProvider.init(Account)` --> internally calls `WebAuthProvider.login(Account)`
- `WebAuthProvider.init(Context)` --> internally calls `WebAuthProvider.login(Account)`


Both `init` method are now deprecated. Functionality is not changed other than that..
I've updated the README snippets.

### References

https://github.com/auth0/Auth0.Android/pull/245

### Testing

Not much tests that I can add as all the methods are static and cannot be mocked nicely. I added one that checks that the new `login` signature still returns a `WebAuthProvider` instance. The rest of the tests remain the same, calling the deprecated `init` methods.

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
