### PR TITLE
Add credentials manager thread-safe note [SDK-2078]

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ The basic version supports asking for `Credentials` existence, storing them and 
 
 #### Usage
 1. **Instantiate the manager:**
-You'll need an `AuthenticationAPIClient` instance to renew the credentials when they expire and a `Storage` object. We provide a `SharedPreferencesStorage` class that makes use of `SharedPreferences` to create a file in the application's directory with **Context.MODE_PRIVATE** mode. This implementation is thread safe and can either be obtained through a shared method or on demand.
+You'll need an `AuthenticationAPIClient` instance to renew the credentials when they expire and a `Storage` object. We provide a `SharedPreferencesStorage` class that makes use of `SharedPreferences` to create a file in the application's directory with **Context.MODE_PRIVATE** mode.
 
 ```java
 AuthenticationAPIClient authentication = new AuthenticationAPIClient(account);
@@ -730,6 +730,8 @@ boolean authenticated = manager.hasValidCredentials();
 
 4. **Retrieve credentials:**
 Existing credentials will be returned if they are still valid, otherwise the `refresh_token` will be used to attempt to renew them. If the `expires_in` or both the `access_token` and `id_token` values are missing, the method will throw a `CredentialsManagerException`. The same will happen if the credentials have expired and there's no `refresh_token` available.
+
+> This method is not thread-safe, so if you're using _Refresh Token Rotation_ you should avoid calling this method concurrently (might result in more than one renew request being fired, and only the first one will succeed).
 
 ```java
 manager.getCredentials(new BaseCallback<Credentials, CredentialsManagerException>() {


### PR DESCRIPTION
### Changes

This also removes a previous note that mentioned the basic `CredentialManager` being thread-safe. While most of that class is, the network request runs asynchronously and multiple calls to `getCredentials` can still trigger an error scenario when used in combination with Refresh Token Rotation.

### References

SDK-2078

