### PR TITLE
Refactor: Move passwordless "invalid credentials" errors

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -201,9 +201,7 @@ public class AuthenticationException extends Auth0Exception {
     /// When MFA code sent is invalid or expired
     public boolean isMultifactorCodeInvalid() {
         return "a0.mfa_invalid_code".equals(code) 
-            || "invalid_grant".equals(code) && "Invalid otp_code.".equals(description)
-            || "invalid_grant".equals(code) && "Wrong phone number or verification code.".equals(description)
-            || "invalid_grant".equals(code) && "Wrong email or verification code.".equals(description);
+            || "invalid_grant".equals(code) && "Invalid otp_code.".equals(description);
     }
 
     /// When password used for SignUp does not match connection's strength requirements.
@@ -228,7 +226,10 @@ public class AuthenticationException extends Auth0Exception {
 
     /// When username and/or password used for authentication are invalid
     public boolean isInvalidCredentials() {
-        return "invalid_user_password".equals(code) || "invalid_grant".equals(code) && "Wrong email or password.".equals(description);
+        return "invalid_user_password".equals(code)
+                || "invalid_grant".equals(code) && "Wrong email or password.".equals(description)
+                || "invalid_grant".equals(code) && "Wrong phone number or verification code.".equals(description)
+                || "invalid_grant".equals(code) && "Wrong email or verification code.".equals(description);
     }
 
     /// When authenticating with web-based authentication and the resource server denied access per OAuth2 spec

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
@@ -215,22 +215,6 @@ public class AuthenticationExceptionTest {
     }
 
     @Test
-    public void shouldHaveInvalidMultifactorCodePhoneOTP() {
-        values.put(ERROR_KEY, "invalid_grant");
-        values.put(ERROR_DESCRIPTION_KEY, "Wrong phone number or verification code.");
-        AuthenticationException ex = new AuthenticationException(values);
-        assertThat(ex.isMultifactorCodeInvalid(), is(true));
-    }
-
-    @Test
-    public void shouldHaveInvalidMultifactorCodeEmailOTP() {
-        values.put(ERROR_KEY, "invalid_grant");
-        values.put(ERROR_DESCRIPTION_KEY, "Wrong email or verification code.");
-        AuthenticationException ex = new AuthenticationException(values);
-        assertThat(ex.isMultifactorCodeInvalid(), is(true));
-    }
-
-    @Test
     public void shouldHaveInvalidMultifactorCode() {
         values.put(CODE_KEY, "a0.mfa_invalid_code");
         AuthenticationException ex = new AuthenticationException(values);
@@ -286,6 +270,22 @@ public class AuthenticationExceptionTest {
     public void shouldHaveOIDCInvalidCredentials() {
         values.put(CODE_KEY, "invalid_grant");
         values.put(ERROR_DESCRIPTION_KEY, "Wrong email or password.");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isInvalidCredentials(), is(true));
+    }
+
+    @Test
+    public void shouldHaveInvalidCredentialsOnPhonePasswordless() {
+        values.put(ERROR_KEY, "invalid_grant");
+        values.put(ERROR_DESCRIPTION_KEY, "Wrong phone number or verification code.");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isInvalidCredentials(), is(true));
+    }
+
+    @Test
+    public void shouldHaveInvalidCredentialsOnEmailPasswordless() {
+        values.put(ERROR_KEY, "invalid_grant");
+        values.put(ERROR_DESCRIPTION_KEY, "Wrong email or verification code.");
         AuthenticationException ex = new AuthenticationException(values);
         assertThat(ex.isInvalidCredentials(), is(true));
     }


### PR DESCRIPTION
### Changes

On the [last patch](https://github.com/auth0/Auth0.Android/releases/tag/1.29.1) we released support for catching additional Passwordless error messages that were missing from this SDK. However, we realized that the method in which those were added was not quite right, as it corresponded to MFA flows. This PR changes that and moves the new error handling into a proper method for invalid credentials.

#### TLDR
If you were using version `1.29.1` to catch Passwordless invalid code errors, you will need to update your code:
```diff
-boolean invalidInput = err.isMultifactorCodeInvalid()
+boolean invalidInput = err.isInvalidCredentials()
```


### References

This rollbacks the changes introduced in #371, but keeps them in a separate method.
- https://github.com/auth0/Auth0.Android/releases/tag/1.29.1

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
