### PR TITLE
Fix NPE on Kotlin when callbacks returned a nullable value

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -26,6 +26,7 @@ package com.auth0.android.authentication;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
 import com.auth0.android.Auth0;
@@ -593,7 +594,7 @@ public class AuthenticationAPIClient {
      * @return a request to start
      */
     @NonNull
-    public DatabaseConnectionRequest<DatabaseUser, AuthenticationException> createUser(@NonNull String email, @NonNull String password, @NonNull String username, @NonNull String connection) {
+    public DatabaseConnectionRequest<DatabaseUser, AuthenticationException> createUser(@NonNull String email, @NonNull String password, @Nullable String username, @NonNull String connection) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(DB_CONNECTIONS_PATH)
                 .addPathSegment(SIGN_UP_PATH)
@@ -635,7 +636,6 @@ public class AuthenticationAPIClient {
      */
     @NonNull
     public DatabaseConnectionRequest<DatabaseUser, AuthenticationException> createUser(@NonNull String email, @NonNull String password, @NonNull String connection) {
-        //noinspection ConstantConditions
         return createUser(email, password, null, connection);
     }
 

--- a/auth0/src/main/java/com/auth0/android/authentication/request/DelegationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/DelegationRequest.java
@@ -25,7 +25,6 @@
 package com.auth0.android.authentication.request;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.auth0.android.Auth0Exception;
 import com.auth0.android.authentication.AuthenticationException;

--- a/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.java
@@ -141,11 +141,13 @@ public class ProfileRequest implements Request<Authentication, AuthenticationExc
         getAuthRequest().start(new BaseCallback<Credentials, AuthenticationException>() {
             @Override
             public void onSuccess(@Nullable final Credentials credentials) {
+                //noinspection ConstantConditions
                 userInfoRequest
                         .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials.getAccessToken())
                         .start(new BaseCallback<UserProfile, AuthenticationException>() {
                             @Override
                             public void onSuccess(@Nullable UserProfile profile) {
+                                //noinspection ConstantConditions
                                 callback.onSuccess(new Authentication(profile, credentials));
                             }
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
@@ -275,6 +275,7 @@ public class SecureCredentialsManager {
             @Override
             public void onSuccess(@Nullable Credentials fresh) {
                 //non-empty refresh token for refresh token rotation scenarios
+                //noinspection ConstantConditions
                 String updatedRefreshToken = isEmpty(fresh.getRefreshToken()) ? credentials.getRefreshToken() : fresh.getRefreshToken();
                 Credentials refreshed = new Credentials(fresh.getIdToken(), fresh.getAccessToken(), fresh.getType(), updatedRefreshToken, fresh.getExpiresAt(), fresh.getScope());
                 saveCredentials(refreshed);

--- a/auth0/src/main/java/com/auth0/android/callback/BaseCallback.java
+++ b/auth0/src/main/java/com/auth0/android/callback/BaseCallback.java
@@ -24,7 +24,7 @@
 
 package com.auth0.android.callback;
 
-import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.auth0.android.Auth0Exception;
 
@@ -38,6 +38,6 @@ public interface BaseCallback<T, U extends Auth0Exception> extends Callback<U> {
      *
      * @param payload Request payload or null
      */
-    void onSuccess(@NonNull T payload);
+    void onSuccess(@Nullable T payload);
 
 }

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -231,6 +231,7 @@ class OAuthManager extends ResumableManager {
 
             @Override
             public void onSuccess(@Nullable SignatureVerifier signatureVerifier) {
+                //noinspection ConstantConditions
                 IdTokenVerificationOptions options = new IdTokenVerificationOptions(idTokenVerificationIssuer, apiClient.getClientId(), signatureVerifier);
                 String maxAge = parameters.get(KEY_MAX_AGE);
                 if (!TextUtils.isEmpty(maxAge)) {

--- a/auth0/src/main/java/com/auth0/android/provider/PKCE.java
+++ b/auth0/src/main/java/com/auth0/android/provider/PKCE.java
@@ -88,6 +88,7 @@ class PKCE {
                 .start(new BaseCallback<Credentials, AuthenticationException>() {
                     @Override
                     public void onSuccess(@Nullable Credentials payload) {
+                        //noinspection ConstantConditions
                         callback.onSuccess(payload);
                     }
 

--- a/auth0/src/main/java/com/auth0/android/provider/SignatureVerifier.java
+++ b/auth0/src/main/java/com/auth0/android/provider/SignatureVerifier.java
@@ -59,6 +59,7 @@ abstract class SignatureVerifier {
         apiClient.fetchJsonWebKeys().start(new AuthenticationCallback<Map<String, PublicKey>>() {
             @Override
             public void onSuccess(@Nullable Map<String, PublicKey> jwks) {
+                //noinspection ConstantConditions
                 PublicKey publicKey = jwks.get(keyId);
                 try {
                     callback.onSuccess(new AsymmetricSignatureVerifier(publicKey));

--- a/auth0/src/main/java/com/auth0/android/provider/VoidCallback.java
+++ b/auth0/src/main/java/com/auth0/android/provider/VoidCallback.java
@@ -24,8 +24,6 @@
 
 package com.auth0.android.provider;
 
-import android.support.annotation.Nullable;
-
 import com.auth0.android.Auth0Exception;
 import com.auth0.android.callback.BaseCallback;
 
@@ -34,6 +32,4 @@ import com.auth0.android.callback.BaseCallback;
  */
 @SuppressWarnings("WeakerAccess")
 public interface VoidCallback extends BaseCallback<Void, Auth0Exception> {
-    @Override
-    void onSuccess(@Nullable Void payload);
 }

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -139,6 +139,7 @@ public class WebAuthProvider {
             if (returnToUrl == null) {
                 returnToUrl = CallbackHelper.getCallbackUri(scheme, context.getApplicationContext().getPackageName(), account.getDomainUrl());
             }
+            //noinspection ConstantConditions
             LogoutManager logoutManager = new LogoutManager(this.account, callback, returnToUrl);
             logoutManager.setCustomTabsOptions(ctOptions);
 

--- a/auth0/src/main/java/com/auth0/android/request/internal/ManagementErrorBuilder.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/ManagementErrorBuilder.java
@@ -1,6 +1,7 @@
 package com.auth0.android.request.internal;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.auth0.android.Auth0Exception;
 import com.auth0.android.management.ManagementException;
@@ -30,7 +31,7 @@ public class ManagementErrorBuilder implements ErrorBuilder<ManagementException>
 
     @NonNull
     @Override
-    public ManagementException from(@NonNull String payload, int statusCode) {
+    public ManagementException from(@Nullable String payload, int statusCode) {
         return new ManagementException(payload, statusCode);
     }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -843,7 +843,6 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulSignUp();
 
         final MockAuthenticationCallback<DatabaseUser> callback = new MockAuthenticationCallback<>();
-        //noinspection ConstantConditions
         client.createUser(SUPPORT_AUTH0_COM, PASSWORD, null, MY_CONNECTION)
                 .start(callback);
 
@@ -864,7 +863,6 @@ public class AuthenticationAPIClientTest {
     public void shouldNotSendNullUsernameOnSignUpSync() throws Exception {
         mockAPI.willReturnSuccessfulSignUp();
 
-        //noinspection ConstantConditions
         final DatabaseUser user = client.createUser(SUPPORT_AUTH0_COM, PASSWORD, null, MY_CONNECTION)
                 .execute();
 

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
@@ -172,13 +172,13 @@ public class CredentialsManagerTest {
         manager.saveCredentials(credentials);
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Test
     public void shouldThrowOnSetIfCredentialsDoesNotHaveExpiresAt() {
         exception.expect(CredentialsManagerException.class);
         exception.expectMessage("Credentials must have a valid date of expiration and a valid access_token or id_token value.");
 
         Date date = null;
+        //noinspection ConstantConditions
         Credentials credentials = new CredentialsMock("idToken", "accessToken", "type", "refreshToken", date, "scope");
         manager.saveCredentials(credentials);
     }

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.java
@@ -277,13 +277,13 @@ public class SecureCredentialsManagerTest {
         manager.saveCredentials(credentials);
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Test
     public void shouldThrowOnSaveIfCredentialsDoesNotHaveExpiresAt() {
         exception.expect(CredentialsManagerException.class);
         exception.expectMessage("Credentials must have a valid date of expiration and a valid access_token or id_token value.");
 
         Date date = null;
+        //noinspection ConstantConditions
         Credentials credentials = new CredentialsMock("idToken", "accessToken", "type", "refreshToken", date, "scope");
         prepareJwtDecoderMock(new Date());
         manager.saveCredentials(credentials);

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
@@ -67,11 +67,11 @@ public class SharedPreferencesStorageTest {
         verify(context).getSharedPreferences("my-preferences-file", Context.MODE_PRIVATE);
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Test
     public void shouldThrowOnCreateIfCustomPreferencesFileNameIsNull() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The SharedPreferences name is invalid");
+        //noinspection ConstantConditions
         new SharedPreferencesStorage(context, null);
     }
 
@@ -184,11 +184,11 @@ public class SharedPreferencesStorageTest {
 
     //Remove
 
-    @SuppressWarnings("ConstantConditions")
     @Test
     public void shouldRemovePreferencesKeyOnNullStringValue() {
         SharedPreferencesStorage storage = new SharedPreferencesStorage(context);
         String value = null;
+        //noinspection ConstantConditions
         storage.store("name", value);
         verify(sharedPreferencesEditor).remove("name");
         verify(sharedPreferencesEditor).apply();


### PR DESCRIPTION
### Changes

On a previous PR, we introduced annotations to prevent the Kotlin compiler from guessing the nullability of the SDK's params and returned values by rather being explicit. This fix to the lint warnings was meant to improve the compatibility when this SDK was used in a Kotlin environment. 

In the case of the callbacks that returned a `Void` type, those were annotated as "Non-null" and still returned `null`, given that the return value is not supposed to be used. However, Kotlin was checking its nullability on runtime crashing the app with an NPE when the value of a declared non-null variable was null.

This was not caught in unit tests because we are not using Kotlin to compile this SDK nor run its tests. This only affects Kotlin codebases.

The fix was to roll back those changes in particular to the value that could be returned in a `BaseCallback` implementation, changing it back again to `Nullable`.

### References
Fixes https://github.com/auth0/Auth0.Android/issues/341

### Testing
I've manually tested this on a kotlin app. Calling methods that make use of the `VoidRequest` (like the logout manager), an `AuthenticationCallback` implementation that returns null (like passwordless/start), and a regular API call that returns a different type.

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
