### PR TITLE
Use closeTo matcher to compare date-time conversions

### DIFF
--- a/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerTest.java
@@ -7,7 +7,6 @@ import com.auth0.android.result.CredentialsMock;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -16,6 +15,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -37,22 +37,27 @@ public class CredentialsDeserializerTest {
     @Test
     public void shouldSetExpiresAtFromExpiresIn() throws Exception {
         final Credentials credentials = gson.getAdapter(Credentials.class).fromJson(new FileReader(BASIC_CREDENTIALS));
-        assertThat(credentials.getExpiresIn(), is(86000L));
+        assertThat(credentials.getExpiresIn().doubleValue(), is(closeTo(86000, 1)));
         assertThat(credentials.getExpiresAt(), is(notNullValue()));
-        assertThat(credentials.getExpiresAt().getTime(), is(CredentialsMock.CURRENT_TIME_MS + 86000 * 1000));
+        double expiresAt = credentials.getExpiresAt().getTime();
+        double expectedExpiresAt = CredentialsMock.CURRENT_TIME_MS + 86000 * 1000;
+        assertThat(expiresAt, is(closeTo(expectedExpiresAt, 1)));
     }
 
     @Test
     public void shouldSetExpiresInFromExpiresAt() throws Exception {
         Calendar cal = Calendar.getInstance();
         cal.add(Calendar.DAY_OF_YEAR, 7);
-        Date expiresAt = cal.getTime();
-        final Credentials credentials = gson.getAdapter(Credentials.class).fromJson(generateExpiresAtCredentialsJSON(expiresAt));
-        assertThat(credentials.getExpiresAt(), is(notNullValue()));
+        Date exp = cal.getTime();
+        final Credentials credentials = gson.getAdapter(Credentials.class).fromJson(generateExpiresAtCredentialsJSON(exp));
         //The hardcoded value comes from the JSON file
-        assertThat(credentials.getExpiresAt().getTime(), is(expiresAt.getTime()));
+        assertThat(credentials.getExpiresAt(), is(notNullValue()));
+        double expiresAt = credentials.getExpiresAt().getTime();
+        double expectedExpiresAt = exp.getTime();
+        assertThat(expiresAt, is(closeTo(expectedExpiresAt, 1)));
         assertThat(credentials.getExpiresIn(), is(notNullValue()));
-        assertThat(credentials.getExpiresIn(), Matchers.is((expiresAt.getTime() - CredentialsMock.CURRENT_TIME_MS) / 1000));
+        double expectedExpiresIn = (exp.getTime() - CredentialsMock.CURRENT_TIME_MS) / 1000;
+        assertThat(credentials.getExpiresIn().doubleValue(), is(closeTo(expectedExpiresIn, 1)));
     }
 
 

--- a/auth0/src/test/java/com/auth0/android/request/internal/CredentialsGsonTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CredentialsGsonTest.java
@@ -19,6 +19,7 @@ import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -68,7 +69,8 @@ public class CredentialsGsonTest extends GsonBaseTest {
         assertThat(credentials.getIdToken(), is(nullValue()));
         assertThat(credentials.getType(), equalTo("bearer"));
         assertThat(credentials.getRefreshToken(), is(nullValue()));
-        assertThat(credentials.getExpiresIn(), is(86000L));
+        assertThat(credentials.getExpiresIn(), is(notNullValue()));
+        assertThat(credentials.getExpiresIn().doubleValue(), is(closeTo(86000, 1)));
         assertThat(credentials.getExpiresAt(), is(notNullValue()));
         assertThat(credentials.getScope(), is(nullValue()));
     }
@@ -76,16 +78,20 @@ public class CredentialsGsonTest extends GsonBaseTest {
     @Test
     public void shouldReturnWithExpiresAt() throws Exception {
         Calendar cal = Calendar.getInstance();
-        cal.add(Calendar.DAY_OF_YEAR, 7);
-        Date expiresAt = cal.getTime();
-        final Credentials credentials = buildCredentialsFrom(new StringReader(generateExpiresAtCredentialsJSON(expiresAt)));
+        cal.add(Calendar.DAY_OF_YEAR, 1);
+        Date exp = cal.getTime();
+        String credentialsJSON = generateJSONWithExpiresAt(exp);
+        final Credentials credentials = buildCredentialsFrom(new StringReader(credentialsJSON));
         assertThat(credentials, is(notNullValue()));
         assertThat(credentials.getAccessToken(), is(notNullValue()));
         assertThat(credentials.getType(), equalTo("bearer"));
-        assertThat(credentials.getExpiresIn(), is(not(86000L)));
-        assertThat(credentials.getExpiresAt(), is(notNullValue()));
         //The hardcoded value comes from the JSON file
-        assertThat(credentials.getExpiresAt().getTime(), is(expiresAt.getTime()));
+        assertThat(credentials.getExpiresIn(), is(notNullValue()));
+        double expectedCalculatedExpiresIn = (exp.getTime() - System.currentTimeMillis()) / 1000;
+        assertThat(credentials.getExpiresIn().doubleValue(), is(closeTo(expectedCalculatedExpiresIn, 1)));
+        assertThat(credentials.getExpiresAt(), is(notNullValue()));
+        double expiresAt = credentials.getExpiresAt().getTime();
+        assertThat(expiresAt, is(closeTo(exp.getTime(), 1)));
     }
 
     @Test
@@ -96,7 +102,8 @@ public class CredentialsGsonTest extends GsonBaseTest {
         assertThat(credentials.getIdToken(), is(notNullValue()));
         assertThat(credentials.getType(), equalTo("bearer"));
         assertThat(credentials.getRefreshToken(), is(nullValue()));
-        assertThat(credentials.getExpiresIn(), is(86000L));
+        assertThat(credentials.getExpiresIn(), is(notNullValue()));
+        assertThat(credentials.getExpiresIn().doubleValue(), is(closeTo(86000, 1)));
         assertThat(credentials.getExpiresAt(), is(notNullValue()));
         assertThat(credentials.getScope(), is("openid profile"));
     }
@@ -109,7 +116,8 @@ public class CredentialsGsonTest extends GsonBaseTest {
         assertThat(credentials.getIdToken(), is(notNullValue()));
         assertThat(credentials.getType(), equalTo("bearer"));
         assertThat(credentials.getRefreshToken(), is(notNullValue()));
-        assertThat(credentials.getExpiresIn(), is(86000L));
+        assertThat(credentials.getExpiresIn(), is(notNullValue()));
+        assertThat(credentials.getExpiresIn().doubleValue(), is(closeTo(86000, 1)));
         assertThat(credentials.getExpiresAt(), is(notNullValue()));
         assertThat(credentials.getScope(), is("openid profile"));
     }
@@ -145,7 +153,7 @@ public class CredentialsGsonTest extends GsonBaseTest {
         return pojoFrom(json, Credentials.class);
     }
 
-    private String generateExpiresAtCredentialsJSON(@NonNull Date expiresAt) {
+    private String generateJSONWithExpiresAt(@NonNull Date expiresAt) {
         return "{\n" +
                 "\"access_token\": \"s6GS5FGJN2jfd4l6\",\n" +
                 "\"token_type\": \"bearer\",\n" +


### PR DESCRIPTION
### Changes

Use approximate assertions when comparing date/time values that have been converted from millis to int and vice-versa.

**This change only impacts unit-tests.**

### Testing

- [x] This change adds unit test coverage

- [] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
