### PR TITLE
Improve consistency around Expires At in CredentialsManager

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
@@ -248,12 +248,13 @@ public class SecureCredentialsManager {
             return;
         }
         final Credentials credentials = gson.fromJson(json, Credentials.class);
-        if (isEmpty(credentials.getAccessToken()) && isEmpty(credentials.getIdToken()) || credentials.getExpiresAt() == null) {
+        Long expiresAt = storage.retrieveLong(KEY_EXPIRES_AT);
+        if (isEmpty(credentials.getAccessToken()) && isEmpty(credentials.getIdToken()) || expiresAt == null) {
             callback.onFailure(new CredentialsManagerException("No Credentials were previously set."));
             decryptCallback = null;
             return;
         }
-        if (credentials.getExpiresAt().getTime() > getCurrentTimeInMillis()) {
+        if (expiresAt > getCurrentTimeInMillis()) {
             callback.onSuccess(credentials);
             decryptCallback = null;
             return;

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.java
@@ -195,7 +195,6 @@ public class SecureCredentialsManagerTest {
         assertThat(storedCredentials.getExpiresAt(), is(notNullValue()));
         assertThat(storedCredentials.getExpiresAt().getTime(), is(accessTokenExpirationTime));
         assertThat(storedCredentials.getScope(), is("scope"));
-
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.java
@@ -195,6 +195,7 @@ public class SecureCredentialsManagerTest {
         assertThat(storedCredentials.getExpiresAt(), is(notNullValue()));
         assertThat(storedCredentials.getExpiresAt().getTime(), is(accessTokenExpirationTime));
         assertThat(storedCredentials.getScope(), is("scope"));
+
     }
 
     @Test
@@ -712,6 +713,7 @@ public class SecureCredentialsManagerTest {
     public void shouldGetCredentialsAfterAuthentication() {
         Date expiresAt = new Date(CredentialsMock.CURRENT_TIME_MS + 123456L * 1000);
         insertTestCredentials(true, true, false, expiresAt);
+        when(storage.retrieveLong("com.auth0.credentials_expires_at")).thenReturn(expiresAt.getTime());
 
         //Require authentication
         Activity activity = spy(Robolectric.buildActivity(Activity.class).create().start().resume().get());
@@ -744,6 +746,36 @@ public class SecureCredentialsManagerTest {
         assertThat(retrievedCredentials.getExpiresAt(), is(notNullValue()));
         assertThat(retrievedCredentials.getExpiresAt().getTime(), is(expiresAt.getTime()));
         assertThat(retrievedCredentials.getScope(), is("scope"));
+
+        //A second call to checkAuthenticationResult should fail as callback is set to null
+        final boolean retryCheck = manager.checkAuthenticationResult(123, Activity.RESULT_OK);
+        assertThat(retryCheck, is(false));
+    }
+
+    @Test
+    public void shouldNotGetCredentialsWhenCredentialsHaveExpired() {
+        Date credentialsExpiresAt = new Date(CredentialsMock.CURRENT_TIME_MS + 123456L * 1000);
+        Date storedExpiresAt = new Date(CredentialsMock.CURRENT_TIME_MS - 60L * 1000);
+        insertTestCredentials(true, true, false, credentialsExpiresAt);
+        when(storage.retrieveLong("com.auth0.credentials_expires_at")).thenReturn(storedExpiresAt.getTime());
+
+        //Require authentication
+        Activity activity = spy(Robolectric.buildActivity(Activity.class).create().start().resume().get());
+        KeyguardManager kService = mock(KeyguardManager.class);
+        when(activity.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(kService);
+        when(kService.isKeyguardSecure()).thenReturn(true);
+        Intent confirmCredentialsIntent = mock(Intent.class);
+        when(kService.createConfirmDeviceCredentialIntent("theTitle", "theDescription")).thenReturn(confirmCredentialsIntent);
+        boolean willRequireAuthentication = manager.requireAuthentication(activity, 123, "theTitle", "theDescription");
+        assertThat(willRequireAuthentication, is(true));
+
+        manager.getCredentials(callback);
+
+        //Should fail because of expired credentials
+        verify(callback).onFailure(exceptionCaptor.capture());
+        CredentialsManagerException exception = exceptionCaptor.getValue();
+        assertThat(exception, is(notNullValue()));
+        assertThat(exception.getMessage(), is("No Credentials were previously set."));
 
         //A second call to checkAuthenticationResult should fail as callback is set to null
         final boolean retryCheck = manager.checkAuthenticationResult(123, Activity.RESULT_OK);


### PR DESCRIPTION
### Changes

Add a missing test case. Also, improve consistency on the usage of Expires At for the `CredentialsManager` class.

### References

Will close https://github.com/auth0/Auth0.Android/issues/293

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
