### PR TITLE
Add support for Social Native Token Exchange endpoint

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
@@ -55,6 +55,7 @@ public class ParameterBuilder {
     public static final String GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code";
     public static final String GRANT_TYPE_MFA_OTP = "http://auth0.com/oauth/grant-type/mfa-otp";
     public static final String GRANT_TYPE_PASSWORDLESS_OTP = "http://auth0.com/oauth/grant-type/passwordless/otp";
+    public static final String GRANT_TYPE_TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange";
 
     public static final String SCOPE_OPENID = "openid";
     public static final String SCOPE_OFFLINE_ACCESS = "openid offline_access";

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -422,6 +422,51 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
+    public void shouldLoginWithNativeSocialToken() throws Exception {
+        mockAPI
+                .willReturnSuccessfulLogin();
+
+        final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
+        client.loginWithNativeSocialToken("test-token-value", "test-token-type")
+                .start(callback);
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
+        assertThat(request.getPath(), equalTo("/oauth/token"));
+
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("grant_type", ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE));
+        assertThat(body, hasEntry("subject_token", "test-token-value"));
+        assertThat(body, hasEntry("subject_token_type", "test-token-type"));
+        assertThat(body, hasEntry("scope", OPENID));
+
+        assertThat(callback, hasPayloadOfType(Credentials.class));
+    }
+
+    @Test
+    public void shouldLoginWithNativeSocialTokenSync() throws Exception {
+        mockAPI.willReturnSuccessfulLogin();
+
+        final Credentials credentials = client
+                .loginWithNativeSocialToken("test-token-value", "test-token-type")
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), is(getDefaultLocale()));
+        assertThat(request.getPath(), equalTo("/oauth/token"));
+
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("grant_type", ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE));
+        assertThat(body, hasEntry("subject_token", "test-token-value"));
+        assertThat(body, hasEntry("subject_token_type", "test-token-type"));
+        assertThat(body, hasEntry("scope", OPENID));
+
+        assertThat(credentials, is(notNullValue()));
+    }
+
+    @Test
     public void shouldLoginWithPhoneNumberWithCustomConnectionWithOTPGrantIfOIDCConformant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -382,8 +382,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldLoginWithOAuthAccessToken() throws Exception {
-        mockAPI
-                .willReturnSuccessfulLogin();
+        mockAPI.willReturnSuccessfulLogin();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
         client.loginWithOAuthAccessToken("fbtoken", "facebook")
@@ -423,8 +422,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldLoginWithNativeSocialToken() throws Exception {
-        mockAPI
-                .willReturnSuccessfulLogin();
+        mockAPI.willReturnSuccessfulLogin();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
         client.loginWithNativeSocialToken("test-token-value", "test-token-type")
@@ -598,8 +596,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldLoginWithEmailOnlySyncWithOTPGrantIfOIDCConformant() throws Exception {
-        mockAPI
-                .willReturnSuccessfulLogin()
+        mockAPI.willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
 
         Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
@@ -736,8 +733,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldLoginWithEmailOnlySync() throws Exception {
-        mockAPI
-                .willReturnSuccessfulLogin()
+        mockAPI.willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
 
         final Credentials credentials = client
@@ -1307,8 +1303,7 @@ public class AuthenticationAPIClientTest {
     public void shouldGetCustomizedDelegationRequestWithIdTokenSync() throws Exception {
         mockAPI.willReturnNewIdToken();
 
-        client
-                .delegationWithIdToken(ID_TOKEN, "custom_api_type")
+        client.delegationWithIdToken(ID_TOKEN, "custom_api_type")
                 .setScope("custom_scope")
                 .setTarget("custom_target")
                 .execute();
@@ -1961,8 +1956,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldParseUnauthorizedPKCEError() throws Exception {
-        mockAPI
-                .willReturnPlainTextUnauthorized();
+        mockAPI.willReturnPlainTextUnauthorized();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
         client.token("code", "http://redirect.uri")


### PR DESCRIPTION
### Changes

This is a small addition to the pool of supported endpoints. It's meant to exchange an external provider's token for auth0 tokens. AKA sign in into Auth0 with an external native provider.

### References

See https://auth0.com/docs/api/authentication#token-exchange-for-native-social

### Testing

I did not test this manually. Will be doing so soon.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
