### PR TITLE
Use of a unique keystore key alias across apps

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
@@ -74,8 +74,8 @@ class CryptoUtil {
         if (TextUtils.isEmpty(keyAlias)) {
             throw new IllegalArgumentException("RSA and AES Key alias must be valid.");
         }
-        this.KEY_ALIAS = keyAlias;
-        this.KEY_IV_ALIAS = keyAlias + "_iv";
+        this.KEY_ALIAS = context.getPackageName() + "." + keyAlias;
+        this.KEY_IV_ALIAS = context.getPackageName() + "." + keyAlias + "_iv";
         this.context = context;
         this.storage = storage;
     }

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CryptoUtilTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CryptoUtilTest.java
@@ -65,6 +65,7 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -98,7 +99,9 @@ public class CryptoUtilTest {
 
     private CryptoUtil cryptoUtil;
 
-    private static final String KEY_ALIAS = "keyName";
+    private static final String APP_PACKAGE_NAME = "com.mycompany.myapp";
+    private static final String BASE_ALIAS = "keyName";
+    private static final String KEY_ALIAS = APP_PACKAGE_NAME + "." + BASE_ALIAS;
     private Context context;
 
     //Android KeyStore not accessible using Robolectric
@@ -118,6 +121,7 @@ public class CryptoUtilTest {
         });
 
         context = mock(Context.class);
+        when(context.getPackageName()).thenReturn(APP_PACKAGE_NAME);
         cryptoUtil = newCryptoUtilSpy();
     }
 
@@ -1317,7 +1321,7 @@ public class CryptoUtilTest {
     }
 
     private CryptoUtil newCryptoUtilSpy() throws Exception {
-        CryptoUtil cryptoUtil = PowerMockito.spy(new CryptoUtil(context, storage, KEY_ALIAS));
+        CryptoUtil cryptoUtil = PowerMockito.spy(new CryptoUtil(context, storage, BASE_ALIAS));
         PowerMockito.mockStatic(KeyStore.class);
         PowerMockito.when(KeyStore.getInstance(ANDROID_KEY_STORE)).thenReturn(keyStore);
         PowerMockito.mockStatic(KeyPairGenerator.class);


### PR DESCRIPTION
### Changes

The intention is to use the App's Package Name from the `Context` vs the library's Application ID from the `BuildConfig`, to generate a key alias that is **unique across app** installs. This should prevent errors where apps using this very same library (or sharing the key alias) would have their keys collide.

#### Note
Since the key alias is changing with this PR, when you update to this last version of the SDK, any existing key will not be found and it will act as if the user was logged out. Double-check that you are not ignoring the exceptions thrown when the credential manager methods are being used. See our [docs](https://github.com/auth0/Auth0.Android#credentials-manager) for more information.

### References
Closes https://github.com/auth0/Auth0.Android/issues/309

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
