### PR TITLE
Revert "Release 1.17.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Change Log
 
-## [1.17.0](https://github.com/auth0/Auth0.Android/tree/1.17.0) (2019-06-28)
-[Full Changelog](https://github.com/auth0/Auth0.Android/compare/1.16.0...1.17.0)
-
-**Added**
-- Add WebAuth Logout feature [\#245](https://github.com/auth0/Auth0.Android/pull/245) ([lbalmaceda](https://github.com/lbalmaceda))
-
-**Deprecated**
-- Deprecate WebAuthProvider.init() [\#247](https://github.com/auth0/Auth0.Android/pull/247) ([lbalmaceda](https://github.com/lbalmaceda))
-
 ## [1.16.0](https://github.com/auth0/Auth0.Android/tree/1.16.0) (2019-06-18)
 [Full Changelog](https://github.com/auth0/Auth0.Android/compare/1.15.2...1.16.0)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Auth0.android is available through [Gradle](https://gradle.org/). To install it,
 
 ```gradle
 dependencies {
-    implementation 'com.auth0.android:auth0:1.17.0'
+    implementation 'com.auth0.android:auth0:1.16.0'
 }
 ```
 


### PR DESCRIPTION
Reverts auth0/Auth0.Android#249 От 166ce6b2054a9d74a328ff073680136fcba6dbd6 Пон Сеп 17 00:00:00 2001
От: Luciano Balmaceda <balmacedaluciano@gmail.com>
Дата: петък, 28 юни 2019 г. 14:31:27 -0300
Тема: [PATCH] Издание 1.17.0

---
 CHANGELOG.md | 9 +++++++++
 README.md | 2 + -
 Променени са 2 файла, 10 вмъквания (+), 1 изтриване (-)

diff - затвори a / CHANGELOG.md b / CHANGELOG.md
индекс c54c8810..7f6420c1 100644
--- a / CHANGELOG.md
+++ b / CHANGELOG.md
@@ -1,5 +1,14 @@
 # Протокол за промени
 
+ ## [1.17.0] (https://github.com/auth0/Auth0.Android/tree/1.17.0) (2019-06-28)
+ [Пълен списък с промени] (https://github.com/auth0/Auth0.Android/compare/1.16.0...1.17.0)
+
+ ** Добавен **
+ - Добавяне на функция за излизане от WebAuth [# 245] (https://github.com/auth0/Auth0.Android/pull/245) ([lbalmaceda] (https://github.com/lbalmaceda))
+
+ ** Оттеглено **
+ - Откажете се от WebAuthProvider.init () [247] (https://github.com/auth0/Auth0.Android/pull/247) (
+
 ## [1.16.0] (https://github.com/auth0/Auth0.Android/tree/1.16.0) (2019-06-18)
 [Пълен списък с промени] (https://github.com/auth0/Auth0.Android/compare/1.15.2...1.16.0)
 
diff - затвори a / README.md b / README.md
индекс 57879f9b..6e53a4f0 100644
--- a / README.md
+++ b / README.md
@@ -20,7 +20,7 @@ Auth0.android е достъпен чрез [Gradle] (https://gradle.org/). За да я инсталирате,
 
 `` `Gradle
 зависимости {
- изпълнение 'com.auth0.android:auth0:1.16.0'
+ изпълнение 'com.auth0.android:auth0:1.17.0'
 }
 `` `
 