### PR TITLE
Update CredentialManager classes to include IDToken expiration

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -52,13 +52,12 @@ public class CredentialsManager {
 
         long expiresAt = credentials.getExpiresAt().getTime();
 
-        if(credentials.getIdToken() != null) {
-
+        if (credentials.getIdToken() != null) {
             JWT idToken = new JWT(credentials.getIdToken());
             Date idTokenExpiresAtDate = idToken.getExpiresAt();
 
             if (idTokenExpiresAtDate != null) {
-                expiresAt = Math.min(idTokenExpiresAtDate.getTime(), credentials.getExpiresAt().getTime());
+                expiresAt = Math.min(idTokenExpiresAtDate.getTime(), expiresAt);
             }
         }
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -7,6 +7,7 @@ import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.AuthenticationCallback;
 import com.auth0.android.callback.BaseCallback;
+import com.auth0.android.jwt.JWT;
 import com.auth0.android.result.Credentials;
 
 import java.util.Date;
@@ -48,11 +49,24 @@ public class CredentialsManager {
         if ((isEmpty(credentials.getAccessToken()) && isEmpty(credentials.getIdToken())) || credentials.getExpiresAt() == null) {
             throw new CredentialsManagerException("Credentials must have a valid date of expiration and a valid access_token or id_token value.");
         }
+
+        long expiresAt = credentials.getExpiresAt().getTime();
+
+        if(credentials.getIdToken() != null) {
+
+            JWT idToken = new JWT(credentials.getIdToken());
+            Date idTokenExpiresAtDate = idToken.getExpiresAt();
+
+            if (idTokenExpiresAtDate != null) {
+                expiresAt = Math.min(idTokenExpiresAtDate.getTime(), credentials.getExpiresAt().getTime());
+            }
+        }
+
         storage.store(KEY_ACCESS_TOKEN, credentials.getAccessToken());
         storage.store(KEY_REFRESH_TOKEN, credentials.getRefreshToken());
         storage.store(KEY_ID_TOKEN, credentials.getIdToken());
         storage.store(KEY_TOKEN_TYPE, credentials.getType());
-        storage.store(KEY_EXPIRES_AT, credentials.getExpiresAt().getTime());
+        storage.store(KEY_EXPIRES_AT, expiresAt);
         storage.store(KEY_SCOPE, credentials.getScope());
     }
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/JWTDecoder.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/JWTDecoder.java
@@ -1,0 +1,17 @@
+package com.auth0.android.authentication.storage;
+
+import com.auth0.android.jwt.JWT;
+
+/**
+ * Bridge class for decoding JWTs.
+ * Used to abstract the implementation for testing purposes.
+ */
+class JWTDecoder {
+
+    JWTDecoder() {
+    }
+
+    JWT decode(String jwt) {
+        return new JWT(jwt);
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
@@ -18,9 +18,12 @@ import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.AuthenticationCallback;
 import com.auth0.android.callback.BaseCallback;
+import com.auth0.android.jwt.JWT;
 import com.auth0.android.request.internal.GsonProvider;
 import com.auth0.android.result.Credentials;
 import com.google.gson.Gson;
+
+import java.util.Date;
 
 import static android.text.TextUtils.isEmpty;
 
@@ -139,8 +142,18 @@ public class SecureCredentialsManager {
             throw new CredentialsManagerException("Credentials must have a valid date of expiration and a valid access_token or id_token value.");
         }
 
-        String json = gson.toJson(credentials);
         long expiresAt = credentials.getExpiresAt().getTime();
+
+        if(credentials.getIdToken() != null) {
+            JWT idToken = new JWT(credentials.getIdToken());
+            Date idTokenExpiresAtDate = idToken.getExpiresAt();
+
+            if (idTokenExpiresAtDate != null) {
+                expiresAt = Math.min(idTokenExpiresAtDate.getTime(), credentials.getExpiresAt().getTime());
+            }
+        }
+
+        String json = gson.toJson(credentials);
         boolean canRefresh = !isEmpty(credentials.getRefreshToken());
 
         Log.d(TAG, "Trying to encrypt the given data using the private key.");

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
@@ -144,12 +144,12 @@ public class SecureCredentialsManager {
 
         long expiresAt = credentials.getExpiresAt().getTime();
 
-        if(credentials.getIdToken() != null) {
+        if (credentials.getIdToken() != null) {
             JWT idToken = new JWT(credentials.getIdToken());
             Date idTokenExpiresAtDate = idToken.getExpiresAt();
 
             if (idTokenExpiresAtDate != null) {
-                expiresAt = Math.min(idTokenExpiresAtDate.getTime(), credentials.getExpiresAt().getTime());
+                expiresAt = Math.min(idTokenExpiresAtDate.getTime(), expiresAt);
             }
         }
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
@@ -47,6 +47,7 @@ public class SecureCredentialsManager {
     private final Storage storage;
     private final CryptoUtil crypto;
     private final Gson gson;
+    private final JWTDecoder jwtDecoder;
 
     //Changeable by the user
     private boolean authenticateBeforeDecrypt;
@@ -59,12 +60,13 @@ public class SecureCredentialsManager {
 
 
     @VisibleForTesting
-    SecureCredentialsManager(@NonNull AuthenticationAPIClient apiClient, @NonNull Storage storage, @NonNull CryptoUtil crypto) {
+    SecureCredentialsManager(@NonNull AuthenticationAPIClient apiClient, @NonNull Storage storage, @NonNull CryptoUtil crypto, @NonNull JWTDecoder jwtDecoder) {
         this.apiClient = apiClient;
         this.storage = storage;
         this.crypto = crypto;
         this.gson = GsonProvider.buildGson();
         this.authenticateBeforeDecrypt = false;
+        this.jwtDecoder = jwtDecoder;
     }
 
     /**
@@ -75,7 +77,7 @@ public class SecureCredentialsManager {
      * @param storage   the storage implementation to use
      */
     public SecureCredentialsManager(@NonNull Context context, @NonNull AuthenticationAPIClient apiClient, @NonNull Storage storage) {
-        this(apiClient, storage, new CryptoUtil(context, storage, KEY_ALIAS));
+        this(apiClient, storage, new CryptoUtil(context, storage, KEY_ALIAS), new JWTDecoder());
     }
 
     /**
@@ -145,7 +147,7 @@ public class SecureCredentialsManager {
         long expiresAt = credentials.getExpiresAt().getTime();
 
         if (credentials.getIdToken() != null) {
-            JWT idToken = new JWT(credentials.getIdToken());
+            JWT idToken = jwtDecoder.decode(credentials.getIdToken());
             Date idTokenExpiresAtDate = idToken.getExpiresAt();
 
             if (idTokenExpiresAtDate != null) {

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/JWTDecoderTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/JWTDecoderTest.java
@@ -1,0 +1,38 @@
+package com.auth0.android.authentication.storage;
+
+import com.auth0.android.jwt.JWT;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+public class JWTDecoderTest {
+
+    @Test
+    public void shouldDecodeAToken() {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        JWT jwt1 = new JWT(token);
+
+        JWT jwt2 = new JWTDecoder().decode(token);
+
+        //Header claims
+        assertThat(jwt1.getHeader().get("alg"), is("HS256"));
+        assertThat(jwt1.getHeader().get("typ"), is("JWT"));
+
+        assertThat(jwt2.getHeader().get("typ"), is("JWT"));
+        assertThat(jwt2.getHeader().get("alg"), is("HS256"));
+
+        //Payload claims
+        assertThat(jwt1.getSubject(), is("1234567890"));
+        assertThat(jwt1.getIssuedAt().getTime(), is(1516239022000L));
+        assertThat(jwt1.getClaim("name").asString(), is("John Doe"));
+
+        assertThat(jwt2.getSubject(), is("1234567890"));
+        assertThat(jwt2.getIssuedAt().getTime(), is(1516239022000L));
+        assertThat(jwt2.getClaim("name").asString(), is("John Doe"));
+    }
+}


### PR DESCRIPTION
### Changes

Made both classes aware of the ID Token `exp` value (when available) to decide when the whole Credentials object can be renewed.

### References
Closes https://github.com/auth0/Auth0.Android/issues/253

### Testing
Added more unit tests

- [x] This change adds unit test coverage

- [] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
