### PR TITLE
Allow to set headers and parameters in all requests

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -34,10 +34,10 @@ import com.auth0.android.authentication.request.DelegationRequest;
 import com.auth0.android.authentication.request.ProfileRequest;
 import com.auth0.android.authentication.request.SignUpRequest;
 import com.auth0.android.authentication.request.TokenRequest;
+import com.auth0.android.request.AuthRequest;
 import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.request.ErrorBuilder;
 import com.auth0.android.request.ParameterizableRequest;
-import com.auth0.android.request.Request;
 import com.auth0.android.request.internal.AuthenticationErrorBuilder;
 import com.auth0.android.request.internal.GsonProvider;
 import com.auth0.android.request.internal.OkHttpClientFactory;
@@ -197,7 +197,7 @@ public class AuthenticationAPIClient {
      * @return a request to configure and start that will yield {@link Credentials}
      */
     @SuppressWarnings("WeakerAccess")
-    public AuthenticationRequest login(@NonNull String usernameOrEmail, @NonNull String password, @NonNull String realmOrConnection) {
+    public AuthRequest login(@NonNull String usernameOrEmail, @NonNull String password, @NonNull String realmOrConnection) {
 
         ParameterBuilder builder = ParameterBuilder.newBuilder()
                 .set(USERNAME_KEY, usernameOrEmail)
@@ -240,7 +240,7 @@ public class AuthenticationAPIClient {
      * @return a request to configure and start that will yield {@link Credentials}
      */
     @SuppressWarnings("WeakerAccess")
-    public AuthenticationRequest login(@NonNull String usernameOrEmail, @NonNull String password) {
+    public AuthRequest login(@NonNull String usernameOrEmail, @NonNull String password) {
         Map<String, Object> requestParameters = ParameterBuilder.newBuilder()
                 .set(USERNAME_KEY, usernameOrEmail)
                 .set(PASSWORD_KEY, password)
@@ -273,7 +273,7 @@ public class AuthenticationAPIClient {
      * @return a request to configure and start that will yield {@link Credentials}
      */
     @SuppressWarnings("WeakerAccess")
-    public AuthenticationRequest loginWithOTP(@NonNull String mfaToken, @NonNull String otp) {
+    public AuthRequest loginWithOTP(@NonNull String mfaToken, @NonNull String otp) {
         Map<String, Object> parameters = ParameterBuilder.newBuilder()
                 .setGrantType(GRANT_TYPE_MFA_OTP)
                 .set(MFA_TOKEN_KEY, mfaToken)
@@ -305,7 +305,7 @@ public class AuthenticationAPIClient {
      * @return a request to configure and start that will yield {@link Credentials}
      */
     @SuppressWarnings("WeakerAccess")
-    public AuthenticationRequest loginWithOAuthAccessToken(@NonNull String token, @NonNull String connection) {
+    public AuthRequest loginWithOAuthAccessToken(@NonNull String token, @NonNull String connection) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(OAUTH_PATH)
                 .addPathSegment(ACCESS_TOKEN_PATH)
@@ -317,8 +317,9 @@ public class AuthenticationAPIClient {
                 .setAccessToken(token)
                 .asDictionary();
 
-        return factory.authenticationPOST(url, client, gson)
-                .addAuthenticationParameters(parameters);
+        AuthRequest authRequest = factory.authenticationPOST(url, client, gson);
+        authRequest.addAuthenticationParameters(parameters);
+        return authRequest;
     }
 
     /**
@@ -343,7 +344,7 @@ public class AuthenticationAPIClient {
      * @return a request to configure and start that will yield {@link Credentials}
      */
     @SuppressWarnings("WeakerAccess")
-    public AuthenticationRequest loginWithNativeSocialToken(@NonNull String token, @NonNull String tokenType) {
+    public AuthRequest loginWithNativeSocialToken(@NonNull String token, @NonNull String tokenType) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(OAUTH_PATH)
                 .addPathSegment(TOKEN_PATH)
@@ -356,8 +357,9 @@ public class AuthenticationAPIClient {
                 .set(SUBJECT_TOKEN_TYPE_KEY, tokenType)
                 .asDictionary();
 
-        return factory.authenticationPOST(url, client, gson)
-                .addAuthenticationParameters(parameters);
+        AuthRequest authRequest = factory.authenticationPOST(url, client, gson);
+        authRequest.addAuthenticationParameters(parameters);
+        return authRequest;
     }
 
     /**
@@ -385,7 +387,7 @@ public class AuthenticationAPIClient {
      * @return a request to configure and start that will yield {@link Credentials}
      */
     @SuppressWarnings("WeakerAccess")
-    public AuthenticationRequest loginWithPhoneNumber(@NonNull String phoneNumber, @NonNull String verificationCode, @NonNull String realmOrConnection) {
+    public AuthRequest loginWithPhoneNumber(@NonNull String phoneNumber, @NonNull String verificationCode, @NonNull String realmOrConnection) {
         ParameterBuilder builder = ParameterBuilder.newAuthenticationBuilder()
                 .setClientId(getClientId())
                 .set(USERNAME_KEY, phoneNumber);
@@ -431,7 +433,7 @@ public class AuthenticationAPIClient {
      * @return a request to configure and start that will yield {@link Credentials}
      */
     @SuppressWarnings("WeakerAccess")
-    public AuthenticationRequest loginWithPhoneNumber(@NonNull String phoneNumber, @NonNull String verificationCode) {
+    public AuthRequest loginWithPhoneNumber(@NonNull String phoneNumber, @NonNull String verificationCode) {
         return loginWithPhoneNumber(phoneNumber, verificationCode, SMS_CONNECTION);
     }
 
@@ -460,7 +462,7 @@ public class AuthenticationAPIClient {
      * @return a request to configure and start that will yield {@link Credentials}
      */
     @SuppressWarnings("WeakerAccess")
-    public AuthenticationRequest loginWithEmail(@NonNull String email, @NonNull String verificationCode, @NonNull String realmOrConnection) {
+    public AuthRequest loginWithEmail(@NonNull String email, @NonNull String verificationCode, @NonNull String realmOrConnection) {
         ParameterBuilder builder = ParameterBuilder.newAuthenticationBuilder()
                 .setClientId(getClientId())
                 .set(USERNAME_KEY, email);
@@ -506,7 +508,7 @@ public class AuthenticationAPIClient {
      * @return a request to configure and start that will yield {@link Credentials}
      */
     @SuppressWarnings("WeakerAccess")
-    public AuthenticationRequest loginWithEmail(@NonNull String email, @NonNull String verificationCode) {
+    public AuthRequest loginWithEmail(@NonNull String email, @NonNull String verificationCode) {
         return loginWithEmail(email, verificationCode, EMAIL_CONNECTION);
     }
 
@@ -530,7 +532,7 @@ public class AuthenticationAPIClient {
      * @return a request to start
      */
     @SuppressWarnings("WeakerAccess")
-    public Request<UserProfile, AuthenticationException> userInfo(@NonNull String accessToken) {
+    public ParameterizableRequest<UserProfile, AuthenticationException> userInfo(@NonNull String accessToken) {
         return profileRequest()
                 .addHeader(HEADER_AUTHORIZATION, "Bearer " + accessToken);
     }
@@ -557,7 +559,7 @@ public class AuthenticationAPIClient {
      */
     @SuppressWarnings("WeakerAccess")
     @Deprecated
-    public Request<UserProfile, AuthenticationException> tokenInfo(@NonNull String idToken) {
+    public ParameterizableRequest<UserProfile, AuthenticationException> tokenInfo(@NonNull String idToken) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(TOKEN_INFO_PATH)
                 .build();
@@ -661,7 +663,7 @@ public class AuthenticationAPIClient {
     @SuppressWarnings("WeakerAccess")
     public SignUpRequest signUp(@NonNull String email, @NonNull String password, @NonNull String username, @NonNull String connection) {
         final DatabaseConnectionRequest<DatabaseUser, AuthenticationException> createUserRequest = createUser(email, password, username, connection);
-        final AuthenticationRequest authenticationRequest = login(email, password, connection);
+        final AuthRequest authenticationRequest = login(email, password, connection);
 
         return new SignUpRequest(createUserRequest, authenticationRequest);
     }
@@ -691,7 +693,7 @@ public class AuthenticationAPIClient {
     @SuppressWarnings("WeakerAccess")
     public SignUpRequest signUp(@NonNull String email, @NonNull String password, @NonNull String connection) {
         final DatabaseConnectionRequest<DatabaseUser, AuthenticationException> createUserRequest = createUser(email, password, connection);
-        final AuthenticationRequest authenticationRequest = login(email, password, connection);
+        final AuthRequest authenticationRequest = login(email, password, connection);
         return new SignUpRequest(createUserRequest, authenticationRequest);
     }
 
@@ -754,7 +756,7 @@ public class AuthenticationAPIClient {
      * @return a request to start
      */
     @SuppressWarnings("WeakerAccess")
-    public Request<Void, AuthenticationException> revokeToken(@NonNull String refreshToken) {
+    public ParameterizableRequest<Void, AuthenticationException> revokeToken(@NonNull String refreshToken) {
         final Map<String, Object> parameters = ParameterBuilder.newBuilder()
                 .setClientId(getClientId())
                 .set(TOKEN_KEY, refreshToken)
@@ -1161,7 +1163,7 @@ public class AuthenticationAPIClient {
      *
      * @return a request to obtain the JSON Web Keys associated with this Auth0 account.
      */
-    public Request<Map<String, PublicKey>, AuthenticationException> fetchJsonWebKeys() {
+    public ParameterizableRequest<Map<String, PublicKey>, AuthenticationException> fetchJsonWebKeys() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(WELL_KNOWN_PATH)
                 .addPathSegment(JWKS_FILE_PATH)
@@ -1171,7 +1173,7 @@ public class AuthenticationAPIClient {
         return factory.GET(url, client, gson, jwksType, authErrorBuilder);
     }
 
-    private AuthenticationRequest loginWithToken(Map<String, Object> parameters) {
+    private AuthRequest loginWithToken(Map<String, Object> parameters) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(OAUTH_PATH)
                 .addPathSegment(TOKEN_PATH)
@@ -1181,11 +1183,12 @@ public class AuthenticationAPIClient {
                 .setClientId(getClientId())
                 .addAll(parameters)
                 .asDictionary();
-        return factory.authenticationPOST(url, client, gson)
-                .addAuthenticationParameters(requestParameters);
+        AuthRequest authRequest = factory.authenticationPOST(url, client, gson);
+        authRequest.addAuthenticationParameters(requestParameters);
+        return authRequest;
     }
 
-    private AuthenticationRequest loginWithResourceOwner(Map<String, Object> parameters) {
+    private AuthRequest loginWithResourceOwner(Map<String, Object> parameters) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(OAUTH_PATH)
                 .addPathSegment(RESOURCE_OWNER_PATH)
@@ -1195,8 +1198,9 @@ public class AuthenticationAPIClient {
                 .setClientId(getClientId())
                 .addAll(parameters)
                 .asDictionary();
-        return factory.authenticationPOST(url, client, gson)
-                .addAuthenticationParameters(requestParameters);
+        AuthRequest authRequest = factory.authenticationPOST(url, client, gson);
+        authRequest.addAuthenticationParameters(requestParameters);
+        return authRequest;
     }
 
     private ParameterizableRequest<UserProfile, AuthenticationException> profileRequest() {

--- a/auth0/src/main/java/com/auth0/android/authentication/request/DatabaseConnectionRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/DatabaseConnectionRequest.java
@@ -21,6 +21,7 @@ public class DatabaseConnectionRequest<T, U extends Auth0Exception> {
 
     /**
      * Add the given parameters to the request
+     *
      * @param parameters to be sent with the request
      * @return itself
      */
@@ -31,7 +32,8 @@ public class DatabaseConnectionRequest<T, U extends Auth0Exception> {
 
     /**
      * Add a parameter by name to the request
-     * @param name of the parameter
+     *
+     * @param name  of the parameter
      * @param value of the parameter
      * @return itself
      */
@@ -41,8 +43,9 @@ public class DatabaseConnectionRequest<T, U extends Auth0Exception> {
     }
 
     /**
-     * Add a header for the request, e.g. "Authorization"
-     * @param name of the header
+     * Add a header to the request, e.g. "Authorization"
+     *
+     * @param name  of the header
      * @param value of the header
      * @return itself
      */
@@ -53,6 +56,7 @@ public class DatabaseConnectionRequest<T, U extends Auth0Exception> {
 
     /**
      * Set the Auth0 Database Connection used for this request using its name.
+     *
      * @param connection name
      * @return itself
      */
@@ -63,6 +67,7 @@ public class DatabaseConnectionRequest<T, U extends Auth0Exception> {
 
     /**
      * Executes the request async and returns its results via callback
+     *
      * @param callback called on success or failure of the request
      */
     public void start(BaseCallback<T, U> callback) {
@@ -71,6 +76,7 @@ public class DatabaseConnectionRequest<T, U extends Auth0Exception> {
 
     /**
      * Executes the request synchronously
+     *
      * @return the request result
      * @throws Auth0Exception if the request failed
      */

--- a/auth0/src/main/java/com/auth0/android/authentication/request/DelegationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/DelegationRequest.java
@@ -67,6 +67,18 @@ public class DelegationRequest<T> implements Request<T, AuthenticationException>
     }
 
     /**
+     * Add a header to the request, e.g. "Authorization"
+     *
+     * @param name  of the header
+     * @param value of the header
+     * @return itself
+     */
+    public DelegationRequest<T> addHeader(String name, String value) {
+        request.addHeader(name, value);
+        return this;
+    }
+
+    /**
      * Set the 'api_type' parameter to be sent in the request
      *
      * @param apiType the delegation api type

--- a/auth0/src/main/java/com/auth0/android/authentication/request/TokenRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/TokenRequest.java
@@ -7,6 +7,8 @@ import com.auth0.android.request.ParameterizableRequest;
 import com.auth0.android.request.Request;
 import com.auth0.android.result.Credentials;
 
+import java.util.Map;
+
 /**
  * Auth Request to obtain tokens using OAuth2 {@literal /oauth/token} method
  */
@@ -19,6 +21,29 @@ public class TokenRequest implements Request<Credentials, AuthenticationExceptio
 
     public TokenRequest(ParameterizableRequest<Credentials, AuthenticationException> request) {
         this.request = request;
+    }
+
+    /**
+     * Adds additional parameters to the request.
+     *
+     * @param parameters as a non-null dictionary
+     * @return itself
+     */
+    public TokenRequest addParameters(Map<String, Object> parameters) {
+        request.addParameters(parameters);
+        return this;
+    }
+
+    /**
+     * Add a header to the request, e.g. "Authorization"
+     *
+     * @param name  of the header
+     * @param value of the header
+     * @return itself
+     */
+    public TokenRequest addHeader(String name, String value) {
+        request.addHeader(name, value);
+        return this;
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
@@ -31,7 +31,7 @@ import android.support.annotation.VisibleForTesting;
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.ParameterBuilder;
 import com.auth0.android.request.ErrorBuilder;
-import com.auth0.android.request.Request;
+import com.auth0.android.request.ParameterizableRequest;
 import com.auth0.android.request.internal.GsonProvider;
 import com.auth0.android.request.internal.ManagementErrorBuilder;
 import com.auth0.android.request.internal.OkHttpClientFactory;
@@ -68,7 +68,8 @@ public class UsersAPIClient {
     private static final String USER_METADATA_KEY = "user_metadata";
 
     private final Auth0 auth0;
-    @VisibleForTesting final OkHttpClient client;
+    @VisibleForTesting
+    final OkHttpClient client;
     private final Gson gson;
     private final RequestFactory factory;
     private final ErrorBuilder<ManagementException> mgmtErrorBuilder;
@@ -154,7 +155,7 @@ public class UsersAPIClient {
      * @return a request to start
      */
     @SuppressWarnings("WeakerAccess")
-    public Request<List<UserIdentity>, ManagementException> link(String primaryUserId, String secondaryToken) {
+    public ParameterizableRequest<List<UserIdentity>, ManagementException> link(String primaryUserId, String secondaryToken) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(API_PATH)
                 .addPathSegment(V2_PATH)
@@ -195,7 +196,7 @@ public class UsersAPIClient {
      * @return a request to start
      */
     @SuppressWarnings("WeakerAccess")
-    public Request<List<UserIdentity>, ManagementException> unlink(String primaryUserId, String secondaryUserId, String secondaryProvider) {
+    public ParameterizableRequest<List<UserIdentity>, ManagementException> unlink(String primaryUserId, String secondaryUserId, String secondaryProvider) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(API_PATH)
                 .addPathSegment(V2_PATH)
@@ -232,7 +233,7 @@ public class UsersAPIClient {
      * @return a request to start
      */
     @SuppressWarnings("WeakerAccess")
-    public Request<UserProfile, ManagementException> updateMetadata(String userId, Map<String, Object> userMetadata) {
+    public ParameterizableRequest<UserProfile, ManagementException> updateMetadata(String userId, Map<String, Object> userMetadata) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(API_PATH)
                 .addPathSegment(V2_PATH)
@@ -264,7 +265,7 @@ public class UsersAPIClient {
      * @return a request to start
      */
     @SuppressWarnings("WeakerAccess")
-    public Request<UserProfile, ManagementException> getProfile(String userId) {
+    public ParameterizableRequest<UserProfile, ManagementException> getProfile(String userId) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(API_PATH)
                 .addPathSegment(V2_PATH)

--- a/auth0/src/main/java/com/auth0/android/request/AuthRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/AuthRequest.java
@@ -1,0 +1,14 @@
+package com.auth0.android.request;
+
+public interface AuthRequest extends AuthenticationRequest {
+
+    /**
+     * Add a header to the request, e.g. "Authorization"
+     *
+     * @param name  of the header
+     * @param value of the header
+     * @return itself
+     */
+    AuthRequest addHeader(String name, String value);
+
+}

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
@@ -3,7 +3,7 @@ package com.auth0.android.request.internal;
 import android.util.Log;
 
 import com.auth0.android.authentication.AuthenticationException;
-import com.auth0.android.request.AuthenticationRequest;
+import com.auth0.android.request.AuthRequest;
 import com.auth0.android.result.Credentials;
 import com.google.gson.Gson;
 import com.squareup.okhttp.HttpUrl;
@@ -20,7 +20,7 @@ import static com.auth0.android.authentication.ParameterBuilder.GRANT_TYPE_KEY;
 import static com.auth0.android.authentication.ParameterBuilder.REALM_KEY;
 import static com.auth0.android.authentication.ParameterBuilder.SCOPE_KEY;
 
-class BaseAuthenticationRequest extends SimpleRequest<Credentials, AuthenticationException> implements AuthenticationRequest {
+class BaseAuthenticationRequest extends SimpleRequest<Credentials, AuthenticationException> implements AuthRequest {
 
     private static final String TAG = BaseAuthenticationRequest.class.getSimpleName();
 
@@ -39,7 +39,7 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
      * @return itself
      */
     @Override
-    public AuthenticationRequest setGrantType(String grantType) {
+    public AuthRequest setGrantType(String grantType) {
         addParameter(GRANT_TYPE_KEY, grantType);
         return this;
     }
@@ -51,7 +51,7 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
      * @return itself
      */
     @Override
-    public AuthenticationRequest setConnection(String connection) {
+    public AuthRequest setConnection(String connection) {
         if (!hasLegacyPath()) {
             Log.w(TAG, "Not setting the 'connection' parameter as the request is using a OAuth 2.0 API Authorization endpoint that doesn't support it.");
             return this;
@@ -67,7 +67,7 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
      * @return itself
      */
     @Override
-    public AuthenticationRequest setRealm(String realm) {
+    public AuthRequest setRealm(String realm) {
         if (hasLegacyPath()) {
             Log.w(TAG, "Not setting the 'realm' parameter as the request is using a Legacy Authorization API endpoint that doesn't support it.");
             return this;
@@ -82,7 +82,7 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
      * @param scope a scope value
      * @return itself
      */
-    public AuthenticationRequest setScope(String scope) {
+    public AuthRequest setScope(String scope) {
         addParameter(SCOPE_KEY, scope);
         return this;
     }
@@ -93,7 +93,7 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
      * @param device a device name
      * @return itself
      */
-    public AuthenticationRequest setDevice(String device) {
+    public AuthRequest setDevice(String device) {
         addParameter(DEVICE_KEY, device);
         return this;
     }
@@ -105,7 +105,7 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
      * @return itself
      */
     @Override
-    public AuthenticationRequest setAudience(String audience) {
+    public AuthRequest setAudience(String audience) {
         addParameter(AUDIENCE_KEY, audience);
         return this;
     }
@@ -116,13 +116,13 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
      * @param accessToken a access token
      * @return itself
      */
-    public AuthenticationRequest setAccessToken(String accessToken) {
+    public AuthRequest setAccessToken(String accessToken) {
         addParameter(ACCESS_TOKEN_KEY, accessToken);
         return this;
     }
 
     @Override
-    public AuthenticationRequest addAuthenticationParameters(Map<String, Object> parameters) {
+    public AuthRequest addAuthenticationParameters(Map<String, Object> parameters) {
         final HashMap<String, Object> params = new HashMap<>(parameters);
         if (parameters.containsKey(CONNECTION_KEY)) {
             setConnection((String) params.remove(CONNECTION_KEY));
@@ -131,6 +131,12 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
             setRealm((String) params.remove(REALM_KEY));
         }
         addParameters(params);
+        return this;
+    }
+
+    @Override
+    public BaseAuthenticationRequest addHeader(String name, String value) {
+        super.addHeader(name, value);
         return this;
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
@@ -27,6 +27,7 @@ package com.auth0.android.request.internal;
 import android.support.annotation.NonNull;
 
 import com.auth0.android.Auth0Exception;
+import com.auth0.android.request.AuthRequest;
 import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.request.ErrorBuilder;
 import com.auth0.android.request.ParameterizableRequest;
@@ -71,8 +72,8 @@ public class RequestFactory {
     }
 
 
-    public AuthenticationRequest authenticationPOST(HttpUrl url, OkHttpClient client, Gson gson) {
-        final AuthenticationRequest request = createAuthenticationRequest(url, client, gson, "POST");
+    public AuthRequest authenticationPOST(HttpUrl url, OkHttpClient client, Gson gson) {
+        final AuthRequest request = createAuthenticationRequest(url, client, gson, "POST");
         addMetrics((ParameterizableRequest) request);
         return request;
     }
@@ -143,7 +144,7 @@ public class RequestFactory {
         return new SimpleRequest<>(url, client, gson, method, errorBuilder);
     }
 
-    AuthenticationRequest createAuthenticationRequest(HttpUrl url, OkHttpClient client, Gson gson, String method) {
+    AuthRequest createAuthenticationRequest(HttpUrl url, OkHttpClient client, Gson gson, String method) {
         return new BaseAuthenticationRequest(url, client, gson, method, Credentials.class);
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/request/DelegationRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/DelegationRequestTest.java
@@ -3,6 +3,7 @@ package com.auth0.android.authentication.request;
 import com.auth0.android.callback.BaseCallback;
 import com.auth0.android.request.ParameterizableRequest;
 
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,6 +15,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -36,6 +38,14 @@ public class DelegationRequestTest {
         final DelegationRequest req = delegationRequest.addParameters(params);
         verify(mockRequest).addParameters(params);
         Assert.assertThat(req, is(notNullValue()));
+        Assert.assertThat(req, is(delegationRequest));
+    }
+
+    @Test
+    public void shouldAddHeader() {
+        final DelegationRequest req = delegationRequest.addHeader("auth", "val123");
+        verify(mockRequest).addHeader(eq("auth"), eq("val123"));
+        Assert.assertThat(req, is(Matchers.notNullValue()));
         Assert.assertThat(req, is(delegationRequest));
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/request/SignUpRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/SignUpRequestTest.java
@@ -2,6 +2,7 @@ package com.auth0.android.authentication.request;
 
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.BaseCallback;
+import com.auth0.android.request.AuthRequest;
 import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.result.Credentials;
 import com.auth0.android.result.DatabaseUser;
@@ -22,8 +23,10 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
@@ -31,13 +34,13 @@ import static org.mockito.Mockito.when;
 public class SignUpRequestTest {
 
     private DatabaseConnectionRequest dbMockRequest;
-    private AuthenticationRequest authenticationMockRequest;
+    private AuthRequest authenticationMockRequest;
     private SignUpRequest signUpRequest;
 
     @Before
     public void setUp() {
         dbMockRequest = mock(DatabaseConnectionRequest.class);
-        authenticationMockRequest = mock(AuthenticationRequest.class);
+        authenticationMockRequest = mock(AuthRequest.class);
         signUpRequest = new SignUpRequest(dbMockRequest, authenticationMockRequest);
     }
 
@@ -63,6 +66,24 @@ public class SignUpRequestTest {
     public void shouldSetScope() {
         final SignUpRequest req = signUpRequest.setScope("oauth2 offline_access profile");
         verify(authenticationMockRequest).setScope("oauth2 offline_access profile");
+        Assert.assertThat(req, is(notNullValue()));
+        Assert.assertThat(req, is(signUpRequest));
+    }
+
+    @Test
+    public void shouldAddHeader() {
+        final SignUpRequest req = signUpRequest.addHeader("auth", "val123");
+        verify(authenticationMockRequest).addHeader(eq("auth"), eq("val123"));
+        Assert.assertThat(req, is(notNullValue()));
+        Assert.assertThat(req, is(signUpRequest));
+    }
+
+    @Test
+    public void shouldNotAddHeaderWithAuthenticationRequest() {
+        AuthenticationRequest authenticationMockRequest = mock(AuthenticationRequest.class);
+        SignUpRequest signUpRequest = new SignUpRequest(dbMockRequest, authenticationMockRequest);
+        final SignUpRequest req = signUpRequest.addHeader("auth", "val123");
+        verifyZeroInteractions(authenticationMockRequest);
         Assert.assertThat(req, is(notNullValue()));
         Assert.assertThat(req, is(signUpRequest));
     }

--- a/auth0/src/test/java/com/auth0/android/authentication/request/TokenRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/TokenRequestTest.java
@@ -10,8 +10,11 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.Map;
+
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -47,6 +50,19 @@ public class TokenRequestTest {
     public void shouldExecuteTheRequest() {
         tokenRequest.execute();
         verify(mockRequest).execute();
+    }
+
+    @Test
+    public void shouldAddHeaders() {
+        tokenRequest.addHeader("auth", "val123");
+        verify(mockRequest).addHeader(eq("auth"), eq("val123"));
+    }
+
+    @Test
+    public void shouldAddParameters() {
+        Map params = mock(Map.class);
+        tokenRequest.addParameters(params);
+        verify(mockRequest).addParameters(eq(params));
     }
 
 }

--- a/auth0/src/test/java/com/auth0/android/request/internal/MockAuthenticationRequest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/MockAuthenticationRequest.java
@@ -3,6 +3,7 @@ package com.auth0.android.request.internal;
 import com.auth0.android.Auth0Exception;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.BaseCallback;
+import com.auth0.android.request.AuthRequest;
 import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.request.ParameterizableRequest;
 import com.auth0.android.result.Credentials;
@@ -13,7 +14,7 @@ import com.squareup.okhttp.OkHttpClient;
 import java.util.HashMap;
 import java.util.Map;
 
-public class MockAuthenticationRequest implements ParameterizableRequest<Credentials, AuthenticationException>, AuthenticationRequest {
+public class MockAuthenticationRequest implements ParameterizableRequest<Credentials, AuthenticationException>, AuthRequest {
 
     HashMap<String, String> headers;
     HttpUrl url;
@@ -80,7 +81,7 @@ public class MockAuthenticationRequest implements ParameterizableRequest<Credent
     }
 
     @Override
-    public ParameterizableRequest<Credentials, AuthenticationException> addHeader(String name, String value) {
+    public MockAuthenticationRequest addHeader(String name, String value) {
         headers.put(name, value);
         return this;
     }

--- a/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
@@ -2,7 +2,7 @@ package com.auth0.android.request.internal;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.Auth0Exception;
-import com.auth0.android.request.AuthenticationRequest;
+import com.auth0.android.request.AuthRequest;
 import com.auth0.android.request.ErrorBuilder;
 import com.auth0.android.request.ParameterizableRequest;
 import com.google.gson.Gson;
@@ -231,7 +231,7 @@ public class RequestFactoryTest {
         }
 
         @Override
-        AuthenticationRequest createAuthenticationRequest(HttpUrl url, OkHttpClient client, Gson gson, String method) {
+        AuthRequest createAuthenticationRequest(HttpUrl url, OkHttpClient client, Gson gson, String method) {
             authenticationRequest = new MockAuthenticationRequest(url, client, gson, method);
             return authenticationRequest;
         }


### PR DESCRIPTION
### Changes
All the methods of both API clients now return a request instance that supports being set headers and additional parameters, without the need of casting them to a different class.

- Methods returning `Request` now return `ParameterizableRequest`, exposing both customization methods. This fixes the use case for all the `UsersAPIClient` and 40% of the `AuthenticationAPIClient`.
- Adds a new interface `AuthRequest` that extends the existing `AuthenticationRequest`, which already supported adding parameters, and now supports adding headers.
- `DelegationRequest`, `SignUpRequest`, and `ProfileRequest` got these methods added.
- `SignUpRequest` and `ProfileRequest` got the existing constructor deprecated to signal that when used, the headers are not customizable. They were only used internally on 3 occasions across the `AuthenticationAPIClient` class.

There are code formatting changes among the diff, apologies in advance if that generates noise.

### References
https://github.com/auth0/Auth0.Android/issues/314 / `ESD-7306`

### Testing

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
