### PR TITLE
Browser package support

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.java
@@ -9,6 +9,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
+import java.util.List;
+
 public class AuthenticationActivity extends Activity {
 
     static final String EXTRA_USE_BROWSER = "com.auth0.android.EXTRA_USE_BROWSER";
@@ -16,16 +18,18 @@ public class AuthenticationActivity extends Activity {
     static final String EXTRA_CONNECTION_NAME = "com.auth0.android.EXTRA_CONNECTION_NAME";
     static final String EXTRA_AUTHORIZE_URI = "com.auth0.android.EXTRA_AUTHORIZE_URI";
     static final String EXTRA_CT_OPTIONS = "com.auth0.android.EXTRA_CT_OPTIONS";
+    static final String EXTRA_BROWSER_PACKAGES = "com.auth0.android.EXTRA_BROWSER_PACKAGES";
     private static final String EXTRA_INTENT_LAUNCHED = "com.auth0.android.EXTRA_INTENT_LAUNCHED";
 
     private boolean intentLaunched;
     private CustomTabsController customTabsController;
 
-    static void authenticateUsingBrowser(@NonNull Context context, @NonNull Uri authorizeUri, @Nullable CustomTabsOptions options) {
+    static void authenticateUsingBrowser(@NonNull Context context, @NonNull Uri authorizeUri, @Nullable CustomTabsOptions options, @Nullable String[] browserPackages) {
         Intent intent = new Intent(context, AuthenticationActivity.class);
         intent.putExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI, authorizeUri);
         intent.putExtra(AuthenticationActivity.EXTRA_USE_BROWSER, true);
         intent.putExtra(AuthenticationActivity.EXTRA_CT_OPTIONS, options);
+        intent.putExtra(AuthenticationActivity.EXTRA_BROWSER_PACKAGES, browserPackages);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         context.startActivity(intent);
     }
@@ -113,15 +117,16 @@ public class AuthenticationActivity extends Activity {
             return;
         }
 
-        customTabsController = createCustomTabsController(this);
+        String[] browserPackages = extras.getStringArray(EXTRA_BROWSER_PACKAGES);
+        customTabsController = createCustomTabsController(this, browserPackages);
         customTabsController.setCustomizationOptions((CustomTabsOptions) extras.getParcelable(EXTRA_CT_OPTIONS));
         customTabsController.bindService();
         customTabsController.launchUri(authorizeUri);
     }
 
     @VisibleForTesting
-    CustomTabsController createCustomTabsController(@NonNull Context context) {
-        return new CustomTabsController(context);
+    CustomTabsController createCustomTabsController(@NonNull Context context, @Nullable String[] browserPackages) {
+        return new CustomTabsController(context, browserPackages);
     }
 
     @VisibleForTesting

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -172,9 +172,19 @@ class CustomTabsController extends CustomTabsServiceConnection {
         PackageManager pm = context.getPackageManager();
         Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"));
 
-        String[] browserPackages = overrideBrowserPackages == null ? getBrowserPackages(pm) : overrideBrowserPackages;
+        String[] browserPackages;
+        int packageManagerFlags;
 
-        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(browserIntent, 0);
+        // if the overrideBrowserPackages is null, preserve old behaviour of the library
+        if(overrideBrowserPackages != null){
+            browserPackages = overrideBrowserPackages;
+            packageManagerFlags = PackageManager.MATCH_ALL;
+        }else{
+            browserPackages = getBrowserPackages(pm);
+            packageManagerFlags = 0;
+        }
+
+        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(browserIntent, packageManagerFlags);
         List<String> customTabsBrowsers = new ArrayList<>();
         for (ResolveInfo info : resolvedActivityList) {
             Intent serviceIntent = new Intent();

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
@@ -27,6 +27,7 @@ class LogoutManager extends ResumableManager {
     private final Map<String, String> parameters;
 
     private CustomTabsOptions ctOptions;
+    private String[] browserPackages;
 
     LogoutManager(@NonNull Auth0 account, @NonNull VoidCallback callback, @NonNull String returnToUrl) {
         this.account = account;
@@ -39,11 +40,15 @@ class LogoutManager extends ResumableManager {
         this.ctOptions = options;
     }
 
+    void setBrowserPackages(@Nullable String[] browserPackages){
+        this.browserPackages = browserPackages;
+    }
+
     void startLogout(Context context) {
         addClientParameters(parameters);
         Uri uri = buildLogoutUri();
 
-        AuthenticationActivity.authenticateUsingBrowser(context, uri, ctOptions);
+        AuthenticationActivity.authenticateUsingBrowser(context, uri, ctOptions, browserPackages);
     }
 
     @Override

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -20,6 +20,7 @@ import com.auth0.android.result.Credentials;
 import java.security.SecureRandom;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("WeakerAccess")
@@ -67,6 +68,7 @@ class OAuthManager extends ResumableManager {
     private PKCE pkce;
     private Long currentTimeInMillis;
     private CustomTabsOptions ctOptions;
+    private String[] browserPackages;
     private Integer idTokenVerificationLeeway;
     private String idTokenVerificationIssuer;
 
@@ -87,6 +89,10 @@ class OAuthManager extends ResumableManager {
 
     public void setCustomTabsOptions(@Nullable CustomTabsOptions options) {
         this.ctOptions = options;
+    }
+
+    public void setBrowserPackages(@Nullable String[] browserPackages){
+        this.browserPackages = browserPackages;
     }
 
     @VisibleForTesting
@@ -110,7 +116,7 @@ class OAuthManager extends ResumableManager {
         this.requestCode = requestCode;
 
         if (useBrowser) {
-            AuthenticationActivity.authenticateUsingBrowser(activity, uri, ctOptions);
+            AuthenticationActivity.authenticateUsingBrowser(activity, uri, ctOptions, browserPackages);
         } else {
             AuthenticationActivity.authenticateUsingWebView(activity, uri, requestCode, parameters.get(KEY_CONNECTION), useFullScreen);
         }

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -41,6 +41,7 @@ import com.auth0.android.Auth0Exception;
 import com.auth0.android.authentication.AuthenticationException;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.auth0.android.provider.OAuthManager.KEY_CONNECTION;
@@ -69,6 +70,7 @@ public class WebAuthProvider {
         private String scheme;
         private String returnToUrl;
         private CustomTabsOptions ctOptions;
+        private String[] browserPackages;
 
         LogoutBuilder(Auth0 account) {
             this.account = account;
@@ -85,6 +87,16 @@ public class WebAuthProvider {
          */
         public LogoutBuilder withCustomTabsOptions(@NonNull CustomTabsOptions options) {
             this.ctOptions = options;
+            return this;
+        }
+
+        /**
+         * When using override custom tabs browser packages
+         * @param browserPackages the List of browsers to be used
+         * @return the current builder instance
+         */
+        public LogoutBuilder withBrowserPackage(@NonNull String[] browserPackages){
+            this.browserPackages = browserPackages;
             return this;
         }
 
@@ -137,6 +149,7 @@ public class WebAuthProvider {
             }
             LogoutManager logoutManager = new LogoutManager(this.account, callback, returnToUrl);
             logoutManager.setCustomTabsOptions(ctOptions);
+            logoutManager.setBrowserPackages(browserPackages);
 
             managerInstance = logoutManager;
             logoutManager.startLogout(context);
@@ -151,6 +164,7 @@ public class WebAuthProvider {
         private static final String SCOPE_TYPE_OPENID = "openid";
         private static final String RESPONSE_TYPE_TOKEN = "token";
 
+
         private final Auth0 account;
         private final Map<String, String> values;
         private boolean useBrowser;
@@ -161,6 +175,8 @@ public class WebAuthProvider {
         private String redirectUri;
         private CustomTabsOptions ctOptions;
         private Integer leeway;
+
+        private String[] browserPackages;
 
         Builder(Auth0 account) {
             this.account = account;
@@ -398,6 +414,11 @@ public class WebAuthProvider {
             return this;
         }
 
+        public Builder withBrowserPackage(@NonNull String[] browserPackages){
+            this.browserPackages = browserPackages;
+            return this;
+        }
+
         @VisibleForTesting
         Builder withPKCE(PKCE pkce) {
             this.pkce = pkce;
@@ -430,6 +451,7 @@ public class WebAuthProvider {
             manager.setPKCE(pkce);
             manager.setIdTokenVerificationLeeway(leeway);
             manager.setIdTokenVerificationIssuer(issuer);
+            manager.setBrowserPackages(browserPackages);
 
             managerInstance = manager;
 

--- a/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityMock.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityMock.java
@@ -3,6 +3,7 @@ package com.auth0.android.provider;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 /**
  * Created by lbalmaceda on 6/12/17.
@@ -14,7 +15,7 @@ public class AuthenticationActivityMock extends AuthenticationActivity {
     private Intent deliveredIntent;
 
     @Override
-    protected CustomTabsController createCustomTabsController(@NonNull Context context) {
+    protected CustomTabsController createCustomTabsController(@NonNull Context context, @Nullable String[] browserPackages) {
         return customTabsController;
     }
 

--- a/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
@@ -85,7 +85,7 @@ public class AuthenticationActivityTest {
 
     @Test
     public void shouldAuthenticateUsingBrowser() {
-        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions);
+        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions, null);
         verify(callerActivity).startActivity(intentCaptor.capture());
 
         createActivity(intentCaptor.getValue());
@@ -115,7 +115,7 @@ public class AuthenticationActivityTest {
 
     @Test
     public void shouldAuthenticateAfterRecreatedUsingBrowser() {
-        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions);
+        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions, null);
         verify(callerActivity).startActivity(intentCaptor.capture());
 
         createActivity(intentCaptor.getValue());
@@ -143,7 +143,7 @@ public class AuthenticationActivityTest {
 
     @Test
     public void shouldCancelAuthenticationUsingBrowser() {
-        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions);
+        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions, null);
         verify(callerActivity).startActivity(intentCaptor.capture());
 
         createActivity(intentCaptor.getValue());
@@ -275,7 +275,7 @@ public class AuthenticationActivityTest {
 
     @Test
     public void shouldLaunchForBrowserAuthentication() {
-        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions);
+        AuthenticationActivity.authenticateUsingBrowser(callerActivity, uri, customTabsOptions, null);
         verify(callerActivity).startActivity(intentCaptor.capture());
 
         Intent intent = intentCaptor.getValue();
@@ -318,7 +318,7 @@ public class AuthenticationActivityTest {
     @Test
     public void shouldCreateCustomTabsController() {
         final AuthenticationActivity authenticationActivity = new AuthenticationActivity();
-        final CustomTabsController controller = authenticationActivity.createCustomTabsController(RuntimeEnvironment.application);
+        final CustomTabsController controller = authenticationActivity.createCustomTabsController(RuntimeEnvironment.application, null);
 
         assertThat(controller, is(notNullValue()));
     }

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -110,56 +110,56 @@ public class CustomTabsControllerTest {
     @Test
     public void shouldChooseNullBrowserIfNoBrowserAvailable() {
         preparePackageManagerForCustomTabs(null);
-        String bestPackage = CustomTabsController.getBestBrowserPackage(context);
+        String bestPackage = CustomTabsController.getBestSupportedBrowserPackage(context,  null);
         assertThat(bestPackage, is(nullValue()));
     }
 
     @Test
     public void shouldChooseDefaultBrowserIfIsCustomTabsCapable() {
         preparePackageManagerForCustomTabs(DEFAULT_BROWSER_PACKAGE, DEFAULT_BROWSER_PACKAGE);
-        String bestPackage = CustomTabsController.getBestBrowserPackage(context);
+        String bestPackage = CustomTabsController.getBestSupportedBrowserPackage(context,  null);
         assertThat(bestPackage, is(DEFAULT_BROWSER_PACKAGE));
     }
 
     @Test
     public void shouldReturnNullIfNoBrowserIsCustomTabsCapable() {
         preparePackageManagerForCustomTabs(DEFAULT_BROWSER_PACKAGE);
-        String bestPackage = CustomTabsController.getBestBrowserPackage(context);
+        String bestPackage = CustomTabsController.getBestSupportedBrowserPackage(context,  null);
         assertThat(bestPackage, is(nullValue()));
     }
 
     @Test
     public void shouldChooseChromeStableOverOtherCustomTabsCapableBrowsers() {
         preparePackageManagerForCustomTabs(DEFAULT_BROWSER_PACKAGE, CHROME_STABLE_PACKAGE, CHROME_SYSTEM_PACKAGE, CHROME_BETA_PACKAGE, CHROME_DEV_PACKAGE, CUSTOM_TABS_BROWSER_1, CUSTOM_TABS_BROWSER_2);
-        String bestPackage = CustomTabsController.getBestBrowserPackage(context);
+        String bestPackage = CustomTabsController.getBestSupportedBrowserPackage(context,  null);
         assertThat(bestPackage, is(CHROME_STABLE_PACKAGE));
     }
 
     @Test
     public void shouldChooseChromeSystemOverOtherCustomTabsCapableBrowsers() {
         preparePackageManagerForCustomTabs(DEFAULT_BROWSER_PACKAGE, CHROME_SYSTEM_PACKAGE, CHROME_BETA_PACKAGE, CHROME_DEV_PACKAGE, CUSTOM_TABS_BROWSER_1, CUSTOM_TABS_BROWSER_2);
-        String bestPackage = CustomTabsController.getBestBrowserPackage(context);
+        String bestPackage = CustomTabsController.getBestSupportedBrowserPackage(context,  null);
         assertThat(bestPackage, is(CHROME_SYSTEM_PACKAGE));
     }
 
     @Test
     public void shouldChooseChromeBetaOverOtherCustomTabsCapableBrowsers() {
         preparePackageManagerForCustomTabs(DEFAULT_BROWSER_PACKAGE, CHROME_BETA_PACKAGE, CHROME_DEV_PACKAGE, CUSTOM_TABS_BROWSER_1, CUSTOM_TABS_BROWSER_2);
-        String bestPackage = CustomTabsController.getBestBrowserPackage(context);
+        String bestPackage = CustomTabsController.getBestSupportedBrowserPackage(context,  null);
         assertThat(bestPackage, is(CHROME_BETA_PACKAGE));
     }
 
     @Test
     public void shouldChooseChromeDevOverOtherCustomTabsCapableBrowsers() {
         preparePackageManagerForCustomTabs(DEFAULT_BROWSER_PACKAGE, CHROME_DEV_PACKAGE, CUSTOM_TABS_BROWSER_1, CUSTOM_TABS_BROWSER_2);
-        String bestPackage = CustomTabsController.getBestBrowserPackage(context);
+        String bestPackage = CustomTabsController.getBestSupportedBrowserPackage(context,  null);
         assertThat(bestPackage, is(CHROME_DEV_PACKAGE));
     }
 
     @Test
     public void shouldChooseCustomTabsCapableBrowserIfAvailable() {
         preparePackageManagerForCustomTabs(DEFAULT_BROWSER_PACKAGE, CUSTOM_TABS_BROWSER_1, CUSTOM_TABS_BROWSER_2);
-        String bestPackage = CustomTabsController.getBestBrowserPackage(context);
+        String bestPackage = CustomTabsController.getBestSupportedBrowserPackage(context,  null);
         assertThat(bestPackage, is(CUSTOM_TABS_BROWSER_1));
     }
 
@@ -204,7 +204,7 @@ public class CustomTabsControllerTest {
 
     @Test
     public void shouldLaunchUriUsingFallbackWhenNoCustomTabsCompatibleBrowserIsAvailable() {
-        CustomTabsController controller = new CustomTabsController(context, null);
+        CustomTabsController controller = new CustomTabsController(context, (String[]) null);
         controller.launchUri(uri);
 
         verify(context, timeout(MAX_TEST_WAIT_TIME_MS)).startActivity(launchIntentCaptor.capture());


### PR DESCRIPTION
### Changes

Adds the ability to override the default browser packages list when opening Chrome Custom Tabs for Universal Login. This is required in certain situations when a combination of Custom Domains and app-specific behaviour makes it impossible to login in browsers like Firefox.

Despite the customers should follow the default behaviour, in certain cases they understand the associated risks and are willing to override the list of packages to use.

This PR adds a new method in the Authentication and Logout builders (WebAuthenticationProvider.java) withBrowserPackages which accepts an array of browser packages to try, instead of the default ones.

The provided array as a parameter is pushed all the way down to the CustomTabsController class which uses it to determine the best browser package. If the array is null - it will use the default behaviour, otherwise, it will use the best first package from the provided array which supports ChromeCustomTabs

### Testing

To test the changes:

*Testing old behaviour*: Run a sample and make sure it opens the Universal Login in the default browser (it's best to use Firefox for this to clearly see the change).

*Testing new behaviour*: Use the `withBrowserPackages` method to force the usage of a browser other than the default one, make sure Universal Login opens in the indicated browser.

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

Do not merge this PR yet, I will add unit tests once the customer confirms that it works for them and repository maintainers are ok with the proposed changes.

### Checklist

- [ x ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [ x ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ x ] All existing and new tests complete without errors
