### PR TITLE
Fix CredentialsManager migration scenario

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -93,6 +93,9 @@ public class CredentialsManager {
         Long expiresAt = storage.retrieveLong(KEY_EXPIRES_AT);
         String scope = storage.retrieveString(KEY_SCOPE);
         Long cacheExpiresAt = storage.retrieveLong(KEY_CACHE_EXPIRES_AT);
+        if (cacheExpiresAt == null) {
+            cacheExpiresAt = expiresAt;
+        }
 
         if (isEmpty(accessToken) && isEmpty(idToken) || expiresAt == null) {
             callback.onFailure(new CredentialsManagerException("No Credentials were previously set."));


### PR DESCRIPTION
### Changes

Fix a bug when a field was not set yet, caused after migrating from version 1.19.0 to a newer one.

### References

Closes https://github.com/auth0/Auth0.Android/issues/261

### Testing

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
