### PR TITLE
Accept a custom clock instance in both Credentials Managers [SDK-1973]

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/ClockImpl.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/ClockImpl.java
@@ -1,0 +1,21 @@
+package com.auth0.android.authentication.storage;
+
+import com.auth0.android.util.Clock;
+
+/**
+ * Default Clock implementation used for verification.
+ *
+ * @see Clock
+ * <p>
+ * This class is thread-safe.
+ */
+final class ClockImpl implements Clock {
+
+    ClockImpl() {
+    }
+
+    @Override
+    public long getCurrentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -10,6 +10,7 @@ import com.auth0.android.callback.AuthenticationCallback;
 import com.auth0.android.callback.BaseCallback;
 import com.auth0.android.jwt.JWT;
 import com.auth0.android.result.Credentials;
+import com.auth0.android.util.Clock;
 
 import java.util.Date;
 
@@ -31,12 +32,14 @@ public class CredentialsManager {
     private final AuthenticationAPIClient authClient;
     private final Storage storage;
     private final JWTDecoder jwtDecoder;
+    private Clock clock;
 
     @VisibleForTesting
     CredentialsManager(@NonNull AuthenticationAPIClient authenticationClient, @NonNull Storage storage, @NonNull JWTDecoder jwtDecoder) {
         this.authClient = authenticationClient;
         this.storage = storage;
         this.jwtDecoder = jwtDecoder;
+        this.clock = new ClockImpl();
     }
 
     /**
@@ -47,6 +50,17 @@ public class CredentialsManager {
      */
     public CredentialsManager(@NonNull AuthenticationAPIClient authenticationClient, @NonNull Storage storage) {
         this(authenticationClient, storage, new JWTDecoder());
+    }
+
+    /**
+     * Updates the clock instance used for expiration verification purposes.
+     * The use of this method can help on situations where the clock comes from an external synced source.
+     * The default implementation uses the time returned by {@link System#currentTimeMillis()}.
+     *
+     * @param clock the new clock instance to use.
+     */
+    public void setClock(@NonNull Clock clock) {
+        this.clock = clock;
     }
 
     /**
@@ -164,7 +178,7 @@ public class CredentialsManager {
 
     @VisibleForTesting
     long getCurrentTimeInMillis() {
-        return System.currentTimeMillis();
+        return clock.getCurrentTimeMillis();
     }
 
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
@@ -21,6 +21,7 @@ import com.auth0.android.callback.BaseCallback;
 import com.auth0.android.jwt.JWT;
 import com.auth0.android.request.internal.GsonProvider;
 import com.auth0.android.result.Credentials;
+import com.auth0.android.util.Clock;
 import com.google.gson.Gson;
 
 import java.util.Date;
@@ -50,6 +51,7 @@ public class SecureCredentialsManager {
     private final CryptoUtil crypto;
     private final Gson gson;
     private final JWTDecoder jwtDecoder;
+    private Clock clock;
 
     //Changeable by the user
     private boolean authenticateBeforeDecrypt;
@@ -69,6 +71,7 @@ public class SecureCredentialsManager {
         this.gson = GsonProvider.buildGson();
         this.authenticateBeforeDecrypt = false;
         this.jwtDecoder = jwtDecoder;
+        this.clock = new ClockImpl();
     }
 
     /**
@@ -80,6 +83,17 @@ public class SecureCredentialsManager {
      */
     public SecureCredentialsManager(@NonNull Context context, @NonNull AuthenticationAPIClient apiClient, @NonNull Storage storage) {
         this(apiClient, storage, new CryptoUtil(context, storage, KEY_ALIAS), new JWTDecoder());
+    }
+
+    /**
+     * Updates the clock instance used for expiration verification purposes.
+     * The use of this method can help on situations where the clock comes from an external synced source.
+     * The default implementation uses the time returned by {@link System#currentTimeMillis()}.
+     *
+     * @param clock the new clock instance to use.
+     */
+    public void setClock(@NonNull Clock clock) {
+        this.clock = clock;
     }
 
     /**
@@ -293,7 +307,7 @@ public class SecureCredentialsManager {
 
     @VisibleForTesting
     long getCurrentTimeInMillis() {
-        return System.currentTimeMillis();
+        return clock.getCurrentTimeMillis();
     }
 
 }

--- a/auth0/src/main/java/com/auth0/android/util/Clock.java
+++ b/auth0/src/main/java/com/auth0/android/util/Clock.java
@@ -1,0 +1,16 @@
+package com.auth0.android.util;
+
+/**
+ * The clock used for verification purposes.
+ *
+ * @see com.auth0.android.authentication.storage.SecureCredentialsManager
+ * @see com.auth0.android.authentication.storage.CredentialsManager
+ */
+public interface Clock {
+    /**
+     * Returns the current time in milliseconds (epoch).
+     *
+     * @return the current time in milliseconds.
+     */
+    long getCurrentTimeMillis();
+}

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/ClockImplTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/ClockImplTest.java
@@ -1,0 +1,16 @@
+package com.auth0.android.authentication.storage;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+
+public class ClockImplTest {
+
+    @Test
+    public void shouldGetCurrentTime() {
+        double time = new ClockImpl().getCurrentTimeMillis();
+        assertThat(time, is(closeTo(System.currentTimeMillis(), 1)));
+    }
+}


### PR DESCRIPTION
### Changes

This change adds support for passing a custom implementation of the Clock used for verifying the expiration of the credentials stored in the any of the two credentials manager implementations.

### References
- Resolves https://github.com/auth0/Auth0.Android/issues/350
- Jira: SDK-1973

### Testing


- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
