### PR TITLE
Add Bot Protection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ Create a new instance by passing the account:
 AuthenticationAPIClient authentication = new AuthenticationAPIClient(account);
 ```
 
+**Note:** If your Auth0 account has the ["Bot Protection"](https://auth0.com/docs/anomaly-detection/bot-protection) feature enabled, your requests might be flagged for verification. Read how to handle this scenario on the [Bot Protection](#bot-protection) section.
+
 #### Login with database connection
 
 If the `Auth0` instance wasn't configured as "OIDC conformant", this call requires the Application to have the *Resource Owner* Client Grant Type enabled. Check [this article](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
@@ -519,6 +521,55 @@ authentication
    });
 ```
 
+
+#### Bot Protection
+If you are using the [Bot Protection](https://auth0.com/docs/anomaly-detection/bot-protection) feature and performing database login/sign up via the Authentication API, you need to handle the `AuthenticationException#isVerificationRequired()` error. It indicates that the request was flagged as suspicious and an additional verification step is necessary to log the user in. That verification step is web-based, so you need to use Universal Login to complete it.
+
+```java
+final String email = "info@auth0.com";
+final String password = "a secret password";
+final String realm = "my-database-connection";
+
+AuthenticationAPIClient authentication = new AuthenticationAPIClient(account);
+authentication.login(email, password, realm)
+        .start(new BaseCallback<Credentials, AuthenticationException>() {
+
+            @Override
+            public void onFailure(AuthenticationException error) {
+                if (error.isVerificationRequired()){
+                    Map<String, Object> params = new HashMap<>();
+                    params.put("login_hint", email); // So the user doesn't have to type it again
+                    WebAuthProvider.login(account)
+                            .withParameters(params)
+                            .start(LoginActivity.this, new AuthCallback() {
+                                // You might already have an AuthCallback instance defined
+
+                                @Override
+                                public void onFailure(@NonNull Dialog dialog) {
+                                    // Error dialog available
+                                }
+
+                                @Override
+                                public void onFailure(AuthenticationException exception) {
+                                    // Error
+                                }
+
+                                @Override
+                                public void onSuccess(@NonNull Credentials credentials) {
+                                    // Handle WebAuth success
+                                }
+                            });
+                }
+            }
+
+            @Override
+            public void onSuccess(Credentials payload) {
+                //Handle API success
+            }
+        });
+```
+
+Check out how to set up Universal Login in the [Authentication with Universal Login](#authentication-with-universal-login) section.
 
 ### Management API (Users)
 

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -181,6 +181,11 @@ public class AuthenticationException extends Auth0Exception {
         return "a0.mfa_registration_required".equals(code) || "unsupported_challenge_type".equals(code);
     }
 
+    /// When Bot Protection flags the request as suspicious
+    public boolean isVerificationRequired() {
+        return "requires_verification".equals(code);
+    }
+
     /// When the MFA Token used on the login request is malformed or has expired
     public boolean isMultifactorTokenInvalid() {
         return "expired_token".equals(code) && "mfa_token is expired".equals(description) ||

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
@@ -152,6 +152,14 @@ public class AuthenticationExceptionTest {
     }
 
     @Test
+    public void shouldHaveRequestVerificationError() {
+        values.put(CODE_KEY, "requires_verification");
+        values.put(ERROR_DESCRIPTION_KEY, "Suspicious request requires verification");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isVerificationRequired(), is(true));
+    }
+
+    @Test
     public void shouldHaveExpiredMultifactorTokenOnOIDCMode() {
         values.put(ERROR_KEY, "expired_token");
         values.put(ERROR_DESCRIPTION_KEY, "mfa_token is expired");


### PR DESCRIPTION
### Changes

When Bot Protection is enabled, the requests can be flagged as suspicious requiring the user to complete the authentication following a browser-based flow. This PR adds guidance as well as tests that the introduced error code is supported.

### References
https://auth0.com/docs/anomaly-detection/bot-protection
### Testing
I've manually tested the README snippet on a separate app.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
