### PR TITLE
Handle weird SecureCredentialsManager exceptions

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
@@ -24,6 +24,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
+import java.security.ProviderException;
 import java.security.UnrecoverableEntryException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -142,7 +143,7 @@ class CryptoUtil {
             generator.generateKeyPair();
 
             return getKeyEntryCompat(keyStore);
-        } catch (CertificateException | InvalidAlgorithmParameterException | NoSuchProviderException | NoSuchAlgorithmException | KeyStoreException e) {
+        } catch (CertificateException | InvalidAlgorithmParameterException | NoSuchProviderException | NoSuchAlgorithmException | KeyStoreException | ProviderException e) {
             /*
              * This exceptions are safe to be ignored:
              *
@@ -157,6 +158,9 @@ class CryptoUtil {
              *      Thrown if Key Size is other than 512, 768, 1024, 2048, 3072, 4096
              *      or if Padding is other than RSA/ECB/PKCS1Padding, introduced on API 18
              *      or if Block Mode is other than ECB
+             * - ProviderException:
+             *      Thrown on some modified devices when KeyPairGenerator#generateKeyPair is called.
+             *      See: https://www.bountysource.com/issues/45527093-keystore-issues
              *
              * However if any of this exceptions happens to be thrown (OEMs often change their Android distribution source code),
              * all the checks performed in this class wouldn't matter and the device would not be compatible at all with it.

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
@@ -94,8 +94,11 @@ class CryptoUtil {
             KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
             keyStore.load(null);
             if (keyStore.containsAlias(KEY_ALIAS)) {
-                //Return existing key
-                return getKeyEntryCompat(keyStore);
+                //Return existing key. On weird cases, the alias would be present but the key not
+                KeyStore.PrivateKeyEntry existingKey = getKeyEntryCompat(keyStore);
+                if (existingKey != null) {
+                    return existingKey;
+                }
             }
 
             Calendar start = Calendar.getInstance();
@@ -191,7 +194,7 @@ class CryptoUtil {
      * the KeyStore using the {@link #KEY_ALIAS}.
      *
      * @param keyStore the KeyStore instance. Must be initialized (loaded).
-     * @return the key entry stored in the KeyStore.
+     * @return the key entry stored in the KeyStore or null if not present.
      * @throws KeyStoreException           if the keystore was not initialized.
      * @throws NoSuchAlgorithmException    if device is not compatible with RSA algorithm. RSA is available since API 18.
      * @throws UnrecoverableEntryException if key cannot be recovered. Probably because it was invalidated by a Lock Screen change.
@@ -209,6 +212,9 @@ class CryptoUtil {
         }
 
         Certificate certificate = keyStore.getCertificate(KEY_ALIAS);
+        if (certificate == null) {
+            return null;
+        }
         return new KeyStore.PrivateKeyEntry(privateKey, new Certificate[]{certificate});
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CryptoUtilTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CryptoUtilTest.java
@@ -39,6 +39,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
+import java.security.ProviderException;
 import java.security.UnrecoverableEntryException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -487,6 +488,16 @@ public class CryptoUtilTest {
         exception.expectMessage("The device is not compatible with the CryptoUtil class");
 
         doThrow(new CertificateException()).when(keyStore).load(any(KeyStore.LoadStoreParameter.class));
+
+        cryptoUtil.getRSAKeyEntry();
+    }
+
+    @Test
+    public void shouldThrowOnProviderExceptionWhenTryingToObtainRSAKeys() throws Exception {
+        exception.expect(IncompatibleDeviceException.class);
+        exception.expectMessage("The device is not compatible with the CryptoUtil class");
+
+        doThrow(new ProviderException()).when(keyStore).load(any(KeyStore.LoadStoreParameter.class));
 
         cryptoUtil.getRSAKeyEntry();
     }


### PR DESCRIPTION
### Changes

This PR attempts to fix a number of weird exceptions that happen on some devices running unsupported hardware or software. They are listed below.

#### java.lang.NullPointerException: invalid null input
Also `Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.security.cert.Certificate.getType()' on a null object reference`

Appears to happen when the key alias is present on the Keystore but when one attempts to retrieve it, the value turns out to have a `null` certificate. So when this value is used to re-create the key, it throws a NPE. According to the reports, this happened on the `CryptoUtil#getRSAKeyEntry` call, right after checking if a key exists. It could be due to a Lock-Screen Security requirement change (i.e. from none to require PIN).

The decision I took was to null-check the result from obtaining the existing key, and if the value is null, continue down the code to create/generate a new RSA key and persist it on the Keystore. This means that this error is recoverable and is not going to deem the device as incompatible.

First reported here: https://github.com/auth0/Auth0.Android/issues/230

<details><summary>Complete stack trace:</summary>

```java
java.lang.NullPointerException: invalid null input
	 at java.security.KeyStore$PrivateKeyEntry.<init>(KeyStore.java:559)
	 at java.security.KeyStore$PrivateKeyEntry.<init>(KeyStore.java:526)
	 at java.security.KeyStoreSpi.engineGetEntry(KeyStoreSpi.java:477)
	 at java.security.KeyStore.getEntry(KeyStore.java:1560)
	 at com.auth0.android.authentication.storage.CryptoUtil.getKeyEntryCompat(CryptoUtil.java:197)
	 at com.auth0.android.authentication.storage.CryptoUtil.getRSAKeyEntry(CryptoUtil.java:97)
	 at com.auth0.android.authentication.storage.CryptoUtil.RSAEncrypt(CryptoUtil.java:297)
	 at com.auth0.android.authentication.storage.CryptoUtil.getAESKey(CryptoUtil.java:353)
	 at com.auth0.android.authentication.storage.CryptoUtil.encrypt(CryptoUtil.java:434)
	 at com.auth0.android.authentication.storage.SecureCredentialsManager.saveCredentials(SecureCredentialsManager.java:148)
	 at ch.letemps.internal.auth.Auth.onSuccess(Auth.kt:44)
	 at com.auth0.android.provider.OAuthManager$1.onSuccess(OAuthManager.java:145)
	 at com.auth0.android.provider.PKCE$1.onSuccess(PKCE.java:90)
	 at com.auth0.android.provider.PKCE$1.onSuccess(PKCE.java:87)
	 at com.auth0.android.request.internal.BaseRequest.postOnSuccess(BaseRequest.java:92)
	 at com.auth0.android.request.internal.SimpleRequest.onResponse(SimpleRequest.java:76)
	 at com.squareup.okhttp.Call$AsyncCall.execute(Call.java:177)
	 at com.squareup.okhttp.internal.NamedRunnable.run(NamedRunnable.java:33)
	 at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
	 at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
	 at java.lang.Thread.run(Thread.java:764)
```

and

```java
java.lang.IllegalArgumentException: Empty key
        at javax.crypto.spec.SecretKeySpec.<init>(SecretKeySpec.java:96)
        at com.auth0.android.authentication.storage.CryptoUtil.encrypt(CryptoUtil.java:243)
        at com.auth0.android.authentication.storage.SecureCredentialsManager.saveCredentials(SecureCredentialsManager.java:146)
        at com.neurotrack.mhp.app.login.LoginActivity.finishAuthFlow(LoginActivity.kt:114)
        at com.neurotrack.mhp.app.login.LoginActivity.access$finishAuthFlow(LoginActivity.kt:23)
        at com.neurotrack.mhp.app.login.LoginActivity$promptLogin$1.onSuccess(LoginActivity.kt:82)
        at com.auth0.android.provider.OAuthManager$1.onSuccess(OAuthManager.java:145)
        at com.auth0.android.provider.PKCE$1.onSuccess(PKCE.java:90)
        at com.auth0.android.provider.PKCE$1.onSuccess(PKCE.java:87)
        at com.auth0.android.request.internal.BaseRequest.postOnSuccess(BaseRequest.java:92)
        at com.auth0.android.request.internal.SimpleRequest.onResponse(SimpleRequest.java:76)
        at com.squareup.okhttp.Call$AsyncCall.execute(Call.java:177)
        at com.squareup.okhttp.internal.NamedRunnable.run(NamedRunnable.java:33)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:764)
```

</details>


#### java.lang.IllegalArgumentException: Empty key

Appears to happen when the AES key recovered from the Storage instance is an empty string or a string representation of a key which's size is different from the used one (256 bits). There's no clear reason why this happens, other than some external factor modifying the contents of the shared preferences (that's the default Storage implementation).

The decision I took was to check for empty strings ("") and also check for the byte size of the stored AES key value. If any of this is not valid, the AES key will be deemed invalid and it will be re-created. This is also a recoverable exception scenario. However, as in any re-creation scenario, data already saved might be lost; applied to the auth context it means users would need to re-auth.

First reported here: https://github.com/auth0/Auth0.Android/issues/167

<details><summary>Complete stack trace:</summary>

```java
com.auth0.android.authentication.storage.CryptoUtil.decrypt | CryptoUtil.java:225
com.auth0.android.authentication.storage.SecureCredentialsManager.continueGetCredentials | SecureCredentialsManager.java:208
com.auth0.android.authentication.storage.SecureCredentialsManager.getCredentials | SecureCredentialsManager.java:175
```

</details>

#### java.security.ProviderException: Failed to load generated key pair from keystore

Appears to happen on some LineageOS powered devices (OnePlus) when the key is about to be created. This is a software bug that seems to be fixed, but would still happen on those devices that haven't updated yet. Unfortunately, this error would mean that an RSA key cannot be created, thus the device is deemed incompatible.

The decision I took was to catch this `ProviderException` and deem the device as incompatible. The developer should catch this re-thrown exception and take the decision of using a fallback Credentials Manager implementation, as stated on the README.

Reported internally: ESD-4308

<details><summary>Complete stack trace:</summary>

```java
CryptoUtil.java – line 142
com.auth0.android.authentication.storage.CryptoUtil.getRSAKeyEntry
Fatal Exception: java.security.ProviderException: Failed to load generated key pair from keystore
at android.security.keystore.AndroidKeyStoreKeyPairGeneratorSpi.loadKeystoreKeyPair(AndroidKeyStoreKeyPairGeneratorSpi.java:530)
at android.security.keystore.AndroidKeyStoreKeyPairGeneratorSpi.generateKeyPair(AndroidKeyStoreKeyPairGeneratorSpi.java:472)
at java.security.KeyPairGenerator$Delegate.generateKeyPair(KeyPairGenerator.java:727)
at com.auth0.android.authentication.storage.CryptoUtil.getRSAKeyEntry(CryptoUtil.java:142)
at com.auth0.android.authentication.storage.CryptoUtil.RSAEncrypt(CryptoUtil.java:297)
at com.auth0.android.authentication.storage.CryptoUtil.getAESKey(CryptoUtil.java:353)
at com.auth0.android.authentication.storage.CryptoUtil.encrypt(CryptoUtil.java:434)
at com.auth0.android.authentication.storage.SecureCredentialsManager.saveCredentials(SecureCredentialsManager.java:163)
at com.whitbread.premierinn.data.authentication.AuthenticationRepositoryImpl$authenticate$2$1.onSuccess(AuthenticationRepositoryImpl.java:43)
at com.whitbread.premierinn.data.authentication.AuthenticationRepositoryImpl$authenticate$2$1.onSuccess(AuthenticationRepositoryImpl.java:40)
at com.auth0.android.request.internal.BaseRequest.postOnSuccess(BaseRequest.java:93)
at com.auth0.android.request.internal.SimpleRequest.onResponse(SimpleRequest.java:77)
at com.squareup.okhttp.Call$AsyncCall.execute(Call.java:177)
at com.squareup.okhttp.internal.NamedRunnable.run(NamedRunnable.java:33)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
at java.lang.Thread.run(Thread.java:919)
```

</details>

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
