### PR TITLE
Prefer robolectric.properties instead of @Config

### DIFF
--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -27,8 +27,6 @@ package com.auth0.android;
 import android.content.Context;
 import android.content.res.Resources;
 
-import androidx.test.core.app.ApplicationProvider;
-
 import com.auth0.android.util.Telemetry;
 import com.squareup.okhttp.HttpUrl;
 
@@ -41,8 +39,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static com.auth0.android.util.HttpUrlMatcher.hasHost;
 import static com.auth0.android.util.HttpUrlMatcher.hasPath;
@@ -52,9 +48,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -51,7 +51,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.lang.reflect.Type;
 import java.security.PublicKey;
@@ -75,7 +74,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -83,7 +81,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class AuthenticationAPIClientTest {
 
     private static final String CLIENT_ID = "CLIENTID";

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -29,7 +28,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class AuthenticationExceptionTest {
 
     @Rule

--- a/auth0/src/test/java/com/auth0/android/authentication/request/DatabaseConnectionRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/DatabaseConnectionRequestTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Map;
 
@@ -18,7 +17,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class DatabaseConnectionRequestTest {
 
     private ParameterizableRequest mockRequest;

--- a/auth0/src/test/java/com/auth0/android/authentication/request/DelegationRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/DelegationRequestTest.java
@@ -8,7 +8,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Map;
 
@@ -20,7 +19,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class DelegationRequestTest {
 
     private ParameterizableRequest mockRequest;

--- a/auth0/src/test/java/com/auth0/android/authentication/request/ProfileRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/ProfileRequestTest.java
@@ -16,7 +16,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Map;
 
@@ -35,7 +34,6 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class ProfileRequestTest {
 
     private AuthRequest authenticationMockRequest;

--- a/auth0/src/test/java/com/auth0/android/authentication/request/SignUpRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/SignUpRequestTest.java
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Map;
 
@@ -30,7 +29,6 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class SignUpRequestTest {
 
     private DatabaseConnectionRequest dbMockRequest;

--- a/auth0/src/test/java/com/auth0/android/authentication/request/TokenRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/TokenRequestTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Map;
 
@@ -19,7 +18,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class TokenRequestTest {
 
     private ParameterizableRequest mockRequest;

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.java
@@ -25,7 +25,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Date;
 
@@ -51,7 +50,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class CredentialsManagerTest {
 
     private static final long ONE_HOUR_SECONDS = 60 * 60;

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CryptoUtilTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CryptoUtilTest.java
@@ -11,20 +11,16 @@ import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
 
-import androidx.annotation.RequiresApi;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.robolectric.RuntimeEnvironment;
@@ -74,15 +70,8 @@ import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
-/**
- * Created by lbalmaceda on 8/24/17.
- */
-@RequiresApi(api = Build.VERSION_CODES.KITKAT)
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({CryptoUtil.class, KeyGenerator.class, TextUtils.class, Build.VERSION.class, Base64.class, Cipher.class, Log.class})
-//@PowerMockIgnore({ "javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*",
-//        "org.xml.*", "org.w3c.dom.*", "com.sun.org.apache.xalan.*", "javax.activation.*" })
-@Config(sdk = 22)
 public class CryptoUtilTest {
 
     private static final String RSA_TRANSFORMATION = "RSA/ECB/PKCS1Padding";
@@ -142,7 +131,6 @@ public class CryptoUtilTest {
         new CryptoUtil(RuntimeEnvironment.application, storage, " ");
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
     @Test
     @Config(sdk = 19)
     public void shouldNotCreateProtectedRSAKeyPairIfMissingAndLockScreenEnabledOnAPI19() throws Exception {
@@ -193,7 +181,6 @@ public class CryptoUtilTest {
         assertThat(entry, is(expectedEntry));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     @Test
     @Config(sdk = 21)
     public void shouldCreateUnprotectedRSAKeyPairIfMissingAndLockScreenDisabledOnAPI21() throws Exception {
@@ -245,7 +232,6 @@ public class CryptoUtilTest {
         assertThat(entry, is(expectedEntry));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     @Test
     @Config(sdk = 21)
     public void shouldCreateProtectedRSAKeyPairIfMissingAndLockScreenEnabledOnAPI21() throws Exception {
@@ -297,7 +283,6 @@ public class CryptoUtilTest {
         assertThat(entry, is(expectedEntry));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.M)
     @Test
     @Config(sdk = 23)
     public void shouldCreateRSAKeyPairIfMissingOnAPI23AndUp() throws Exception {
@@ -345,7 +330,6 @@ public class CryptoUtilTest {
         assertThat(entry, is(expectedEntry));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.P)
     @Test
     @Config(sdk = 28)
     public void shouldCreateRSAKeyPairIfMissingOnAPI28AndUp() throws Exception {
@@ -392,7 +376,6 @@ public class CryptoUtilTest {
         assertThat(entry, is(expectedEntry));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.P)
     @Test
     @Config(sdk = 28)
     public void shouldCreateNewRSAKeyPairWhenExistingRSAKeyPairCannotBeRebuiltOnAPI28AndUp() throws Exception {
@@ -448,7 +431,6 @@ public class CryptoUtilTest {
         assertThat(entry, is(expectedEntry));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.P)
     @Test
     @Config(sdk = 28)
     public void shouldUseExistingRSAKeyPairRebuildingTheEntryOnAPI28AndUp() throws Exception {
@@ -475,7 +457,6 @@ public class CryptoUtilTest {
         assertThat(capturedCertificatesArray.length, is(1));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.P)
     @Test
     @Config(sdk = 28)
     public void shouldUseExistingRSAKeyPairOnAPI28AndUp() throws Exception {
@@ -491,7 +472,6 @@ public class CryptoUtilTest {
         assertThat(rsaEntry, is(entry));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O_MR1)
     @Test
     @Config(sdk = 27)
     public void shouldUseExistingRSAKeyPairOnAPI27AndDown() throws Exception {
@@ -548,7 +528,6 @@ public class CryptoUtilTest {
     }
 
     @Test
-    @Config(sdk = 22)
     public void shouldThrowOnCertificateExceptionWhenTryingToObtainRSAKeys() throws Exception {
         exception.expect(IncompatibleDeviceException.class);
         exception.expectMessage("The device is not compatible with the CryptoUtil class");
@@ -1311,7 +1290,6 @@ public class CryptoUtilTest {
         return builder;
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.M)
     private KeyGenParameterSpec.Builder newKeyGenParameterSpecBuilder(KeyGenParameterSpec expectedBuilderOutput) {
         KeyGenParameterSpec.Builder builder = PowerMockito.mock(KeyGenParameterSpec.Builder.class);
         PowerMockito.when(builder.setKeySize(anyInt())).thenReturn(builder);

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.java
@@ -5,9 +5,9 @@ import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import android.util.Base64;
+
+import androidx.annotation.Nullable;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationAPIClient;
@@ -58,9 +58,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class SecureCredentialsManagerTest {
 
     private static final long ONE_HOUR_SECONDS = 60 * 60;
@@ -892,7 +890,6 @@ public class SecureCredentialsManagerTest {
         manager.requireAuthentication(activity, 256, null, null);
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     @Test
     @Config(sdk = 21)
     public void shouldNotRequireAuthenticationIfAPI21AndLockScreenDisabled() {
@@ -910,7 +907,6 @@ public class SecureCredentialsManagerTest {
         assertThat(willAskAuthentication, is(false));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.M)
     @Test
     @Config(sdk = 23)
     public void shouldNotRequireAuthenticationIfAPI23AndLockScreenDisabled() {
@@ -928,7 +924,6 @@ public class SecureCredentialsManagerTest {
         assertThat(willAskAuthentication, is(false));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     @Test
     @Config(sdk = 21)
     public void shouldRequireAuthenticationIfAPI21AndLockScreenEnabled() {
@@ -946,7 +941,6 @@ public class SecureCredentialsManagerTest {
         assertThat(willAskAuthentication, is(true));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.M)
     @Test
     @Config(sdk = 23)
     public void shouldRequireAuthenticationIfAPI23AndLockScreenEnabled() {

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
@@ -12,7 +12,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -28,7 +27,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 @SuppressLint("CommitPrefEdits")
 public class SharedPreferencesStorageTest {
 

--- a/auth0/src/test/java/com/auth0/android/provider/AsymmetricSignatureVerifierTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AsymmetricSignatureVerifierTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.security.PublicKey;
 
@@ -16,7 +15,6 @@ import static com.auth0.android.provider.JwtTestUtils.createTestJWT;
 import static com.auth0.android.provider.JwtTestUtils.getPublicKey;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class AsymmetricSignatureVerifierTest {
 
     @Rule

--- a/auth0/src/test/java/com/auth0/android/provider/AuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthProviderTest.java
@@ -27,10 +27,11 @@ package com.auth0.android.provider;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Intent;
+import android.widget.TextView;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.PermissionChecker;
-import android.widget.TextView;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -41,7 +42,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -60,7 +60,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class AuthProviderTest {
 
     @Mock

--- a/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.java
@@ -16,7 +16,6 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
-import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
 
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
@@ -35,7 +34,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
 public class AuthenticationActivityTest {
 
     @Mock

--- a/auth0/src/test/java/com/auth0/android/provider/AuthorizeResultTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthorizeResultTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -42,7 +41,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class AuthorizeResultTest {
 
     private static final int REQUEST_CODE = 11;

--- a/auth0/src/test/java/com/auth0/android/provider/BrowserPickerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/BrowserPickerTest.java
@@ -18,7 +18,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.hamcrest.MockitoHamcrest;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,7 +37,6 @@ import static org.mockito.Mockito.when;
 import static org.robolectric.Robolectric.setupActivity;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
 public class BrowserPickerTest {
     private static final String CHROME_STABLE = "com.android.chrome";
     private static final String CHROME_SYSTEM = "com.google.android.apps.chrome";

--- a/auth0/src/test/java/com/auth0/android/provider/CallbackHelperTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CallbackHelperTest.java
@@ -30,7 +30,6 @@ import org.hamcrest.collection.IsMapWithSize;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,6 @@ import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static org.hamcrest.core.IsNull.nullValue;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class CallbackHelperTest {
 
     private static final String PACKAGE_NAME = "com.auth0.lock.android.app";

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.graphics.Color;
 import android.net.Uri;
+
 import androidx.browser.customtabs.CustomTabsCallback;
 import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
@@ -25,7 +26,6 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.List;
 
@@ -48,7 +48,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class CustomTabsControllerTest {
 
     private static final String DEFAULT_BROWSER_PACKAGE = "com.auth0.browser";

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Parcel;
+
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.core.content.ContextCompat;
 
@@ -12,7 +13,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class CustomTabsOptionsTest {
 
     private Activity context;

--- a/auth0/src/test/java/com/auth0/android/provider/IdTokenVerifierTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/IdTokenVerifierTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.security.PublicKey;
 import java.util.Date;
@@ -25,7 +24,6 @@ import static com.auth0.android.provider.JwtTestUtils.getPublicKey;
 import static org.mockito.Mockito.mock;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
 public class IdTokenVerifierTest {
 
 

--- a/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
@@ -10,7 +10,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -22,7 +21,6 @@ import static org.mockito.Mockito.when;
 
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
 public class LogoutManagerTest {
 
     @Mock

--- a/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
@@ -12,7 +12,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -24,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
 public class OAuthManagerTest {
 
     @Mock

--- a/auth0/src/test/java/com/auth0/android/provider/PKCETest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/PKCETest.java
@@ -40,10 +40,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-
-import java.io.UnsupportedEncodingException;
-import java.security.NoSuchAlgorithmException;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -60,7 +56,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
 public class PKCETest {
 
     private static final String CODE_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";

--- a/auth0/src/test/java/com/auth0/android/provider/PermissionHandlerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/PermissionHandlerTest.java
@@ -9,7 +9,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.List;
 
@@ -30,7 +29,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 23)
 public class PermissionHandlerTest {
 
     private PermissionHandler handler;

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -8,6 +8,7 @@ import android.content.ServiceConnection;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
 
 import com.auth0.android.Auth0;
@@ -31,7 +32,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -76,7 +76,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
 public class WebAuthProviderTest {
 
     private static final int REQUEST_CODE = 11;

--- a/auth0/src/test/java/com/auth0/android/request/internal/AuthenticationErrorBuilderTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/AuthenticationErrorBuilderTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,7 +19,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class AuthenticationErrorBuilderTest {
 
     private AuthenticationErrorBuilder builder;

--- a/auth0/src/test/java/com/auth0/android/request/internal/BaseAuthenticationRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/BaseAuthenticationRequestTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -27,7 +26,6 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class BaseAuthenticationRequestTest {
 
     public static final String OAUTH_PATH = "oauth";

--- a/auth0/src/test/java/com/auth0/android/request/internal/JwksGsonTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/JwksGsonTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -26,7 +25,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class JwksGsonTest extends GsonBaseTest {
     private static final String VALID_RSA_JWKS = "src/test/resources/rsa_jwks.json";
     private static final String EXPECTED_KEY_ID = "key123";

--- a/auth0/src/test/java/com/auth0/android/request/internal/OkHttpClientFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/OkHttpClientFactoryTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 21)
 public class OkHttpClientFactoryTest {
 
     private OkHttpClientFactory factory;
@@ -124,7 +123,7 @@ public class OkHttpClientFactoryTest {
 
     @Test
     @Config(sdk = 22)
-    public void shouldEnableLoggingTLS12NotEnforced_posLollipop() {
+    public void shouldEnableLoggingTLS12NotEnforced_postLollipop() {
         List list = generateInterceptorsMockList(mockClient);
         OkHttpClient client = factory.modifyClient(mockClient, true, false, 0, 0, 0);
         verifyLoggingEnabled(client, list);


### PR DESCRIPTION
Removes usage of `@Config` to set up the SDK version that Robolectric will use on a given test, in favor of [the recommended approach](http://robolectric.org/configuring/) of using the `robolectric.properties`. 

There are a few tests that kept it, as they check specifically code for one particular version.