### PR TITLE
Added custom callback/redirect uri to WebAuthProvider.Builder

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -141,6 +141,7 @@ public class WebAuthProvider {
         private PKCE pkce;
         private String scheme;
         private CustomTabsOptions ctOptions;
+        private String customRedirectUri;
 
         Builder(Auth0 account) {
             this.account = account;
@@ -337,6 +338,17 @@ public class WebAuthProvider {
         }
 
         /**
+         * Give a custom redirect uri for this request.
+         *
+         * @param customRedirectUri the custom redirect uri
+         * @return the current builder instance
+         */
+        public Builder withCustomRedirectUri(@NonNull String customRedirectUri) {
+            this.customRedirectUri = customRedirectUri;
+            return this;
+        }
+
+        /**
          * Request user Authentication. The result will be received in the callback.
          *
          * @param activity    context to run the authentication
@@ -363,7 +375,12 @@ public class WebAuthProvider {
 
             managerInstance = manager;
 
-            String redirectUri = CallbackHelper.getCallbackUri(scheme, activity.getApplicationContext().getPackageName(), account.getDomainUrl());
+            final String redirectUri;
+            if (customRedirectUri == null) {
+                redirectUri = CallbackHelper.getCallbackUri(scheme, activity.getApplicationContext().getPackageName(), account.getDomainUrl());
+            } else {
+                redirectUri = customRedirectUri;
+            }
             manager.startAuthentication(activity, redirectUri, requestCode);
         }
 

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -990,6 +990,19 @@ public class WebAuthProviderTest {
         assertThat(uri, hasParamWithValue("response_type", "code"));
     }
 
+    @Test
+    public void shouldBuildAuthorizeURIWithCustomRedirectUri() {
+        WebAuthProvider.login(account)
+                .withCustomRedirectUri("a-custom-redirect-uri")
+                .start(activity, callback);
+
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        assertThat(uri, hasParamWithValue("redirect_uri", "a-custom-redirect-uri"));
+    }
+
     @SuppressWarnings("deprecation")
     @Test
     public void shouldStartLoginWithBrowserCustomTabsOptions() {


### PR DESCRIPTION
### Changes

There was a need to be able to set a callback/redirect uri that was not using the
same domain as the tenant.

Use-case
The app supports x tenants, via config, and you don't want add x intent
filters to the manifest.
Instead we want to have one "generic" callback/redirect uri that we can use
regardless which tenant that was used.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
