### PR TITLE
Update OSS Gradle plugin version

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -23,7 +23,7 @@
  */
 
 plugins {
-    id "com.auth0.gradle.oss-library.android" version "0.8.0"
+    id "com.auth0.gradle.oss-library.android" version "0.10.0"
 }
 
 logger.lifecycle("Using version ${version} for ${name}")


### PR DESCRIPTION
### Changes

With this new version, the `javaCompile` warning will, at last, go away. 