### PR TITLE
Catch a gson JsonIOException when parsing SimpleRequest response [SDK-1981]

### DIFF
--- a/auth0/src/main/java/com/auth0/android/request/internal/SimpleRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/SimpleRequest.java
@@ -32,6 +32,7 @@ import com.auth0.android.RequestBodyBuildException;
 import com.auth0.android.request.ErrorBuilder;
 import com.auth0.android.request.ParameterizableRequest;
 import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
 import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.HttpUrl;
@@ -77,7 +78,7 @@ class SimpleRequest<T, U extends Auth0Exception> extends BaseRequest<T, U> imple
             Reader charStream = body.charStream();
             T payload = getAdapter().fromJson(charStream);
             postOnSuccess(payload);
-        } catch (IOException e) {
+        } catch (IOException | JsonIOException e) {
             final Auth0Exception auth0Exception = new Auth0Exception("Failed to parse response to request to " + url, e);
             postOnFailure(getErrorBuilder().from("Failed to parse a successful response", auth0Exception));
         } finally {

--- a/auth0/src/main/java/com/auth0/android/request/internal/SimpleRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/SimpleRequest.java
@@ -88,9 +88,9 @@ class SimpleRequest<T, U extends Auth0Exception> extends BaseRequest<T, U> imple
 
     @Override
     protected Request doBuildRequest() throws RequestBodyBuildException {
-        boolean sendBody = method.equals("HEAD") || method.equals("GET");
+        boolean skipBody = method.equals("HEAD") || method.equals("GET");
         return newBuilder()
-                .method(method, sendBody ? null : buildBody())
+                .method(method, skipBody ? null : buildBody())
                 .build();
     }
 
@@ -114,7 +114,7 @@ class SimpleRequest<T, U extends Auth0Exception> extends BaseRequest<T, U> imple
         try {
             Reader charStream = body.charStream();
             return getAdapter().fromJson(charStream);
-        } catch (IOException e) {
+        } catch (IOException | JsonParseException e) {
             throw new Auth0Exception("Failed to parse response to request to " + url, e);
         } finally {
             closeStream(body);

--- a/auth0/src/main/java/com/auth0/android/request/internal/SimpleRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/SimpleRequest.java
@@ -32,7 +32,7 @@ import com.auth0.android.RequestBodyBuildException;
 import com.auth0.android.request.ErrorBuilder;
 import com.auth0.android.request.ParameterizableRequest;
 import com.google.gson.Gson;
-import com.google.gson.JsonIOException;
+import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.HttpUrl;
@@ -78,7 +78,7 @@ class SimpleRequest<T, U extends Auth0Exception> extends BaseRequest<T, U> imple
             Reader charStream = body.charStream();
             T payload = getAdapter().fromJson(charStream);
             postOnSuccess(payload);
-        } catch (IOException | JsonIOException e) {
+        } catch (IOException | JsonParseException e) {
             final Auth0Exception auth0Exception = new Auth0Exception("Failed to parse response to request to " + url, e);
             postOnFailure(getErrorBuilder().from("Failed to parse a successful response", auth0Exception));
         } finally {

--- a/auth0/src/test/java/com/auth0/android/request/internal/OkHttpClientFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/OkHttpClientFactoryTest.java
@@ -172,7 +172,7 @@ public class OkHttpClientFactoryTest {
     }
 
     private static void verifyTLS12NotEnforced(OkHttpClient client) {
-        verify(client, never()).setSslSocketFactory((SSLSocketFactory) any());
+        verify(client, never()).setSslSocketFactory(any(SSLSocketFactory.class));
     }
 
     private static void verifyTLS12Enforced(OkHttpClient client) {

--- a/auth0/src/test/java/com/auth0/android/request/internal/SimpleRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/SimpleRequestTest.java
@@ -38,8 +38,8 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class SimpleRequestTest {
@@ -257,7 +257,7 @@ public class SimpleRequestTest {
             expectedException = e;
         }
         assertThat(result, Matchers.<Object>is(Collections.<String, Object>emptyMap()));
-        verify(errorBuilder, never());
+        verifyZeroInteractions(errorBuilder);
         assertThat(expectedException, is(nullValue()));
     }
 
@@ -365,6 +365,7 @@ public class SimpleRequestTest {
         } catch (Exception e) {
             expectedException = e;
         }
+        verifyZeroInteractions(errorBuilder);
         assertThat(result, is(nullValue()));
         assertThat(expectedException, is(notNullValue()));
         assertThat(expectedException.getCause(), is(Matchers.<Throwable>instanceOf(IOException.class)));
@@ -404,6 +405,7 @@ public class SimpleRequestTest {
         } catch (Exception e) {
             expectedException = e;
         }
+        verifyZeroInteractions(errorBuilder);
         assertThat(result, is(nullValue()));
         assertThat(expectedException, is(notNullValue()));
         assertThat(expectedException.getCause(), is(Matchers.<Throwable>instanceOf(IOException.class)));

--- a/auth0/src/test/java/com/auth0/android/request/internal/SimpleRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/SimpleRequestTest.java
@@ -1,0 +1,413 @@
+package com.auth0.android.request.internal;
+
+import com.auth0.android.Auth0Exception;
+import com.auth0.android.callback.BaseCallback;
+import com.auth0.android.request.ErrorBuilder;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.squareup.okhttp.Call;
+import com.squareup.okhttp.Callback;
+import com.squareup.okhttp.HttpUrl;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Protocol;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SimpleRequestTest {
+
+    private static final MediaType JSON_MEDIATYPE = MediaType.parse("application/json; charset=utf-8");
+
+    private Gson gson;
+    private HttpUrl url;
+    @Mock
+    private OkHttpClient client;
+    @Mock
+    private ErrorBuilder<Auth0Exception> errorBuilder;
+    @Mock
+    private BaseCallback<Object, Auth0Exception> callback;
+    @Mock
+    private JsonDeserializer<Object> adapter;
+    @Captor
+    ArgumentCaptor<Auth0Exception> exceptionMatcher;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        url = HttpUrl.parse("https://mycompany.com/");
+        gson = GsonProvider.buildGson();
+    }
+
+    @Test
+    public void shouldSkipSettingBodyWithGETorHEAD() {
+        SimpleRequest<Object, Auth0Exception> get = new SimpleRequest<>(url, client, gson, "GET", errorBuilder);
+        get.addParameter("name", "john");
+        Request getRequest = get.doBuildRequest();
+        assertThat(getRequest.body(), is(nullValue()));
+
+        SimpleRequest<Object, Auth0Exception> head = new SimpleRequest<>(url, client, gson, "HEAD", errorBuilder);
+        head.addParameter("name", "john");
+        Request headRequest = head.doBuildRequest();
+        assertThat(headRequest.body(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetBodyWithPOSTorPATCH() {
+        SimpleRequest<Object, Auth0Exception> post = new SimpleRequest<>(url, client, gson, "POST", errorBuilder);
+        post.addParameter("name", "john");
+        Request postRequest = post.doBuildRequest();
+        assertThat(postRequest.body(), is(notNullValue()));
+        assertThat(postRequest.body().contentType(), is(JSON_MEDIATYPE));
+
+        SimpleRequest<Object, Auth0Exception> patch = new SimpleRequest<>(url, client, gson, "PATCH", errorBuilder);
+        patch.addParameter("name", "john");
+        Request patchRequest = patch.doBuildRequest();
+        assertThat(patchRequest.body(), is(notNullValue()));
+        assertThat(patchRequest.body().contentType(), is(JSON_MEDIATYPE));
+    }
+
+    @Test
+    public void shouldSucceed() {
+        SimpleRequest<Object, Auth0Exception> get = new SimpleRequest<>(url, client, gson, "GET", errorBuilder);
+        get.setCallback(callback);
+        String validJson = "{}";
+        ResponseBody resBody = ResponseBody.create(JSON_MEDIATYPE, validJson);
+
+        Request request = new Request.Builder()
+                .method("GET", null)
+                .url(url)
+                .build();
+        Response response = new Response.Builder()
+                .body(resBody)
+                .protocol(Protocol.HTTP_2)
+                .request(request)
+                .code(200)
+                .build();
+
+        Call call = mock(Call.class);
+        when(client.newCall(any(Request.class))).thenReturn(call);
+        get.start(callback);
+        verify(call).enqueue(any(Callback.class));
+
+        get.onResponse(response);
+        verify(callback).onSuccess(Collections.<String, Object>emptyMap());
+    }
+
+    @Test
+    public void shouldFailOnUnsuccessfulResponse() {
+        SimpleRequest<Object, Auth0Exception> get = new SimpleRequest<>(url, client, gson, "GET", errorBuilder);
+        get.setCallback(callback);
+        String validJson = "{}";
+        ResponseBody resBody = ResponseBody.create(JSON_MEDIATYPE, validJson);
+
+        Request request = new Request.Builder()
+                .method("GET", null)
+                .url(url)
+                .build();
+        Response response = new Response.Builder()
+                .body(resBody)
+                .protocol(Protocol.HTTP_2)
+                .request(request)
+                .code(422)
+                .build();
+
+        Call call = mock(Call.class);
+        when(client.newCall(any(Request.class))).thenReturn(call);
+        get.start(callback);
+        verify(call).enqueue(any(Callback.class));
+
+        get.onResponse(response);
+        verify(callback).onFailure(any(Auth0Exception.class));
+        verify(errorBuilder).from(Collections.<String, Object>emptyMap());
+    }
+
+    @Test
+    public void shouldFailOnSuccessfulResponseWithIOException() {
+        when(adapter.deserialize(any(JsonElement.class), any(Type.class), any(JsonDeserializationContext.class)))
+                .thenThrow(IOException.class);
+        Gson gson = new GsonBuilder().registerTypeAdapter(Object.class, adapter).create();
+        SimpleRequest<Object, Auth0Exception> get = new SimpleRequest<>(url, client, gson, "GET", errorBuilder);
+        get.setCallback(callback);
+        String invalidJson = "{---}";
+        ResponseBody resBody = ResponseBody.create(JSON_MEDIATYPE, invalidJson);
+
+        Request request = new Request.Builder()
+                .method("GET", null)
+                .url(url)
+                .build();
+        Response response = new Response.Builder()
+                .body(resBody)
+                .protocol(Protocol.HTTP_2)
+                .request(request)
+                .code(200)
+                .build();
+
+        Call call = mock(Call.class);
+        when(client.newCall(any(Request.class))).thenReturn(call);
+        get.start(callback);
+        verify(call).enqueue(any(Callback.class));
+
+        get.onResponse(response);
+
+        verify(callback).onFailure(any(Auth0Exception.class));
+        verify(errorBuilder).from(eq("Failed to parse a successful response"), exceptionMatcher.capture());
+        assertThat(exceptionMatcher.getValue(), is(notNullValue()));
+        assertThat(exceptionMatcher.getValue().getMessage(), is("Failed to parse response to request to https://mycompany.com/"));
+        assertThat(exceptionMatcher.getValue().getCause(), is(Matchers.<Throwable>instanceOf(IOException.class)));
+    }
+
+    @Test
+    public void shouldFailOnSuccessfulResponseWithJsonParseException() {
+        when(adapter.deserialize(any(JsonElement.class), any(Type.class), any(JsonDeserializationContext.class)))
+                .thenThrow(JsonParseException.class);
+        Gson gson = new GsonBuilder().registerTypeAdapter(Object.class, adapter).create();
+        SimpleRequest<Object, Auth0Exception> get = new SimpleRequest<>(url, client, gson, "GET", errorBuilder);
+        get.setCallback(callback);
+        String invalidJson = "{---}";
+        ResponseBody resBody = ResponseBody.create(JSON_MEDIATYPE, invalidJson);
+
+        Request request = new Request.Builder()
+                .method("GET", null)
+                .url(url)
+                .build();
+        Response response = new Response.Builder()
+                .body(resBody)
+                .protocol(Protocol.HTTP_2)
+                .request(request)
+                .code(200)
+                .build();
+
+        Call call = mock(Call.class);
+        when(client.newCall(any(Request.class))).thenReturn(call);
+        get.start(callback);
+        verify(call).enqueue(any(Callback.class));
+
+        get.onResponse(response);
+
+        verify(callback).onFailure(any(Auth0Exception.class));
+        verify(errorBuilder).from(eq("Failed to parse a successful response"), exceptionMatcher.capture());
+        assertThat(exceptionMatcher.getValue(), is(notNullValue()));
+        assertThat(exceptionMatcher.getValue().getMessage(), is("Failed to parse response to request to https://mycompany.com/"));
+        assertThat(exceptionMatcher.getValue().getCause(), is(Matchers.<Throwable>instanceOf(IOException.class)));
+    }
+
+    @Test
+    public void shouldStart() {
+        Call call = mock(Call.class);
+        when(client.newCall(any(Request.class))).thenReturn(call);
+        SimpleRequest<Object, Auth0Exception> get = new SimpleRequest<>(url, client, gson, "GET", errorBuilder);
+        get.start(callback);
+    }
+
+    @Test
+    public void shouldExecuteSuccessfully() throws IOException {
+        String validJson = "{}";
+        ResponseBody resBody = ResponseBody.create(JSON_MEDIATYPE, validJson);
+
+        Request request = new Request.Builder()
+                .method("GET", null)
+                .url(url)
+                .build();
+        Response response = new Response.Builder()
+                .body(resBody)
+                .protocol(Protocol.HTTP_2)
+                .request(request)
+                .code(200)
+                .build();
+
+        Call call = mock(Call.class);
+        when(client.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        SimpleRequest<Object, Auth0Exception> get = new SimpleRequest<>(url, client, gson, "GET", errorBuilder);
+
+
+        Exception expectedException = null;
+        Object result = null;
+        try {
+            result = get.execute();
+        } catch (Exception e) {
+            expectedException = e;
+        }
+        assertThat(result, Matchers.<Object>is(Collections.<String, Object>emptyMap()));
+        verify(errorBuilder, never());
+        assertThat(expectedException, is(nullValue()));
+    }
+
+    @Test
+    public void shouldExecuteSuccessfullyButReceiveFailedResponse() throws IOException {
+        String validJson = "{}";
+        ResponseBody resBody = ResponseBody.create(JSON_MEDIATYPE, validJson);
+
+        Request request = new Request.Builder()
+                .method("GET", null)
+                .url(url)
+                .build();
+        Response response = new Response.Builder()
+                .body(resBody)
+                .protocol(Protocol.HTTP_2)
+                .request(request)
+                .code(422)
+                .build();
+
+        Call call = mock(Call.class);
+        when(client.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        SimpleRequest<Object, Auth0Exception> get = new SimpleRequest<>(url, client, gson, "GET", errorBuilder);
+
+
+        Exception expectedException = null;
+        Object result = null;
+        try {
+            result = get.execute();
+        } catch (Exception e) {
+            expectedException = e;
+        }
+        assertThat(result, is(nullValue()));
+        assertThat(expectedException, is(notNullValue()));
+        verify(errorBuilder).from(Collections.<String, Object>emptyMap());
+    }
+
+    @Test
+    public void shouldFailToExecuteWithIOException() throws IOException {
+        String invalidJson = "{---}";
+        ResponseBody resBody = ResponseBody.create(JSON_MEDIATYPE, invalidJson);
+
+        Request request = new Request.Builder()
+                .method("GET", null)
+                .url(url)
+                .build();
+        Response response = new Response.Builder()
+                .body(resBody)
+                .protocol(Protocol.HTTP_2)
+                .request(request)
+                .code(200)
+                .build();
+
+        Call call = mock(Call.class);
+        when(client.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenThrow(IOException.class);
+        SimpleRequest<Object, Auth0Exception> get = new SimpleRequest<>(url, client, gson, "GET", errorBuilder);
+
+
+        Exception expectedException = null;
+        Object result = null;
+        try {
+            result = get.execute();
+        } catch (Exception e) {
+            expectedException = e;
+        }
+        assertThat(result, is(nullValue()));
+        assertThat(expectedException, is(notNullValue()));
+        verify(errorBuilder).from(eq("Request failed"), exceptionMatcher.capture());
+        assertThat(exceptionMatcher.getValue(), is(notNullValue()));
+        assertThat(exceptionMatcher.getValue().getMessage(), is("Failed to execute the network request"));
+        assertThat(exceptionMatcher.getValue().getCause(), is(Matchers.<Throwable>instanceOf(IOException.class)));
+    }
+
+    @Test
+    public void shouldFailToExecuteOnSuccessfulResponseWithIOException() throws IOException {
+        when(adapter.deserialize(any(JsonElement.class), any(Type.class), any(JsonDeserializationContext.class)))
+                .thenThrow(IOException.class);
+        Gson gson = new GsonBuilder().registerTypeAdapter(Object.class, adapter).create();
+
+        String invalidJson = "{---}";
+        ResponseBody resBody = ResponseBody.create(JSON_MEDIATYPE, invalidJson);
+
+        Request request = new Request.Builder()
+                .method("GET", null)
+                .url(url)
+                .build();
+        Response response = new Response.Builder()
+                .body(resBody)
+                .protocol(Protocol.HTTP_2)
+                .request(request)
+                .code(200)
+                .build();
+
+        Call call = mock(Call.class);
+        when(client.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        SimpleRequest<Object, Auth0Exception> get = new SimpleRequest<>(url, client, gson, "GET", errorBuilder);
+
+
+        Exception expectedException = null;
+        Object result = null;
+        try {
+            result = get.execute();
+        } catch (Exception e) {
+            expectedException = e;
+        }
+        assertThat(result, is(nullValue()));
+        assertThat(expectedException, is(notNullValue()));
+        assertThat(expectedException.getCause(), is(Matchers.<Throwable>instanceOf(IOException.class)));
+        assertThat(expectedException.getMessage(), is("Failed to parse response to request to https://mycompany.com/"));
+    }
+
+    @Test
+    public void shouldFailToExecuteOnSuccessfulResponseWithJsonParseException() throws IOException {
+        when(adapter.deserialize(any(JsonElement.class), any(Type.class), any(JsonDeserializationContext.class)))
+                .thenThrow(JsonParseException.class);
+        Gson gson = new GsonBuilder().registerTypeAdapter(Object.class, adapter).create();
+
+        String invalidJson = "{---}";
+        ResponseBody resBody = ResponseBody.create(JSON_MEDIATYPE, invalidJson);
+
+        Request request = new Request.Builder()
+                .method("GET", null)
+                .url(url)
+                .build();
+        Response response = new Response.Builder()
+                .body(resBody)
+                .protocol(Protocol.HTTP_2)
+                .request(request)
+                .code(200)
+                .build();
+
+        Call call = mock(Call.class);
+        when(client.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        SimpleRequest<Object, Auth0Exception> get = new SimpleRequest<>(url, client, gson, "GET", errorBuilder);
+
+
+        Exception expectedException = null;
+        Object result = null;
+        try {
+            result = get.execute();
+        } catch (Exception e) {
+            expectedException = e;
+        }
+        assertThat(result, is(nullValue()));
+        assertThat(expectedException, is(notNullValue()));
+        assertThat(expectedException.getCause(), is(Matchers.<Throwable>instanceOf(IOException.class)));
+        assertThat(expectedException.getMessage(), is("Failed to parse response to request to https://mycompany.com/"));
+    }
+
+}


### PR DESCRIPTION
This addresses support ticket #00467724. IOExceptions are already caught, but it turns out in some cases, gson actually wraps underlying IOExceptions in JsonIOExceptions (which does not extent IOException).

Example stack trace:
```
Fatal Exception: com.google.gson.JsonIOException: java.net.SocketTimeoutException: timeout
   at com.google.gson.internal.Streams.parse(Streams.java:62)
   at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:65)
   at com.google.gson.TypeAdapter.fromJson(TypeAdapter.java:260)
   at com.auth0.android.request.internal.SimpleRequest.onResponse(SimpleRequest.java:76)
   at com.squareup.okhttp.Call$AsyncCall.execute(Call.java:177)
   at com.squareup.okhttp.internal.NamedRunnable.run(NamedRunnable.java:33)
   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
   at java.lang.Thread.run(Thread.java:764)

Caused by java.net.SocketTimeoutException: timeout
   at okio.SocketAsyncTimeout.newTimeoutException(SocketAsyncTimeout.java:143)
   at okio.AsyncTimeout.access$newTimeoutException(AsyncTimeout.java:162)
   at okio.AsyncTimeout.withTimeout(AsyncTimeout.java:154)
   at okio.AsyncTimeout$source$1.read(AsyncTimeout.java:340)
   at okio.internal.RealBufferedSourceKt.commonRead(RealBufferedSourceKt.java:39)
   at okio.RealBufferedSource.read(RealBufferedSource.java:188)
   at com.squareup.okhttp.internal.http.Http1xStream$ChunkedSource.read(Http1xStream.java:439)
   at okio.internal.RealBufferedSourceKt.commonRead(RealBufferedSourceKt.java:39)
   at okio.RealBufferedSource.read(RealBufferedSource.java:188)
   at okio.internal.RealBufferedSourceKt.commonExhausted(RealBufferedSourceKt.java:49)
   at okio.RealBufferedSource.exhausted(RealBufferedSource.java:198)
   at okio.InflaterSource.refill(InflaterSource.java:112)
   at okio.InflaterSource.readOrInflate(InflaterSource.java:76)
   at okio.InflaterSource.read(InflaterSource.java:49)
   at okio.GzipSource.read(GzipSource.java:69)
   at okio.RealBufferedSource$inputStream$1.read(RealBufferedSource.java:158)
   at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:288)
   at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:351)
   at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:180)
   at java.io.InputStreamReader.read(InputStreamReader.java:184)
   at com.google.gson.stream.JsonReader.fillBuffer(JsonReader.java:1291)
   at com.google.gson.stream.JsonReader.nextNonWhitespace(JsonReader.java:1329)
   at com.google.gson.stream.JsonReader.doPeek(JsonReader.java:550)
   at com.google.gson.stream.JsonReader.peek(JsonReader.java:426)
   at com.google.gson.internal.bind.TypeAdapters$29.read(TypeAdapters.java:700)
   at com.google.gson.internal.bind.TypeAdapters$29.read(TypeAdapters.java:723)
   at com.google.gson.internal.bind.TypeAdapters$29.read(TypeAdapters.java:698)
   at com.google.gson.internal.Streams.parse(Streams.java:48)
   at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:65)
   at com.google.gson.TypeAdapter.fromJson(TypeAdapter.java:260)
   at com.auth0.android.request.internal.SimpleRequest.onResponse(SimpleRequest.java:76)
   at com.squareup.okhttp.Call$AsyncCall.execute(Call.java:177)
   at com.squareup.okhttp.internal.NamedRunnable.run(NamedRunnable.java:33)
   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
   at java.lang.Thread.run(Thread.java:764)
```


### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
