### PR TITLE
Improve docs adding default timeout values

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -272,7 +272,8 @@ public class Auth0 {
     }
 
     /**
-     * Override default connection timeout for requests
+     * Set the connection timeout for network requests.
+     * By default, this value is 10 seconds.
      *
      * @param timeout the new timeout value in seconds
      */
@@ -281,7 +282,8 @@ public class Auth0 {
     }
 
     /**
-     * Override default read timeout for requests
+     * Set the read timeout for network requests.
+     * By default, this value is 10 seconds.
      *
      * @param timeout the new timeout value in seconds
      */
@@ -290,7 +292,8 @@ public class Auth0 {
     }
 
     /**
-     * Override default write timeout for requests
+     * Set the write timeout for network requests.
+     * By default, this value is 10 seconds.
      *
      * @param timeout the new timeout value in seconds
      */


### PR DESCRIPTION
### Changes
Document the default timeout values. When unspecified, they match the OkHttp client ones.
These are converted and set to the equivalent value in milliseconds in [this class](https://github.com/auth0/Auth0.Android/blob/34bc106ff56d30ad28b90b7d63deee0e6079fd4c/auth0/src/main/java/com/auth0/android/request/internal/OkHttpClientFactory.java#L55-L63)

### References

The idea came from https://github.com/auth0/Auth0.Android/issues/305

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
