### PR TITLE
Add support for Android 11 new privacy settings

### DIFF
--- a/auth0/src/main/AndroidManifest.xml
+++ b/auth0/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
   ~ THE SOFTWARE.
   -->
 
+<!--Ignore rule required due to the 'queries' tag, fix only available for targetSdk=30 -->
+<!--suppress AndroidElementNotAllowed -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.auth0.android.auth0">
@@ -54,5 +56,12 @@
 
         <activity android:name="com.auth0.android.provider.WebAuthActivity" />
     </application>
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
 
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.4.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }


### PR DESCRIPTION
### Changes
When this library is used on Android 11, the new privacy rules kick in preventing our `CustomTabsController` class to [query for browser apps](https://github.com/auth0/Auth0.Android/blob/master/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java#L175) in order to pick the best candidate. The result is a failure, or an automatically cancelled authentication. By using the latest Android Gradle Plugin patch and adding the "queries" tag in the library's manifest, the final manifest 

The lint-ignore rule at the top of the manifest is required until we target SDK 30. In order to do that, we need to migrate to and [support AndroidX](https://github.com/auth0/Auth0.Android/issues/306).

**Compiling:** For anyone running into compiling issues where the "queries" tag in the manifest is not a valid tag, that's because your app is using an old version of the Android Gradle Plugin that still doesn't have support for queries. Check the link below to learn to what version you should update.

### References

- Android Gradle Plugin versions with support for the manifest's "queries" tag: https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html
- Checking available browsers query (Recipe): https://developer.android.com/preview/privacy/package-visibility-use-cases#check-browser-available
- Fixes https://github.com/auth0/Auth0.Android/issues/319

### Testing

I've tested this on a separate sample app that targets SDK 30. As seen in the attached screenshot, bottom right, the "queries" tag is added to the merged manifest file and comes from the changes on this PR.

![image](https://user-images.githubusercontent.com/3900123/92417373-233ec400-f138-11ea-9b13-db220e8fe244.png)


I've also tested this when the sample app defines its own set of queries. And both turn out to be merged correctly, without the need to use any special node annotation.
![image](https://user-images.githubusercontent.com/3900123/92417820-9ba68480-f13a-11ea-8254-2f74edd44f79.png)


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
