### PR TITLE
CredentialsManager: Allow to pass scope and minTTL

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -132,7 +132,7 @@ public class CredentialsManager {
             return;
         }
         if (refreshToken == null) {
-            callback.onFailure(new CredentialsManagerException("Credentials have expired and no Refresh Token was available to renew them."));
+            callback.onFailure(new CredentialsManagerException("Credentials need to be renewed but no Refresh Token is available to renew them."));
             return;
         }
 
@@ -175,7 +175,7 @@ public class CredentialsManager {
         Arrays.sort(stored);
         String[] required = requiredScope.split(" ");
         Arrays.sort(required);
-        return stored != required;
+        return !Arrays.equals(stored, required);
     }
 
     private boolean willExpire(long expiresAt, long minTtl) {

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -9,9 +9,11 @@ import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.AuthenticationCallback;
 import com.auth0.android.callback.BaseCallback;
 import com.auth0.android.jwt.JWT;
+import com.auth0.android.request.ParameterizableRequest;
 import com.auth0.android.result.Credentials;
 import com.auth0.android.util.Clock;
 
+import java.util.Arrays;
 import java.util.Date;
 
 import static android.text.TextUtils.isEmpty;
@@ -73,16 +75,7 @@ public class CredentialsManager {
             throw new CredentialsManagerException("Credentials must have a valid date of expiration and a valid access_token or id_token value.");
         }
 
-        long expiresAt = credentials.getExpiresAt().getTime();
-
-        if (credentials.getIdToken() != null) {
-            JWT idToken = jwtDecoder.decode(credentials.getIdToken());
-            Date idTokenExpiresAtDate = idToken.getExpiresAt();
-
-            if (idTokenExpiresAtDate != null) {
-                expiresAt = Math.min(idTokenExpiresAtDate.getTime(), expiresAt);
-            }
-        }
+        long expiresAt = calculateExpiresAt(credentials);
 
         storage.store(KEY_ACCESS_TOKEN, credentials.getAccessToken());
         storage.store(KEY_REFRESH_TOKEN, credentials.getRefreshToken());
@@ -100,24 +93,42 @@ public class CredentialsManager {
      *
      * @param callback the callback that will receive a valid {@link Credentials} or the {@link CredentialsManagerException}.
      */
-    public void getCredentials(@NonNull final BaseCallback<Credentials, CredentialsManagerException> callback) {
+    public void getCredentials(@NonNull BaseCallback<Credentials, CredentialsManagerException> callback) {
+        getCredentials(null, 0, callback);
+    }
+
+    /**
+     * Retrieves the credentials from the storage and refresh them if they have already expired.
+     * It will fail with {@link CredentialsManagerException} if the saved access_token or id_token is null,
+     * or if the tokens have already expired and the refresh_token is null.
+     *
+     * @param scope    the scope to request for the access token. If null is passed, the previous scope will be kept.
+     * @param minTtl   the minimum time in seconds that both the access token and id token should last before expiration.
+     * @param callback the callback that will receive a valid {@link Credentials} or the {@link CredentialsManagerException}.
+     */
+    public void getCredentials(@Nullable String scope, final int minTtl, @NonNull final BaseCallback<Credentials, CredentialsManagerException> callback) {
         String accessToken = storage.retrieveString(KEY_ACCESS_TOKEN);
         final String refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN);
         String idToken = storage.retrieveString(KEY_ID_TOKEN);
         String tokenType = storage.retrieveString(KEY_TOKEN_TYPE);
         Long expiresAt = storage.retrieveLong(KEY_EXPIRES_AT);
-        String scope = storage.retrieveString(KEY_SCOPE);
+        String storedScope = storage.retrieveString(KEY_SCOPE);
         Long cacheExpiresAt = storage.retrieveLong(KEY_CACHE_EXPIRES_AT);
         if (cacheExpiresAt == null) {
             cacheExpiresAt = expiresAt;
         }
 
-        if (isEmpty(accessToken) && isEmpty(idToken) || expiresAt == null) {
+        boolean hasEmptyCredentials = isEmpty(accessToken) && isEmpty(idToken) || expiresAt == null;
+        if (hasEmptyCredentials) {
             callback.onFailure(new CredentialsManagerException("No Credentials were previously set."));
             return;
         }
-        if (cacheExpiresAt > getCurrentTimeInMillis()) {
-            callback.onSuccess(recreateCredentials(idToken, accessToken, tokenType, refreshToken, new Date(expiresAt), scope));
+
+        boolean willExpire = willExpire(cacheExpiresAt, minTtl);
+        boolean scopeChanged = hasScopeChanged(storedScope, scope);
+
+        if (!willExpire && !scopeChanged) {
+            callback.onSuccess(recreateCredentials(idToken, accessToken, tokenType, refreshToken, new Date(expiresAt), storedScope));
             return;
         }
         if (refreshToken == null) {
@@ -125,9 +136,22 @@ public class CredentialsManager {
             return;
         }
 
-        authClient.renewAuth(refreshToken).start(new AuthenticationCallback<Credentials>() {
+        final ParameterizableRequest<Credentials, AuthenticationException> request = authClient.renewAuth(refreshToken);
+        if (scope != null) {
+            request.addParameter("scope", scope);
+        }
+        request.start(new AuthenticationCallback<Credentials>() {
             @Override
             public void onSuccess(@Nullable Credentials fresh) {
+                long nextCacheExpiresAt = calculateExpiresAt(fresh);
+                boolean willExpire = willExpire(nextCacheExpiresAt, minTtl);
+                if (willExpire) {
+                    long tokenLifetime = (nextCacheExpiresAt - getCurrentTimeInMillis() - minTtl * 1000) / -1000;
+                    CredentialsManagerException wrongTtlException = new CredentialsManagerException(String.format("The lifetime of the renewed Access Token or Id Token (%d) is less than the minTTL requested (%d). Increase the 'Token Expiration' setting of your Auth0 API or the 'ID Token Expiration' of your Auth0 Application in the dashboard, or request a lower minTTL.", tokenLifetime, minTtl));
+                    callback.onFailure(wrongTtlException);
+                    return;
+                }
+
                 //non-empty refresh token for refresh token rotation scenarios
                 String updatedRefreshToken = isEmpty(fresh.getRefreshToken()) ? refreshToken : fresh.getRefreshToken();
                 Credentials credentials = new Credentials(fresh.getIdToken(), fresh.getAccessToken(), fresh.getType(), updatedRefreshToken, fresh.getExpiresAt(), fresh.getScope());
@@ -140,6 +164,37 @@ public class CredentialsManager {
                 callback.onFailure(new CredentialsManagerException("An error occurred while trying to use the Refresh Token to renew the Credentials.", error));
             }
         });
+
+    }
+
+    private boolean hasScopeChanged(@NonNull String storedScope, @Nullable String requiredScope) {
+        if (requiredScope == null) {
+            return false;
+        }
+        String[] stored = storedScope.split(" ");
+        Arrays.sort(stored);
+        String[] required = requiredScope.split(" ");
+        Arrays.sort(required);
+        return stored != required;
+    }
+
+    private boolean willExpire(long expiresAt, long minTtl) {
+        long nextClock = getCurrentTimeInMillis() + minTtl * 1000;
+        return expiresAt <= nextClock;
+    }
+
+    private long calculateExpiresAt(@NonNull Credentials credentials) {
+        long expiresAt = credentials.getExpiresAt().getTime();
+
+        if (credentials.getIdToken() != null) {
+            JWT idToken = jwtDecoder.decode(credentials.getIdToken());
+            Date idTokenExpiresAtDate = idToken.getExpiresAt();
+
+            if (idTokenExpiresAtDate != null) {
+                expiresAt = Math.min(idTokenExpiresAtDate.getTime(), expiresAt);
+            }
+        }
+        return expiresAt;
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.java
@@ -213,10 +213,14 @@ public class CredentialsManager {
         String refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN);
         String idToken = storage.retrieveString(KEY_ID_TOKEN);
         Long expiresAt = storage.retrieveLong(KEY_EXPIRES_AT);
+        Long cacheExpiresAt = storage.retrieveLong(KEY_CACHE_EXPIRES_AT);
+        if (cacheExpiresAt == null) {
+            cacheExpiresAt = expiresAt;
+        }
 
         return !(isEmpty(accessToken) && isEmpty(idToken) ||
-                expiresAt == null ||
-                expiresAt <= getCurrentTimeInMillis() && refreshToken == null);
+                cacheExpiresAt == null ||
+                hasExpired(cacheExpiresAt) && refreshToken == null);
     }
 
     /**

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
@@ -351,7 +351,7 @@ public class CredentialsManagerTest {
         when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
         when(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken");
         when(storage.retrieveString("com.auth0.token_type")).thenReturn("type");
-        long expirationTime = CredentialsMock.CURRENT_TIME_MS + 123456L * 1000; //non expired credentials
+        long expirationTime = CredentialsMock.CURRENT_TIME_MS + 123456L * 1000; // non expired credentials
         when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime);
         when(storage.retrieveLong("com.auth0.cache_expires_at")).thenReturn(expirationTime);
         when(storage.retrieveString("com.auth0.scope")).thenReturn("some new scope");
@@ -366,7 +366,7 @@ public class CredentialsManagerTest {
         verify(request).start(requestCallbackCaptor.capture());
         verify(request).addParameter(eq("scope"), eq("some scope"));
 
-        //Trigger success
+        // Trigger success
         String newRefresh = null;
         Credentials renewedCredentials = new Credentials("newId", "newAccess", "newType", newRefresh, newDate, "newScope");
         requestCallbackCaptor.getValue().onSuccess(renewedCredentials);
@@ -375,7 +375,7 @@ public class CredentialsManagerTest {
         // Verify the credentials are property stored
         verify(storage).store("com.auth0.id_token", renewedCredentials.getIdToken());
         verify(storage).store("com.auth0.access_token", renewedCredentials.getAccessToken());
-        //RefreshToken should not be replaced
+        // RefreshToken should not be replaced
         verify(storage, never()).store("com.auth0.refresh_token", newRefresh);
         verify(storage).store("com.auth0.refresh_token", "refreshToken");
         verify(storage).store("com.auth0.token_type", renewedCredentials.getType());
@@ -384,7 +384,7 @@ public class CredentialsManagerTest {
         verify(storage).store("com.auth0.cache_expires_at", renewedCredentials.getExpiresAt().getTime());
         verify(storage, never()).remove(anyString());
 
-        //// Verify the returned credentials are the latest
+        // Verify the returned credentials are the latest
         Credentials retrievedCredentials = credentialsCaptor.getValue();
         assertThat(retrievedCredentials, is(notNullValue()));
         assertThat(retrievedCredentials.getIdToken(), is("newId"));
@@ -401,22 +401,22 @@ public class CredentialsManagerTest {
         when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
         when(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken");
         when(storage.retrieveString("com.auth0.token_type")).thenReturn("type");
-        long expirationTime = CredentialsMock.CURRENT_TIME_MS; //Same as current time --> expired
+        long expirationTime = CredentialsMock.CURRENT_TIME_MS; // Same as current time --> expired
         when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime);
         when(storage.retrieveLong("com.auth0.cache_expires_at")).thenReturn(expirationTime);
         when(storage.retrieveString("com.auth0.scope")).thenReturn("scope");
         when(client.renewAuth("refreshToken")).thenReturn(request);
 
-        Date newDate = new Date(CredentialsMock.CURRENT_TIME_MS + 61 * 1000); //new token expires in minTTL + 1 seconds
+        Date newDate = new Date(CredentialsMock.CURRENT_TIME_MS + 61 * 1000); // New token expires in minTTL + 1 second
         JWT jwtMock = mock(JWT.class);
         when(jwtMock.getExpiresAt()).thenReturn(newDate);
         when(jwtDecoder.decode("newId")).thenReturn(jwtMock);
 
-        manager.getCredentials(null, 60, callback); //60 seconds of minTTL
+        manager.getCredentials(null, 60, callback); // 60 seconds of minTTL
         verify(request, never()).addParameter(eq("scope"), anyString());
         verify(request).start(requestCallbackCaptor.capture());
 
-        //Trigger success
+        // Trigger success
         String newRefresh = null;
         Credentials renewedCredentials = new Credentials("newId", "newAccess", "newType", newRefresh, newDate, "newScope");
         requestCallbackCaptor.getValue().onSuccess(renewedCredentials);
@@ -425,7 +425,7 @@ public class CredentialsManagerTest {
         // Verify the credentials are property stored
         verify(storage).store("com.auth0.id_token", renewedCredentials.getIdToken());
         verify(storage).store("com.auth0.access_token", renewedCredentials.getAccessToken());
-        //RefreshToken should not be replaced
+        // RefreshToken should not be replaced
         verify(storage, never()).store("com.auth0.refresh_token", newRefresh);
         verify(storage).store("com.auth0.refresh_token", "refreshToken");
         verify(storage).store("com.auth0.token_type", renewedCredentials.getType());
@@ -434,7 +434,7 @@ public class CredentialsManagerTest {
         verify(storage).store("com.auth0.cache_expires_at", renewedCredentials.getExpiresAt().getTime());
         verify(storage, never()).remove(anyString());
 
-        //// Verify the returned credentials are the latest
+        // Verify the returned credentials are the latest
         Credentials retrievedCredentials = credentialsCaptor.getValue();
         assertThat(retrievedCredentials, is(notNullValue()));
         assertThat(retrievedCredentials.getIdToken(), is("newId"));
@@ -501,22 +501,22 @@ public class CredentialsManagerTest {
         when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
         when(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken");
         when(storage.retrieveString("com.auth0.token_type")).thenReturn("type");
-        long expirationTime = CredentialsMock.CURRENT_TIME_MS; //Same as current time --> expired
+        long expirationTime = CredentialsMock.CURRENT_TIME_MS; // Same as current time --> expired
         when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime);
         when(storage.retrieveLong("com.auth0.cache_expires_at")).thenReturn(expirationTime);
         when(storage.retrieveString("com.auth0.scope")).thenReturn("scope");
         when(client.renewAuth("refreshToken")).thenReturn(request);
 
-        Date newDate = new Date(CredentialsMock.CURRENT_TIME_MS + 59 * 1000); //new token expires in minTTL - 1 seconds
+        Date newDate = new Date(CredentialsMock.CURRENT_TIME_MS + 59 * 1000); // New token expires in minTTL - 1 second
         JWT jwtMock = mock(JWT.class);
         when(jwtMock.getExpiresAt()).thenReturn(newDate);
         when(jwtDecoder.decode("newId")).thenReturn(jwtMock);
 
-        manager.getCredentials(null, 60, callback); //60 seconds of minTTL
+        manager.getCredentials(null, 60, callback); // 60 seconds of minTTL
         verify(request, never()).addParameter(eq("scope"), anyString());
         verify(request).start(requestCallbackCaptor.capture());
 
-        //Trigger success
+        // Trigger failure
         String newRefresh = null;
         Credentials renewedCredentials = new Credentials("newId", "newAccess", "newType", newRefresh, newDate, "newScope");
         requestCallbackCaptor.getValue().onSuccess(renewedCredentials);

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
@@ -688,10 +689,12 @@ public class CredentialsManagerTest {
         when(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken");
         when(storage.retrieveString("com.auth0.access_token")).thenReturn(null);
         assertThat(manager.hasValidCredentials(), is(true));
+        assertThat(manager.hasValidCredentials(ONE_HOUR_SECONDS - 1), is(true));
 
         when(storage.retrieveString("com.auth0.id_token")).thenReturn(null);
         when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
         assertThat(manager.hasValidCredentials(), is(true));
+        assertThat(manager.hasValidCredentials(ONE_HOUR_SECONDS - 1), is(true));
     }
 
     @Test
@@ -708,6 +711,19 @@ public class CredentialsManagerTest {
         when(storage.retrieveString("com.auth0.id_token")).thenReturn(null);
         when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
         assertFalse(manager.hasValidCredentials());
+    }
+
+    @Test
+    public void shouldNotHaveCredentialsWhenAccessTokenWillExpireAndNoRefreshTokenIsAvailable() {
+        long expirationTime = CredentialsMock.ONE_HOUR_AHEAD_MS;
+        when(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime);
+        when(storage.retrieveLong("com.auth0.cache_expires_at")).thenReturn(expirationTime);
+        when(storage.retrieveString("com.auth0.refresh_token")).thenReturn(null);
+
+        when(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken");
+        when(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken");
+
+        assertFalse(manager.hasValidCredentials(ONE_HOUR_SECONDS));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
@@ -584,7 +584,7 @@ public class CredentialsManagerTest {
         CredentialsManagerException exception = exceptionCaptor.getValue();
         assertThat(exception, is(notNullValue()));
         assertThat(exception.getCause(), is(nullValue()));
-        assertThat(exception.getMessage(), is("The lifetime of the renewed Access Token or Id Token (1) is less than the minTTL requested (60). Increase the 'Token Expiration' setting of your Auth0 API or the 'ID Token Expiration' of your Auth0 Application in the dashboard, or request a lower minTTL."));
+        assertThat(exception.getMessage(), is("The lifetime of the renewed Access Token (1) is less than the minTTL requested (60). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard, or request a lower minTTL."));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsMock.java
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsMock.java
@@ -10,6 +10,7 @@ import java.util.TimeZone;
 public class CredentialsMock extends Credentials {
 
     public static final long CURRENT_TIME_MS = calculateCurrentTime();
+    public static final long ONE_HOUR_AHEAD_MS = CURRENT_TIME_MS + 60 * 60 * 1000;
 
     public CredentialsMock(@Nullable String idToken, @Nullable String accessToken, @Nullable String type, @Nullable String refreshToken, @Nullable Long expiresIn) {
         super(idToken, accessToken, type, refreshToken, expiresIn);


### PR DESCRIPTION
### Changes

This PR improves the feature parity with iOS' CredentialManager class. Now developers can specify a reduced scope for when the tokens expire and need to be refreshed. And also a minimum time to live that the received tokens must have. 

In order to add support for this, a new method was introduced. The old functionality remains the same.

A following PR will add the same support for the `SecureCredentialsManager`.

### References

Relates to https://github.com/auth0/Auth0.Android/issues/349

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
