### PR TITLE
SecureCredentialsManager: Allow to pass scope and minTTL

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.java
@@ -1,0 +1,126 @@
+package com.auth0.android.authentication.storage;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+
+import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.callback.BaseCallback;
+import com.auth0.android.jwt.JWT;
+import com.auth0.android.result.Credentials;
+import com.auth0.android.util.Clock;
+
+import java.util.Arrays;
+import java.util.Date;
+
+/**
+ * Base class meant to abstract common logic across Credentials Manager implementations.
+ * The scope of this class is package-private, as it's not meant to expose
+ */
+abstract class BaseCredentialsManager {
+
+    protected final AuthenticationAPIClient authenticationClient;
+    protected final Storage storage;
+    protected final JWTDecoder jwtDecoder;
+    protected Clock clock;
+
+    BaseCredentialsManager(@NonNull AuthenticationAPIClient authenticationClient, @NonNull Storage storage, @NonNull JWTDecoder jwtDecoder) {
+        this.authenticationClient = authenticationClient;
+        this.storage = storage;
+        this.jwtDecoder = jwtDecoder;
+        this.clock = new ClockImpl();
+    }
+
+    public abstract void saveCredentials(@NonNull Credentials credentials) throws CredentialsManagerException;
+
+    public abstract void getCredentials(@NonNull BaseCallback<Credentials, CredentialsManagerException> callback);
+
+    public abstract void getCredentials(@Nullable String scope, int minTtl, @NonNull BaseCallback<Credentials, CredentialsManagerException> callback);
+
+    public abstract void clearCredentials();
+
+    public abstract boolean hasValidCredentials();
+
+    public abstract boolean hasValidCredentials(long minTtl);
+
+    /**
+     * Updates the clock instance used for expiration verification purposes.
+     * The use of this method can help on situations where the clock comes from an external synced source.
+     * The default implementation uses the time returned by {@link System#currentTimeMillis()}.
+     *
+     * @param clock the new clock instance to use.
+     */
+    public void setClock(@NonNull Clock clock) {
+        this.clock = clock;
+    }
+
+    @VisibleForTesting
+    long getCurrentTimeInMillis() {
+        return clock.getCurrentTimeMillis();
+    }
+
+    /**
+     * Checks if the stored scope is the same as the requested one.
+     *
+     * @param storedScope   the stored scope, separated by space characters.
+     * @param requiredScope the required scope, separated by space characters.
+     * @return whether the scope are different or not
+     */
+    protected boolean hasScopeChanged(@NonNull String storedScope, @Nullable String requiredScope) {
+        if (requiredScope == null) {
+            return false;
+        }
+        String[] stored = storedScope.split(" ");
+        Arrays.sort(stored);
+        String[] required = requiredScope.split(" ");
+        Arrays.sort(required);
+        return !Arrays.equals(stored, required);
+    }
+
+    /**
+     * Checks if given the required minimum time to live, the expiration time can satisfy that value or not.
+     *
+     * @param expiresAt the expiration time, in milliseconds.
+     * @param minTtl    the time to live required, in seconds.
+     * @return whether the value will become expired within the given min TTL or not.
+     */
+    protected boolean willExpire(long expiresAt, long minTtl) {
+        if (expiresAt <= 0) {
+            // Avoids logging out users when this value was not saved (migration scenario)
+            return false;
+        }
+        long nextClock = getCurrentTimeInMillis() + minTtl * 1000;
+        return expiresAt <= nextClock;
+    }
+
+    /**
+     * Checks whether the given expiration time has been reached or not.
+     *
+     * @param expiresAt the expiration time, in milliseconds.
+     * @return whether the given expiration time has been reached or not.
+     */
+    protected boolean hasExpired(long expiresAt) {
+        return expiresAt <= getCurrentTimeInMillis();
+    }
+
+    /**
+     * Takes a credentials object and returns the lowest expiration time, considering
+     * both the access token and the ID token expiration time.
+     *
+     * @param credentials the credentials object to check.
+     * @return the lowest expiration time between the access token and the ID token.
+     */
+    protected long calculateCacheExpiresAt(@NonNull Credentials credentials) {
+        long expiresAt = credentials.getExpiresAt().getTime();
+
+        if (credentials.getIdToken() != null) {
+            JWT idToken = jwtDecoder.decode(credentials.getIdToken());
+            Date idTokenExpiresAtDate = idToken.getExpiresAt();
+
+            if (idTokenExpiresAtDate != null) {
+                expiresAt = Math.min(idTokenExpiresAtDate.getTime(), expiresAt);
+            }
+        }
+        return expiresAt;
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.java
@@ -15,7 +15,7 @@ import java.util.Date;
 
 /**
  * Base class meant to abstract common logic across Credentials Manager implementations.
- * The scope of this class is package-private, as it's not meant to expose
+ * The scope of this class is package-private, as it's not meant to be exposed
  */
 abstract class BaseCredentialsManager {
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.java
@@ -220,7 +220,7 @@ public class SecureCredentialsManager {
      * @param callback the callback to receive the result in.
      */
     public void getCredentials(@Nullable String scope, int minTtl, @NonNull BaseCallback<Credentials, CredentialsManagerException> callback) {
-        if (!hasValidCredentials()) {
+        if (!hasValidCredentials(minTtl)) {
             callback.onFailure(new CredentialsManagerException("No Credentials were previously set."));
             return;
         }
@@ -369,11 +369,11 @@ public class SecureCredentialsManager {
         Arrays.sort(stored);
         String[] required = requiredScope.split(" ");
         Arrays.sort(required);
-        return stored != required;
+        return !Arrays.equals(stored, required);
     }
 
-    private boolean willExpire(Long expiresAt, long minTtl) {
-        if (minTtl == 0 && (expiresAt == null || expiresAt == 0)) {
+    private boolean willExpire(@Nullable Long expiresAt, long minTtl) {
+        if (expiresAt == null || expiresAt <= 0) {
             //expiresAt (access token) only considered if it has a positive value, to avoid logging out users
             return false;
         }
@@ -385,7 +385,7 @@ public class SecureCredentialsManager {
         return expiresAt <= getCurrentTimeInMillis();
     }
 
-    private long calculateCacheExpiresAt(Credentials credentials) {
+    private long calculateCacheExpiresAt(@NonNull Credentials credentials) {
         long expiresAt = credentials.getExpiresAt().getTime();
 
         if (credentials.getIdToken() != null) {


### PR DESCRIPTION
### Changes

This PR improves the feature parity with iOS' CredentialManager class. Now developers can specify a reduced scope for when the tokens expire and need to be refreshed. And also a minimum time to live that the received tokens must have. 

In order to add support for this, a new method was introduced. The old functionality remains the same.

#### Non breaking update
A test was included to check that current users of the SecureCredentialsManager are not "logged out" if the access token's expires_at value was not previously stored. The test is named `shouldHaveValidCredentialsDuringMigrationWhenAccessTokenExpiresAtValueWasNotSaved`

### References

Relates to https://github.com/auth0/Auth0.Android/issues/349

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
