### PR TITLE
Always use Authorization Code + PKCE 

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,17 +225,6 @@ WebAuthProvider.login(account)
     .start(MainActivity.this, authCallback);
 ```
 
-#### Use Code grant with PKCE
-
-> To use the `Code Grant` in Android, go to your [Application](https://manage.auth0.com/#/applications) in the dashboard, Settings tab, set `Application Type` to `Native` and `Token Endpoint Authentication Method` to `None`.
-
-
-```java
-WebAuthProvider.login(account)
-    .useCodeGrant(true)
-    .start(MainActivity.this, authCallback);
-```
-
 #### Specify audience
 
 The snippet below requests the "userinfo" audience in order to guarantee OIDC compliant responses from the server. This can also be achieved by flipping the "OIDC Conformant" switch on in the OAuth Advanced Settings of your application. For more information check [this documentation](https://auth0.com/docs/api-auth/intro#how-to-use-the-new-flows).

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -14,6 +14,10 @@ Previously, it was recommended to use OIDC-Conformant mode, by calling `setOIDCC
 
 You can learn more about the OpenID Connect Protocol [here](https://auth0.com/docs/protocols/openid-connect-protocol).
 
+## Authorization Code with PKCE
+
+Version 2 only supports the [Authorization Code with Proof Key for Code Exchange (PKCE)](https://auth0.com/docs/flows/authorization-code-flow-with-proof-key-for-code-exchange-pkce) flow. Accordingly, the `withResponseType(@ResponseType int type)` method on `WebAuthProvider.Builder` has been removed.
+
 ## Removal of WebView support
 
 The deprecated ability to sign using a WebView component has been removed. External browser applications will always be used instead for increased security and user trust. Please refer to [This blog post](https://auth0.com/blog/google-blocks-oauth-requests-from-embedded-browsers/) for additional information.
@@ -149,7 +153,8 @@ The ability to make requests to the [/delegation](https://auth0.com/docs/api/aut
 - `public Builder useCodeGrant(boolean useCodeGrant)`. There is no replacement; only Code + PKCE flow supported in v2.
 - `public Builder useBrowser(boolean useBrowser)`. There is no replacement; Google no longer supports WebView authentication.
 - `public Builder useFullscreen(boolean useFullscreen)`. There is no replacement; Google no longer supports WebView authentication.
-- `public void start(@NonNull Activity activity, @NonNull AuthCallback callback, int requestCode)`. Use `public void start(@NonNull Activity activity, @NonNull AuthCallback callback)` instead.    
+- `public void start(@NonNull Activity activity, @NonNull AuthCallback callback, int requestCode)`. Use `public void start(@NonNull Activity activity, @NonNull AuthCallback callback)` instead.
+- `public Builder withResponseType(@ResponseType int type)`. There is no replacement; only Code + PKCE flow supported in v2.
 
 #### UsersAPIClient
 

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -24,10 +24,11 @@
 
 package com.auth0.android.authentication;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.auth0.android.Auth0Exception;
 import com.auth0.android.NetworkErrorException;
@@ -61,6 +62,10 @@ public class AuthenticationException extends Auth0Exception {
 
     public AuthenticationException(@NonNull String message) {
         super(message);
+    }
+
+    public AuthenticationException(@NonNull String message, @NonNull Throwable throwable) {
+        super(message, throwable);
     }
 
     public AuthenticationException(@NonNull String message, @Nullable Auth0Exception exception) {

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -64,10 +64,6 @@ public class AuthenticationException extends Auth0Exception {
         super(message);
     }
 
-    public AuthenticationException(@NonNull String message, @NonNull Throwable throwable) {
-        super(message, throwable);
-    }
-
     public AuthenticationException(@NonNull String message, @Nullable Auth0Exception exception) {
         super(message, exception);
     }

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java
@@ -163,6 +163,13 @@ public class AuthenticationException extends Auth0Exception {
         return "a0.browser_not_available".equals(code);
     }
 
+    /**
+     * When the required algorithms to support PKCE web authentication is    not available on the device
+     */
+    public boolean isPKCENotAvailable() {
+        return "a0.pkce_not_available".equals(code);
+    }
+
     // When the Authorize URL is invalid
     public boolean isInvalidAuthorizeURL() {
         return "a0.invalid_authorize_url".equals(code);

--- a/auth0/src/main/java/com/auth0/android/provider/AlgorithmHelper.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AlgorithmHelper.java
@@ -5,7 +5,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -14,7 +14,6 @@ class AlgorithmHelper {
 
     private static final String TAG = AlgorithmHelper.class.getSimpleName();
 
-    private static final String US_ASCII = "US-ASCII";
     private static final String SHA_256 = "SHA-256";
 
     private String getBase64String(byte[] source) {
@@ -22,14 +21,7 @@ class AlgorithmHelper {
     }
 
     byte[] getASCIIBytes(String value) {
-        byte[] input;
-        try {
-            input = value.getBytes(US_ASCII);
-        } catch (UnsupportedEncodingException e) {
-            Log.e(TAG, "Could not convert string to an ASCII byte array", e);
-            throw new IllegalStateException("Could not convert string to an ASCII byte array", e);
-        }
-        return input;
+        return value.getBytes(StandardCharsets.US_ASCII);
     }
 
     byte[] getSHA256(byte[] input) {

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -68,6 +68,7 @@ class OAuthManager extends ResumableManager {
         this.account = account;
         this.callback = callback;
         this.parameters = new HashMap<>(parameters);
+        this.parameters.put(KEY_RESPONSE_TYPE, RESPONSE_TYPE_CODE);
         this.apiClient = new AuthenticationAPIClient(account);
         this.ctOptions = ctOptions;
     }
@@ -104,7 +105,7 @@ class OAuthManager extends ResumableManager {
         try {
             PKCE.throwIfNotAvailable();
         } catch (Throwable t) {
-            callback.onFailure(new AuthenticationException("Algorithims required to use PKCE are not available on this device. Authentication can not be done securely.", t));
+            callback.onFailure(new AuthenticationException("Algorithms required to use PKCE are not available on this device. Authentication can not be done securely.", t));
             return true;
         }
 

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -99,16 +99,6 @@ class OAuthManager extends ResumableManager {
     @SuppressWarnings("ConstantConditions")
     @Override
     boolean resume(AuthorizeResult result) {
-        // Should never happen where the algorithms required are not present, but just in case it does,
-        // this will allow us to at least call the error handler callback with an exception including
-        // the cause
-        try {
-            PKCE.throwIfNotAvailable();
-        } catch (Throwable t) {
-            callback.onFailure(new AuthenticationException("Algorithms required to use PKCE are not available on this device. Authentication can not be done securely.", t));
-            return true;
-        }
-
         if (!result.isValid(requestCode)) {
             Log.w(TAG, "The Authorize Result is invalid.");
             return false;
@@ -253,12 +243,6 @@ class OAuthManager extends ResumableManager {
     }
 
     private void addPKCEParameters(Map<String, String> parameters, String redirectUri) {
-        // If PKCE is not available on the device (should never  happen), just return here and
-        // we will fail later so we can call the error callback and not cause a hard failure
-        if (!PKCE.isAvailable()) {
-            return;
-        }
-
         createPKCE(redirectUri);
         String codeChallenge = pkce.getCodeChallenge();
         parameters.put(KEY_CODE_CHALLENGE, codeChallenge);

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -34,7 +34,6 @@ class OAuthManager extends ResumableManager {
     static final String KEY_NONCE = "nonce";
     static final String KEY_MAX_AGE = "max_age";
     static final String KEY_CONNECTION = "connection";
-    static final String RESPONSE_TYPE_ID_TOKEN = "id_token";
     static final String RESPONSE_TYPE_CODE = "code";
 
     private static final String ERROR_VALUE_INVALID_CONFIGURATION = "a0.invalid_configuration";
@@ -51,12 +50,7 @@ class OAuthManager extends ResumableManager {
     private static final String KEY_TELEMETRY = "auth0Client";
     private static final String KEY_ERROR = "error";
     private static final String KEY_ERROR_DESCRIPTION = "error_description";
-    private static final String KEY_ID_TOKEN = "id_token";
-    private static final String KEY_ACCESS_TOKEN = "access_token";
-    private static final String KEY_TOKEN_TYPE = "token_type";
-    private static final String KEY_EXPIRES_IN = "expires_in";
     private static final String KEY_CODE = "code";
-    private static final String KEY_SCOPE = "scope";
 
     private final Auth0 account;
     private final AuthCallback callback;
@@ -66,7 +60,7 @@ class OAuthManager extends ResumableManager {
     private int requestCode;
     private PKCE pkce;
     private Long currentTimeInMillis;
-    private CustomTabsOptions ctOptions;
+    private final CustomTabsOptions ctOptions;
     private Integer idTokenVerificationLeeway;
     private String idTokenVerificationIssuer;
 
@@ -118,7 +112,7 @@ class OAuthManager extends ResumableManager {
 
         final Map<String, String> values = CallbackHelper.getValuesFromUri(result.getIntentData());
         if (values.isEmpty()) {
-            Log.w(TAG, "The response didn't contain any of these values: code, state, id_token, access_token, token_type, refresh_token");
+            Log.w(TAG, "The response didn't contain any of these values: code, state");
             return false;
         }
         logDebug("The parsed CallbackURI contains the following values: " + values);
@@ -131,47 +125,13 @@ class OAuthManager extends ResumableManager {
             return true;
         }
 
-        final Date expiresAt = !values.containsKey(KEY_EXPIRES_IN) ? null : new Date(getCurrentTimeInMillis() + Long.parseLong(values.get(KEY_EXPIRES_IN)) * 1000);
-        boolean frontChannelIdTokenExpected = parameters.containsKey(KEY_RESPONSE_TYPE) && parameters.get(KEY_RESPONSE_TYPE).contains(RESPONSE_TYPE_ID_TOKEN);
-        final Credentials frontChannelCredentials = new Credentials(frontChannelIdTokenExpected ? values.get(KEY_ID_TOKEN) : null, values.get(KEY_ACCESS_TOKEN), values.get(KEY_TOKEN_TYPE), null, expiresAt, values.get(KEY_SCOPE));
-
-        if (frontChannelIdTokenExpected) {
-            //Must be response_type=id_token (or additional values)
-            assertValidIdToken(frontChannelCredentials.getIdToken(), new VoidCallback() {
-                @Override
-                public void onSuccess(@Nullable Void ignored) {
-                    if (!shouldUsePKCE()) {
-                        //response_type=id_token or response_type=id_token token
-                        callback.onSuccess(frontChannelCredentials);
-                        return;
-                    }
-                    //response_type=id_token code
-                    pkce.getToken(values.get(KEY_CODE), new SimpleAuthCallback(callback) {
-
-                        @Override
-                        public void onSuccess(@NonNull Credentials credentials) {
-                            Credentials finalCredentials = mergeCredentials(frontChannelCredentials, credentials);
-                            callback.onSuccess(finalCredentials);
-                        }
-                    });
-                }
-
-                @Override
-                public void onFailure(@NonNull Auth0Exception error) {
-                    AuthenticationException wrappedError = new AuthenticationException(ERROR_VALUE_ID_TOKEN_VALIDATION_FAILED, error);
-                    callback.onFailure(wrappedError);
-                }
-            });
-            return true;
-        }
-
         if (!shouldUsePKCE()) {
-            //Must be response_type=token
-            callback.onSuccess(frontChannelCredentials);
+            // PKCE required but not available. This is not an expected scenario.
+            callback.onFailure(new AuthenticationException("PKCE not available on this device."));
             return true;
         }
 
-        //Either response_type=code or response_type=token code
+        // response_type=code
         pkce.getToken(values.get(KEY_CODE), new SimpleAuthCallback(callback) {
 
             @Override
@@ -179,8 +139,7 @@ class OAuthManager extends ResumableManager {
                 assertValidIdToken(credentials.getIdToken(), new VoidCallback() {
                     @Override
                     public void onSuccess(@Nullable Void ignored) {
-                        Credentials finalCredentials = mergeCredentials(frontChannelCredentials, credentials);
-                        callback.onSuccess(finalCredentials);
+                        callback.onSuccess(credentials);
                     }
 
                     @Override
@@ -289,9 +248,6 @@ class OAuthManager extends ResumableManager {
     }
 
     private void addPKCEParameters(Map<String, String> parameters, String redirectUri) {
-        if (!shouldUsePKCE()) {
-            return;
-        }
         try {
             createPKCE(redirectUri);
             String codeChallenge = pkce.getCodeChallenge();
@@ -299,20 +255,15 @@ class OAuthManager extends ResumableManager {
             parameters.put(KEY_CODE_CHALLENGE_METHOD, METHOD_SHA_256);
             Log.v(TAG, "Using PKCE authentication flow");
         } catch (IllegalStateException e) {
-            Log.e(TAG, "Some algorithms aren't available on this device and PKCE can't be used. Defaulting to token response_type.", e);
+            Log.e(TAG, "Some algorithms aren't available on this device and PKCE can't be used for authentication, which is required.", e);
         }
     }
 
     private void addValidationParameters(Map<String, String> parameters) {
         String state = getRandomString(parameters.get(KEY_STATE));
+        String nonce = getRandomString(parameters.get(KEY_NONCE));
         parameters.put(KEY_STATE, state);
-
-        //noinspection ConstantConditions
-        boolean idTokenExpected = parameters.containsKey(KEY_RESPONSE_TYPE) && (parameters.get(KEY_RESPONSE_TYPE).contains(RESPONSE_TYPE_ID_TOKEN) || parameters.get(KEY_RESPONSE_TYPE).contains(RESPONSE_TYPE_CODE));
-        if (idTokenExpected) {
-            String nonce = getRandomString(parameters.get(KEY_NONCE));
-            parameters.put(KEY_NONCE, nonce);
-        }
+        parameters.put(KEY_NONCE, nonce);
     }
 
     private void addClientParameters(Map<String, String> parameters, String redirectUri) {
@@ -333,18 +284,6 @@ class OAuthManager extends ResumableManager {
     private boolean shouldUsePKCE() {
         //noinspection ConstantConditions
         return parameters.containsKey(KEY_RESPONSE_TYPE) && parameters.get(KEY_RESPONSE_TYPE).contains(RESPONSE_TYPE_CODE) && PKCE.isAvailable();
-    }
-
-    @VisibleForTesting
-    static Credentials mergeCredentials(Credentials urlCredentials, Credentials codeCredentials) {
-        final String idToken = TextUtils.isEmpty(urlCredentials.getIdToken()) ? codeCredentials.getIdToken() : urlCredentials.getIdToken();
-        final String accessToken = TextUtils.isEmpty(codeCredentials.getAccessToken()) ? urlCredentials.getAccessToken() : codeCredentials.getAccessToken();
-        final String type = TextUtils.isEmpty(codeCredentials.getType()) ? urlCredentials.getType() : codeCredentials.getType();
-        final String refreshToken = codeCredentials.getRefreshToken();
-        final Date expiresAt = codeCredentials.getExpiresAt() != null ? codeCredentials.getExpiresAt() : urlCredentials.getExpiresAt();
-        final String scope = TextUtils.isEmpty(codeCredentials.getScope()) ? urlCredentials.getScope() : codeCredentials.getScope();
-
-        return new Credentials(idToken, accessToken, type, refreshToken, expiresAt, scope);
     }
 
     @VisibleForTesting

--- a/auth0/src/main/java/com/auth0/android/provider/PKCE.java
+++ b/auth0/src/main/java/com/auth0/android/provider/PKCE.java
@@ -24,10 +24,11 @@
 
 package com.auth0.android.provider;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import android.util.Log;
 
 import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.authentication.AuthenticationException;
@@ -112,14 +113,29 @@ class PKCE {
         return isAvailable(new AlgorithmHelper());
     }
 
+    /**
+     * Checks if this device is capable of using the PKCE flow when performing calls to the
+     * /authorize endpoint, throwing an exception if it does not. This can be used to send
+     * the exception stack trace back to the error handler.
+     *
+     * @throws {@linkplain RuntimeException} if the device does not support PKCE
+     */
+    public static void throwIfNotAvailable() throws IllegalStateException {
+        checkIfAvailable(new AlgorithmHelper());
+    }
+
     @VisibleForTesting
     static boolean isAvailable(@NonNull AlgorithmHelper algorithmHelper) {
         try {
-            byte[] input = algorithmHelper.getASCIIBytes("test");
-            algorithmHelper.getSHA256(input);
+            checkIfAvailable(algorithmHelper);
         } catch (Exception ignored) {
             return false;
         }
         return true;
+    }
+
+    private static void checkIfAvailable(@NonNull AlgorithmHelper algorithmHelper) {
+        byte[] input = algorithmHelper.getASCIIBytes("test");
+        algorithmHelper.getSHA256(input);
     }
 }

--- a/auth0/src/main/java/com/auth0/android/provider/PKCE.java
+++ b/auth0/src/main/java/com/auth0/android/provider/PKCE.java
@@ -113,29 +113,14 @@ class PKCE {
         return isAvailable(new AlgorithmHelper());
     }
 
-    /**
-     * Checks if this device is capable of using the PKCE flow when performing calls to the
-     * /authorize endpoint, throwing an exception if it does not. This can be used to send
-     * the exception stack trace back to the error handler.
-     *
-     * @throws {@linkplain RuntimeException} if the device does not support PKCE
-     */
-    static void throwIfNotAvailable() throws IllegalStateException {
-        checkIfAvailable(new AlgorithmHelper());
-    }
-
     @VisibleForTesting
     static boolean isAvailable(@NonNull AlgorithmHelper algorithmHelper) {
         try {
-            checkIfAvailable(algorithmHelper);
+            byte[] input = algorithmHelper.getASCIIBytes("test");
+            algorithmHelper.getSHA256(input);
         } catch (Exception ignored) {
             return false;
         }
         return true;
-    }
-
-    private static void checkIfAvailable(@NonNull AlgorithmHelper algorithmHelper) {
-        byte[] input = algorithmHelper.getASCIIBytes("test");
-        algorithmHelper.getSHA256(input);
     }
 }

--- a/auth0/src/main/java/com/auth0/android/provider/PKCE.java
+++ b/auth0/src/main/java/com/auth0/android/provider/PKCE.java
@@ -109,7 +109,7 @@ class PKCE {
      *
      * @return if this device can use PKCE flow or not.
      */
-    public static boolean isAvailable() {
+    static boolean isAvailable() {
         return isAvailable(new AlgorithmHelper());
     }
 
@@ -120,7 +120,7 @@ class PKCE {
      *
      * @throws {@linkplain RuntimeException} if the device does not support PKCE
      */
-    public static void throwIfNotAvailable() throws IllegalStateException {
+    static void throwIfNotAvailable() throws IllegalStateException {
         checkIfAvailable(new AlgorithmHelper());
     }
 

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -46,7 +46,6 @@ import static com.auth0.android.provider.OAuthManager.KEY_NONCE;
 import static com.auth0.android.provider.OAuthManager.KEY_RESPONSE_TYPE;
 import static com.auth0.android.provider.OAuthManager.KEY_STATE;
 import static com.auth0.android.provider.OAuthManager.RESPONSE_TYPE_CODE;
-import static com.auth0.android.provider.OAuthManager.RESPONSE_TYPE_ID_TOKEN;
 
 /**
  * OAuth2 Web Authentication Provider.
@@ -170,7 +169,7 @@ public class WebAuthProvider {
             //Default values
             this.scheme = "https";
             this.ctOptions = CustomTabsOptions.newBuilder().build();
-            withResponseType(ResponseType.CODE);
+            this.values.put(KEY_RESPONSE_TYPE, RESPONSE_TYPE_CODE);
             withScope(SCOPE_TYPE_OPENID);
         }
 
@@ -306,28 +305,6 @@ public class WebAuthProvider {
                 sb.deleteCharAt(sb.length() - 1);
                 this.values.put(KEY_CONNECTION_SCOPE, sb.toString());
             }
-            return this;
-        }
-
-        /**
-         * Choose the grant type for this request.
-         *
-         * @param type the ResponseType to request to the Authentication API. Multiple ResponseType's can be defined using a pipe. "CODE | TOKEN"
-         * @return the current builder instance
-         */
-        @NonNull
-        public Builder withResponseType(@ResponseType int type) {
-            StringBuilder sb = new StringBuilder();
-            if (FlagChecker.hasFlag(type, ResponseType.CODE)) {
-                sb.append(RESPONSE_TYPE_CODE).append(" ");
-            }
-            if (FlagChecker.hasFlag(type, ResponseType.ID_TOKEN)) {
-                sb.append(RESPONSE_TYPE_ID_TOKEN).append(" ");
-            }
-            if (FlagChecker.hasFlag(type, ResponseType.TOKEN)) {
-                sb.append(RESPONSE_TYPE_TOKEN);
-            }
-            this.values.put(KEY_RESPONSE_TYPE, sb.toString().trim());
             return this;
         }
 

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -367,6 +367,12 @@ public class WebAuthProvider {
                 return;
             }
 
+            if (!PKCE.isAvailable()) {
+                AuthenticationException ex = new AuthenticationException("The SHA-256 algorithm, required to generate the Proof of Key Exchange (PKCE) signature, is not available on this device. See https://developer.android.com/reference/java/security/MessageDigest for additional information on the support for the SHA-256 algorithm.");
+                callback.onFailure(ex);
+                return;
+            }
+
             OAuthManager manager = new OAuthManager(account, callback, values, ctOptions);
             manager.setPKCE(pkce);
             manager.setIdTokenVerificationLeeway(leeway);

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -352,11 +352,14 @@ public class WebAuthProvider {
 
         /**
          * Request user Authentication. The result will be received in the callback.
-         * An error is raised if there are no browser applications installed in the device.
+         * An error is raised if there are no browser applications installed in the device, or if
+         * device does not support the necessary algorithms to support Proof of Key Exchange (PKCE)
+         * (this is not expected).
          *
          * @param activity context to run the authentication
          * @param callback to receive the parsed results
          * @see AuthenticationException#isBrowserAppNotAvailable()
+         * @see AuthenticationException#isPKCENotAvailable()
          */
         public void start(@NonNull Activity activity, @NonNull AuthCallback callback) {
             resetManagerInstance();
@@ -368,7 +371,8 @@ public class WebAuthProvider {
             }
 
             if (!PKCE.isAvailable()) {
-                AuthenticationException ex = new AuthenticationException("The SHA-256 algorithm, required to generate the Proof of Key Exchange (PKCE) signature, is not available on this device. See https://developer.android.com/reference/java/security/MessageDigest for additional information on the support for the SHA-256 algorithm.");
+                AuthenticationException ex = new AuthenticationException("a0.pkce_not_available",
+                        "The SHA-256 algorithm, required to generate the Proof of Key Exchange (PKCE) signature, is not available on this device. See https://developer.android.com/reference/java/security/MessageDigest for additional information on the support for the SHA-256 algorithm.");
                 callback.onFailure(ex);
                 return;
             }

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -43,9 +43,7 @@ import java.util.Map;
 import static com.auth0.android.provider.OAuthManager.KEY_CONNECTION;
 import static com.auth0.android.provider.OAuthManager.KEY_MAX_AGE;
 import static com.auth0.android.provider.OAuthManager.KEY_NONCE;
-import static com.auth0.android.provider.OAuthManager.KEY_RESPONSE_TYPE;
 import static com.auth0.android.provider.OAuthManager.KEY_STATE;
-import static com.auth0.android.provider.OAuthManager.RESPONSE_TYPE_CODE;
 
 /**
  * OAuth2 Web Authentication Provider.
@@ -150,7 +148,6 @@ public class WebAuthProvider {
         private static final String KEY_SCOPE = "scope";
         private static final String KEY_CONNECTION_SCOPE = "connection_scope";
         private static final String SCOPE_TYPE_OPENID = "openid";
-        private static final String RESPONSE_TYPE_TOKEN = "token";
 
 
         private final Auth0 account;
@@ -169,7 +166,6 @@ public class WebAuthProvider {
             //Default values
             this.scheme = "https";
             this.ctOptions = CustomTabsOptions.newBuilder().build();
-            this.values.put(KEY_RESPONSE_TYPE, RESPONSE_TYPE_CODE);
             withScope(SCOPE_TYPE_OPENID);
         }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
@@ -338,7 +338,7 @@ public class AuthenticationExceptionTest {
     }
 
     @Test
-    public void shouldHavePKCENotAvailalbe() {
+    public void shouldHavePKCENotAvailable() {
         values.put(CODE_KEY, "a0.pkce_not_available");
         AuthenticationException ex = new AuthenticationException(values);
         assertThat(ex.isPKCENotAvailable(), is(true));

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.java
@@ -337,4 +337,11 @@ public class AuthenticationExceptionTest {
         assertThat(ex.isBrowserAppNotAvailable(), is(true));
     }
 
+    @Test
+    public void shouldHavePKCENotAvailalbe() {
+        values.put(CODE_KEY, "a0.pkce_not_available");
+        AuthenticationException ex = new AuthenticationException(values);
+        assertThat(ex.isPKCENotAvailable(), is(true));
+    }
+
 }

--- a/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
@@ -2,7 +2,6 @@ package com.auth0.android.provider;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationException;
-import com.auth0.android.result.Credentials;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -12,11 +11,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-
-import java.util.Date;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 
 @RunWith(RobolectricTestRunner.class)
@@ -32,38 +26,6 @@ public class OAuthManagerTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-    }
-
-    @Test
-    public void shouldMergeCredentials() {
-        Date expiresAt = new Date();
-        Credentials frontChannelCredentials = new Credentials("urlId", "urlAccess", "urlType", null, expiresAt, "urlScope");
-        Credentials codeExchangeCredentials = new Credentials("codeId", "codeAccess", "codeType", "codeRefresh", expiresAt, "codeScope");
-        Credentials merged = OAuthManager.mergeCredentials(frontChannelCredentials, codeExchangeCredentials);
-
-        assertThat(merged.getIdToken(), is(frontChannelCredentials.getIdToken()));
-        assertThat(merged.getAccessToken(), is(codeExchangeCredentials.getAccessToken()));
-        assertThat(merged.getType(), is(codeExchangeCredentials.getType()));
-        assertThat(merged.getRefreshToken(), is(codeExchangeCredentials.getRefreshToken()));
-        assertThat(merged.getExpiresIn(), is(codeExchangeCredentials.getExpiresIn()));
-        assertThat(merged.getExpiresAt(), is(expiresAt));
-        assertThat(merged.getExpiresAt(), is(codeExchangeCredentials.getExpiresAt()));
-        assertThat(merged.getScope(), is(codeExchangeCredentials.getScope()));
-    }
-
-    @Test
-    public void shouldPreferNonNullValuesWhenMergingCredentials() {
-        Credentials urlCredentials = new Credentials("urlId", "urlAccess", "urlType", null, new Date(), "urlScope");
-        Credentials codeCredentials = new Credentials(null, null, null, "codeRefresh", null, null);
-        Credentials merged = OAuthManager.mergeCredentials(urlCredentials, codeCredentials);
-
-        assertThat(merged.getIdToken(), is(urlCredentials.getIdToken()));
-        assertThat(merged.getAccessToken(), is(urlCredentials.getAccessToken()));
-        assertThat(merged.getType(), is(urlCredentials.getType()));
-        assertThat(merged.getRefreshToken(), is(codeCredentials.getRefreshToken()));
-        assertThat(merged.getExpiresIn(), is(urlCredentials.getExpiresIn()));
-        assertThat(merged.getScope(), is(urlCredentials.getScope()));
-        assertThat(merged.getExpiresAt(), is(urlCredentials.getExpiresAt()));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -57,7 +57,6 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -527,7 +526,6 @@ public class WebAuthProviderTest {
     @Test
     public void shouldSetNonceByDefaultIfResponseTypeIncludesCodeOnLogin() {
         WebAuthProvider.login(account)
-                .withResponseType(ResponseType.CODE)
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
@@ -535,39 +533,12 @@ public class WebAuthProviderTest {
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithName("nonce"));
-    }
-
-    @Test
-    public void shouldSetNonceByDefaultIfResponseTypeIncludesIdTokenOnLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.ID_TOKEN)
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, hasParamWithName("nonce"));
-    }
-
-    @Test
-    public void shouldNotSetNonceByDefaultIfResponseTypeIsTokenOnLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, not(hasParamWithName("nonce")));
     }
 
     @Test
     public void shouldSetNonNullNonceOnLogin() {
         WebAuthProvider.login(account)
                 .withNonce(null)
-                .withResponseType(ResponseType.ID_TOKEN)
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
@@ -578,23 +549,8 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldSetUserNonceIfResponseTypeIsTokenOnLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.TOKEN)
-                .withNonce("1234567890")
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, hasParamWithValue("nonce", "1234567890"));
-    }
-
-    @Test
     public void shouldSetUserNonceIfResponseTypeIsCodeOnLogin() {
         WebAuthProvider.login(account)
-                .withResponseType(ResponseType.CODE)
                 .withNonce("1234567890")
                 .start(activity, callback);
 
@@ -609,7 +565,6 @@ public class WebAuthProviderTest {
     public void shouldSetNonceFromParametersOnLogin() {
         Map<String, Object> parameters = Collections.singletonMap("nonce", (Object) "1234567890");
         WebAuthProvider.login(account)
-                .withResponseType(ResponseType.ID_TOKEN)
                 .withNonce("abcdefg")
                 .withParameters(parameters)
                 .start(activity, callback);
@@ -625,7 +580,6 @@ public class WebAuthProviderTest {
     public void shouldSetNonceFromSetterOnLogin() {
         Map<String, Object> parameters = Collections.singletonMap("nonce", (Object) "1234567890");
         WebAuthProvider.login(account)
-                .withResponseType(ResponseType.ID_TOKEN)
                 .withParameters(parameters)
                 .withNonce("abcdefg")
                 .start(activity, callback);
@@ -641,7 +595,6 @@ public class WebAuthProviderTest {
     public void shouldNotOverrideNonceValueWithDefaultNonceOnLogin() {
         Map<String, Object> parameters = Collections.singletonMap("nonce", (Object) "1234567890");
         WebAuthProvider.login(account)
-                .withResponseType(ResponseType.ID_TOKEN)
                 .withParameters(parameters)
                 .start(activity, callback);
 
@@ -655,7 +608,6 @@ public class WebAuthProviderTest {
     @Test
     public void shouldSetNonceOnLogin() {
         WebAuthProvider.login(account)
-                .withResponseType(ResponseType.ID_TOKEN)
                 .withNonce("abcdefg")
                 .start(activity, callback);
 
@@ -800,35 +752,8 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldSetResponseTypeTokenOnLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, hasParamWithValue("response_type", "token"));
-    }
-
-    @Test
-    public void shouldSetResponseTypeIdTokenOnLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.ID_TOKEN)
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, hasParamWithValue("response_type", "id_token"));
-    }
-
-    @Test
     public void shouldSetResponseTypeCodeOnLogin() {
         WebAuthProvider.login(account)
-                .withResponseType(ResponseType.CODE)
                 .start(activity, callback);
 
         verify(activity).startActivity(intentCaptor.capture());
@@ -836,58 +761,6 @@ public class WebAuthProviderTest {
         assertThat(uri, is(notNullValue()));
 
         assertThat(uri, hasParamWithValue("response_type", "code"));
-    }
-
-    @Test
-    public void shouldSetResponseTypeCodeTokenOnLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.CODE | ResponseType.TOKEN)
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, hasParamWithValue("response_type", "code token"));
-    }
-
-    @Test
-    public void shouldSetResponseTypeCodeIdTokenOnLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.CODE | ResponseType.ID_TOKEN)
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, hasParamWithValue("response_type", "code id_token"));
-    }
-
-    @Test
-    public void shouldSetResponseTypeIdTokenTokenOnLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.ID_TOKEN | ResponseType.TOKEN)
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, hasParamWithValue("response_type", "id_token token"));
-    }
-
-    @Test
-    public void shouldSetResponseTypeCodeIdTokenTokenOnLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.CODE | ResponseType.ID_TOKEN | ResponseType.TOKEN)
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, hasParamWithValue("response_type", "code id_token token"));
     }
 
     @Test
@@ -926,7 +799,6 @@ public class WebAuthProviderTest {
     @Test
     public void shouldBuildAuthorizeURIWithCorrectSchemeHostAndPathOnLogin() {
         WebAuthProvider.login(account)
-                .withResponseType(ResponseType.ID_TOKEN)
                 .withState("a-state")
                 .withNonce("a-nonce")
                 .start(activity, callback);
@@ -942,44 +814,8 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldBuildAuthorizeURIWithResponseTypeIdTokenOnLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.ID_TOKEN)
-                .withState("a-state")
-                .withNonce("a-nonce")
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, hasParamWithValue("nonce", "a-nonce"));
-        assertThat(uri, not(hasParamWithName("code_challenge")));
-        assertThat(uri, not(hasParamWithName("code_challenge_method")));
-        assertThat(uri, hasParamWithValue("response_type", "id_token"));
-    }
-
-    @Test
-    public void shouldBuildAuthorizeURIWithResponseTypeTokenOnLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.TOKEN)
-                .withState("a-state")
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        assertThat(uri, not(hasParamWithName("nonce")));
-        assertThat(uri, not(hasParamWithName("code_challenge")));
-        assertThat(uri, not(hasParamWithName("code_challenge_method")));
-        assertThat(uri, hasParamWithValue("response_type", "token"));
-    }
-
-    @Test
     public void shouldBuildAuthorizeURIWithResponseTypeCodeOnLogin() {
         WebAuthProvider.login(account)
-                .withResponseType(ResponseType.CODE)
                 .withState("a-state")
                 .start(activity, callback);
 
@@ -1012,91 +848,6 @@ public class WebAuthProviderTest {
         assertThat(extras.getParcelable(AuthenticationActivity.EXTRA_AUTHORIZE_URI), is(notNullValue()));
         assertThat(extras.containsKey(AuthenticationActivity.EXTRA_CT_OPTIONS), is(true));
         assertThat(extras.getParcelable(AuthenticationActivity.EXTRA_CT_OPTIONS), is(options));
-    }
-
-    @Test
-    public void shouldSetExpectedNonceWithResponseTypeIdToken() throws Exception {
-        AuthenticationAPI mockAPI = new AuthenticationAPI();
-        mockAPI.willReturnValidJsonWebKeys();
-
-        MockAuthCallback authCallback = new MockAuthCallback();
-
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
-
-        WebAuthProvider.login(proxyAccount)
-                .withResponseType(ResponseType.ID_TOKEN)
-                .start(activity, authCallback);
-
-        OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
-        managerInstance.setCurrentTimeInMillis(FIXED_CLOCK_CURRENT_TIME_MS);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        String sentState = uri.getQueryParameter(KEY_STATE);
-        String sentNonce = uri.getQueryParameter(KEY_NONCE);
-        assertThat(sentState, is(not(isEmptyOrNullString())));
-        assertThat(sentNonce, is(not(isEmptyOrNullString())));
-
-        Map<String, Object> jwtBody = createJWTBody();
-        jwtBody.put("nonce", sentNonce);
-        jwtBody.put("iss", proxyAccount.getDomainUrl());
-        String expectedIdToken = createTestJWT("RS256", jwtBody);
-
-        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, sentState, null, null, null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        mockAPI.takeRequest();
-
-        assertThat(authCallback, AuthCallbackMatcher.hasCredentials());
-
-        Credentials credentials = authCallback.getCredentials();
-        assertThat(credentials, is(notNullValue()));
-        assertThat(credentials.getIdToken(), is(expectedIdToken));
-
-        mockAPI.shutdown();
-    }
-
-    @Test
-    public void shouldResumeLoginWithIntentWithResponseTypeIdToken() throws Exception {
-        AuthenticationAPI mockAPI = new AuthenticationAPI();
-        mockAPI.willReturnValidJsonWebKeys();
-
-        MockAuthCallback authCallback = new MockAuthCallback();
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
-
-        WebAuthProvider.login(proxyAccount)
-                .withResponseType(ResponseType.ID_TOKEN)
-                .start(activity, authCallback);
-        OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
-        managerInstance.setCurrentTimeInMillis(FIXED_CLOCK_CURRENT_TIME_MS);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        String sentState = uri.getQueryParameter(KEY_STATE);
-        String sentNonce = uri.getQueryParameter(KEY_NONCE);
-        assertThat(sentState, is(not(isEmptyOrNullString())));
-        assertThat(sentNonce, is(not(isEmptyOrNullString())));
-
-        Map<String, Object> jwtBody = createJWTBody();
-        jwtBody.put("nonce", sentNonce);
-        jwtBody.put("iss", proxyAccount.getDomainUrl());
-        String expectedIdToken = createTestJWT("RS256", jwtBody);
-
-        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, sentState, null, null, null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        mockAPI.takeRequest();
-
-        assertThat(authCallback, AuthCallbackMatcher.hasCredentials());
-        Credentials credentials = authCallback.getCredentials();
-        assertThat(credentials, is(notNullValue()));
-        assertThat(credentials.getIdToken(), is(expectedIdToken));
-
-        mockAPI.shutdown();
     }
 
     @Test
@@ -1156,70 +907,6 @@ public class WebAuthProviderTest {
         String expectedIdToken = createTestJWT("RS256", jwtBody);
 
         final Credentials codeCredentials = new Credentials(expectedIdToken, "codeAccess", "codeType", "codeRefresh", expiresAt, "codeScope");
-        Mockito.doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) {
-                callbackCaptor.getValue().onSuccess(codeCredentials);
-                return null;
-            }
-        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
-
-        assertTrue(WebAuthProvider.resume(intent));
-
-        mockAPI.takeRequest();
-
-        assertThat(authCallback, AuthCallbackMatcher.hasCredentials());
-
-        Credentials credentials = authCallback.getCredentials();
-        assertThat(credentials, is(notNullValue()));
-        assertThat(credentials.getIdToken(), is(expectedIdToken));
-        assertThat(credentials.getAccessToken(), is("codeAccess"));
-        assertThat(credentials.getRefreshToken(), is("codeRefresh"));
-        assertThat(credentials.getType(), is("codeType"));
-        assertThat(credentials.getExpiresAt(), is(expiresAt));
-        assertThat(credentials.getScope(), is("codeScope"));
-
-        mockAPI.shutdown();
-    }
-
-    @Test
-    public void shouldResumeLoginWithIntentWithHybridGrant() throws Exception {
-        Date expiresAt = new Date();
-        PKCE pkce = Mockito.mock(PKCE.class);
-
-        AuthenticationAPI mockAPI = new AuthenticationAPI();
-        mockAPI.willReturnValidJsonWebKeys();
-
-        MockAuthCallback authCallback = new MockAuthCallback();
-
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
-
-        WebAuthProvider.login(proxyAccount)
-                .withResponseType(ResponseType.ID_TOKEN | ResponseType.CODE)
-                .withPKCE(pkce)
-                .start(activity, authCallback);
-
-        OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
-        managerInstance.setCurrentTimeInMillis(FIXED_CLOCK_CURRENT_TIME_MS);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        String sentState = uri.getQueryParameter(KEY_STATE);
-        String sentNonce = uri.getQueryParameter(KEY_NONCE);
-
-        assertThat(sentState, is(not(isEmptyOrNullString())));
-        assertThat(sentNonce, is(not(isEmptyOrNullString())));
-
-        Map<String, Object> jwtBody = createJWTBody();
-        jwtBody.put("nonce", sentNonce);
-        jwtBody.put("aud", proxyAccount.getClientId());
-        jwtBody.put("iss", proxyAccount.getDomainUrl());
-        String expectedIdToken = createTestJWT("RS256", jwtBody);
-
-        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, sentState, null, null, "1234"));
-        final Credentials codeCredentials = new Credentials("codeIdtoken", "codeAccess", "codeType", "codeRefresh", expiresAt, "codeScope");
         Mockito.doAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) {
@@ -1307,87 +994,8 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldNotReturnUnverifiedIdTokenWhenResponseTypeIsToken() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        String sentState = uri.getQueryParameter(KEY_STATE);
-        assertThat(sentState, is(not(isEmptyOrNullString())));
-        Intent intent = createAuthIntent(createHash("maliciuouslyPutIdToken", "urlAccess", null, "urlType", 1111L, sentState, null, null, null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        ArgumentCaptor<Credentials> credentialsCaptor = ArgumentCaptor.forClass(Credentials.class);
-        verify(callback).onSuccess(credentialsCaptor.capture());
-
-        assertThat(credentialsCaptor.getValue(), is(notNullValue()));
-        assertThat(credentialsCaptor.getValue().getIdToken(), is(nullValue()));
-        assertThat(credentialsCaptor.getValue().getAccessToken(), is("urlAccess"));
-        assertThat(credentialsCaptor.getValue().getRefreshToken(), is(nullValue()));
-        assertThat(credentialsCaptor.getValue().getType(), is("urlType"));
-        assertThat(credentialsCaptor.getValue().getExpiresIn().doubleValue(), is(closeTo(1111L, 1)));
-    }
-
-    @Test
-    public void shouldResumeLoginWithIntentWithImplicitGrant() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        String sentState = uri.getQueryParameter(KEY_STATE);
-        assertThat(sentState, is(not(isEmptyOrNullString())));
-        Intent intent = createAuthIntent(createHash(null, "urlAccess", null, "urlType", 1111L, sentState, null, null, null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        ArgumentCaptor<Credentials> credentialsCaptor = ArgumentCaptor.forClass(Credentials.class);
-        verify(callback).onSuccess(credentialsCaptor.capture());
-
-        assertThat(credentialsCaptor.getValue(), is(notNullValue()));
-        assertThat(credentialsCaptor.getValue().getIdToken(), is(nullValue()));
-        assertThat(credentialsCaptor.getValue().getAccessToken(), is("urlAccess"));
-        assertThat(credentialsCaptor.getValue().getRefreshToken(), is(nullValue()));
-        assertThat(credentialsCaptor.getValue().getType(), is("urlType"));
-        assertThat(credentialsCaptor.getValue().getExpiresIn().doubleValue(), is(closeTo(1111L, 1)));
-    }
-
-    @Test
-    public void shouldResumeLoginWithRequestCodeWithImplicitGrant() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        String sentState = uri.getQueryParameter(KEY_STATE);
-        assertThat(sentState, is(not(isEmptyOrNullString())));
-        Intent intent = createAuthIntent(createHash(null, "urlAccess", null, "urlType", 1111L, sentState, null, null, null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        ArgumentCaptor<Credentials> credentialsCaptor = ArgumentCaptor.forClass(Credentials.class);
-        verify(callback).onSuccess(credentialsCaptor.capture());
-
-        assertThat(credentialsCaptor.getValue(), is(notNullValue()));
-        assertThat(credentialsCaptor.getValue().getIdToken(), is(nullValue()));
-        assertThat(credentialsCaptor.getValue().getAccessToken(), is("urlAccess"));
-        assertThat(credentialsCaptor.getValue().getRefreshToken(), is(nullValue()));
-        assertThat(credentialsCaptor.getValue().getType(), is("urlType"));
-        assertThat(credentialsCaptor.getValue().getExpiresIn().doubleValue(), is(closeTo(1111L, 1)));
-    }
-
-    @Test
     public void shouldResumeLoginWithRequestCodeWhenResultCancelled() {
         WebAuthProvider.login(account)
-                .withResponseType(ResponseType.TOKEN)
                 .start(activity, callback);
 
         Intent intent = createAuthIntent(null);
@@ -1398,48 +1006,6 @@ public class WebAuthProviderTest {
         assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
         assertThat(authExceptionCaptor.getValue().getCode(), is("a0.authentication_canceled"));
         assertThat(authExceptionCaptor.getValue().getDescription(), is("The user closed the browser app and the authentication was canceled."));
-    }
-
-    @Test
-    public void shouldResumeLoginWithIntentWhenResultCancelled() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-
-        Intent intent = createAuthIntent(null);
-        assertTrue(WebAuthProvider.resume(intent));
-
-        verify(callback).onFailure(authExceptionCaptor.capture());
-
-        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(authExceptionCaptor.getValue().getCode(), is("a0.authentication_canceled"));
-        assertThat(authExceptionCaptor.getValue().getDescription(), is("The user closed the browser app and the authentication was canceled."));
-    }
-
-    @Test
-    public void shouldCalculateExpiresAtDateOnResumeLogin() {
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-        OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
-        managerInstance.setCurrentTimeInMillis(FIXED_CLOCK_CURRENT_TIME_MS);
-
-        verify(activity).startActivity(intentCaptor.capture());
-        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
-        assertThat(uri, is(notNullValue()));
-
-        String sentState = uri.getQueryParameter(KEY_STATE);
-        assertThat(sentState, is(not(isEmptyOrNullString())));
-        Intent intent = createAuthIntent(createHash(null, "urlAccess", null, "urlType", 1111L, sentState, null, null, null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        ArgumentCaptor<Credentials> credentialsCaptor = ArgumentCaptor.forClass(Credentials.class);
-        verify(callback).onSuccess(credentialsCaptor.capture());
-
-        assertThat(credentialsCaptor.getValue(), is(notNullValue()));
-        long expirationTime = FIXED_CLOCK_CURRENT_TIME_MS + 1111L * 1000;
-        assertThat(credentialsCaptor.getValue().getExpiresAt(), is(notNullValue()));
-        assertThat(credentialsCaptor.getValue().getExpiresAt().getTime(), is(expirationTime));
     }
 
     @Test
@@ -1478,7 +1044,6 @@ public class WebAuthProviderTest {
         WebAuthProvider.login(account)
                 .withState("1234567890")
                 .withNonce(EXPECTED_NONCE)
-                .withResponseType(ResponseType.CODE)
                 .withPKCE(pkce)
                 .start(activity, callback);
 
@@ -1495,68 +1060,9 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldReThrowAnyFailedCodeExchangeExceptionOnLoginWithHybridGrant() throws Exception {
-        final AuthenticationException exception = Mockito.mock(AuthenticationException.class);
-        PKCE pkce = Mockito.mock(PKCE.class);
-        Mockito.doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) {
-                callbackCaptor.getValue().onFailure(exception);
-                return null;
-            }
-        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
-
-        AuthenticationAPI mockAPI = new AuthenticationAPI();
-        mockAPI.willReturnValidJsonWebKeys();
-
-        MockAuthCallback authCallback = new MockAuthCallback();
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
-
-        WebAuthProvider.login(proxyAccount)
-                .withState("1234567890")
-                .withNonce(EXPECTED_NONCE)
-                .withResponseType(ResponseType.ID_TOKEN | ResponseType.CODE)
-                .withPKCE(pkce)
-                .start(activity, authCallback);
-
-        OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
-        managerInstance.setCurrentTimeInMillis(FIXED_CLOCK_CURRENT_TIME_MS);
-
-        Map<String, Object> jwtBody = createJWTBody();
-        jwtBody.put("iss", proxyAccount.getDomainUrl());
-        String expectedIdToken = createTestJWT("RS256", jwtBody);
-
-        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, "1234567890", null, null, "1234"));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        mockAPI.takeRequest();
-
-        assertThat(authCallback, AuthCallbackMatcher.hasError());
-
-        mockAPI.shutdown();
-    }
-
-    @Test
     public void shouldFailToResumeLoginWithIntentWithAccessDenied() {
         WebAuthProvider.login(account)
                 .withState("1234567890")
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-        Intent intent = createAuthIntent(createHash(null, "aToken", null, "urlType", 1111L, "1234567890", "access_denied", null, null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        verify(callback).onFailure(authExceptionCaptor.capture());
-
-        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(authExceptionCaptor.getValue().getCode(), is("access_denied"));
-        assertThat(authExceptionCaptor.getValue().getDescription(), is("Permissions were not granted. Try again."));
-    }
-
-    @Test
-    public void shouldFailToResumeLoginWithRequestCodeWithAccessDenied() {
-        WebAuthProvider.login(account)
-                .withState("1234567890")
-                .withResponseType(ResponseType.TOKEN)
                 .start(activity, callback);
         Intent intent = createAuthIntent(createHash(null, "aToken", null, "urlType", 1111L, "1234567890", "access_denied", null, null));
         assertTrue(WebAuthProvider.resume(intent));
@@ -1572,23 +1078,6 @@ public class WebAuthProviderTest {
     public void shouldFailToResumeLoginWithIntentWithRuleError() {
         WebAuthProvider.login(account)
                 .withState("1234567890")
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-        Intent intent = createAuthIntent(createHash(null, "aToken", null, "urlType", 1111L, "1234567890", "unauthorized", "Custom Rule Error", null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        verify(callback).onFailure(authExceptionCaptor.capture());
-
-        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(authExceptionCaptor.getValue().getCode(), is("unauthorized"));
-        assertThat(authExceptionCaptor.getValue().getDescription(), is("Custom Rule Error"));
-    }
-
-    @Test
-    public void shouldFailToResumeLoginWithRequestCodeWithRuleError() {
-        WebAuthProvider.login(account)
-                .withState("1234567890")
-                .withResponseType(ResponseType.TOKEN)
                 .start(activity, callback);
         Intent intent = createAuthIntent(createHash(null, "aToken", null, "urlType", 1111L, "1234567890", "unauthorized", "Custom Rule Error", null));
         assertTrue(WebAuthProvider.resume(intent));
@@ -1604,7 +1093,6 @@ public class WebAuthProviderTest {
     public void shouldFailToResumeLoginWithIntentWithConfigurationInvalid() {
         WebAuthProvider.login(account)
                 .withState("1234567890")
-                .withResponseType(ResponseType.TOKEN)
                 .start(activity, callback);
         Intent intent = createAuthIntent(createHash(null, "aToken", null, "urlType", 1111L, "1234567890", "some other error", null, null));
         assertTrue(WebAuthProvider.resume(intent));
@@ -1614,42 +1102,11 @@ public class WebAuthProviderTest {
         assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
         assertThat(authExceptionCaptor.getValue().getCode(), is("a0.invalid_configuration"));
         assertThat(authExceptionCaptor.getValue().getDescription(), is("The application isn't configured properly for the social connection. Please check your Auth0's application configuration"));
-    }
-
-    @Test
-    public void shouldFailToResumeLoginWithRequestCodeWithConfigurationInvalid() {
-        WebAuthProvider.login(account)
-                .withState("1234567890")
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-        Intent intent = createAuthIntent(createHash(null, "aToken", null, "urlType", 1111L, "1234567890", "some other error", null, null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        verify(callback).onFailure(authExceptionCaptor.capture());
-
-        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(authExceptionCaptor.getValue().getCode(), is("a0.invalid_configuration"));
-        assertThat(authExceptionCaptor.getValue().getDescription(), is("The application isn't configured properly for the social connection. Please check your Auth0's application configuration"));
-    }
-
-    @Test
-    public void shouldFailToResumeLoginWithImplicitGrantMissingIdToken() {
-        WebAuthProvider.login(account)
-                .withState("1234567890")
-                .withResponseType(ResponseType.ID_TOKEN | ResponseType.TOKEN)
-                .start(activity, callback);
-        Intent intent = createAuthIntent(createHash(null, "aToken", null, "urlType", 1111L, "1234567890", null, null, null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        verify(callback).onFailure(authExceptionCaptor.capture());
-
-        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(authExceptionCaptor.getValue().getCause(), is(Matchers.<Throwable>instanceOf(TokenValidationException.class)));
-        assertThat(authExceptionCaptor.getValue().getCause().getMessage(), is("ID token is required but missing"));
     }
 
     @Test
     public void shouldFailToResumeLoginWhenRSAKeyIsMissingFromJWKSet() throws Exception {
+        PKCE pkce = Mockito.mock(PKCE.class);
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnEmptyJsonWebKeys();
 
@@ -1659,7 +1116,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
                 .withNonce(EXPECTED_NONCE)
-                .withResponseType(ResponseType.ID_TOKEN | ResponseType.TOKEN)
+                .withPKCE(pkce)
                 .start(activity, authCallback);
 
         OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
@@ -1669,7 +1126,16 @@ public class WebAuthProviderTest {
         jwtBody.put("iss", proxyAccount.getDomainUrl());
         String expectedIdToken = createTestJWT("RS256", jwtBody);
 
-        Intent intent = createAuthIntent(createHash(expectedIdToken, "aToken", null, "urlType", 1111L, "1234567890", null, null, null));
+        Intent intent = createAuthIntent(createHash(null, null, null, null, null, "1234567890", null, null, "1234"));
+        final Credentials codeCredentials = new Credentials(expectedIdToken, "codeAccess", "codeType", "codeRefresh", null, "codeScope");
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                callbackCaptor.getValue().onSuccess(codeCredentials);
+                return null;
+            }
+        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
+
         assertTrue(WebAuthProvider.resume(intent));
         mockAPI.takeRequest();
 
@@ -1685,6 +1151,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldFailToResumeLoginWhenJWKSRequestFails() throws Exception {
+        PKCE pkce = Mockito.mock(PKCE.class);
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnInvalidRequest();
 
@@ -1694,7 +1161,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
                 .withNonce(EXPECTED_NONCE)
-                .withResponseType(ResponseType.ID_TOKEN | ResponseType.TOKEN)
+                .withPKCE(pkce)
                 .start(activity, authCallback);
 
         OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
@@ -1704,7 +1171,16 @@ public class WebAuthProviderTest {
         jwtBody.put("iss", proxyAccount.getDomainUrl());
         String expectedIdToken = createTestJWT("RS256", jwtBody);
 
-        Intent intent = createAuthIntent(createHash(expectedIdToken, "aToken", null, "urlType", 1111L, "1234567890", null, null, null));
+        Intent intent = createAuthIntent(createHash(null, null, null, null, null, "1234567890", null, null, "1234"));
+        final Credentials codeCredentials = new Credentials(expectedIdToken, "codeAccess", "codeType", "codeRefresh", null, "codeScope");
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                callbackCaptor.getValue().onSuccess(codeCredentials);
+                return null;
+            }
+        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
+
         assertTrue(WebAuthProvider.resume(intent));
         mockAPI.takeRequest();
 
@@ -1720,6 +1196,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldFailToResumeLoginWhenKeyIdIsMissingFromIdTokenHeader() throws Exception {
+        PKCE pkce = Mockito.mock(PKCE.class);
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
 
@@ -1729,14 +1206,23 @@ public class WebAuthProviderTest {
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
                 .withNonce("abcdefg")
-                .withResponseType(ResponseType.ID_TOKEN | ResponseType.TOKEN)
+                .withPKCE(pkce)
                 .start(activity, authCallback);
 
         OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
         managerInstance.setCurrentTimeInMillis(FIXED_CLOCK_CURRENT_TIME_MS);
 
         String expectedIdToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhdXRoMHwxMjM0NTY3ODkifQ.PZivSuGSAWpSU62-iHwI16Po9DgO9lN7SLB3168P03wXBkue6nxbL3beq6jjW9uuhqRKfOiDtsvtr3paGXHONarPqQ1LEm4TDg8CM6AugaphH36EjEjL0zEYo0nxz9Fv1Xu9_bWSzfmLLgRefjZ5R0muV7JlyfBgtkfG0avD3PtjlNtToXX1sN9DyhgCT-STX9kSQAlk23V1XA3c8st09QgmQRgtZC3ZmTEHqq_FTmFUkVUNM6E0LbgLR7bLcOx4Xqayp1mqZxUgTg7ynHI6Ey4No-R5_twAki_BR8uG0TxqHlPxuU9QTzEvCQxrqzZZufRv_kIn2-fqrF3yr3z4Og";
-        Intent intent = createAuthIntent(createHash(expectedIdToken, "aToken", null, "urlType", 1111L, "1234567890", null, null, null));
+        Intent intent = createAuthIntent(createHash(null, null, null, null, null, "1234567890", null, null, "1234"));
+        final Credentials codeCredentials = new Credentials(expectedIdToken, "codeAccess", "codeType", "codeRefresh", null, "codeScope");
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                callbackCaptor.getValue().onSuccess(codeCredentials);
+                return null;
+            }
+        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
+
         assertTrue(WebAuthProvider.resume(intent));
         mockAPI.takeRequest();
 
@@ -1752,6 +1238,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldResumeLoginWhenJWKSRequestSuceeds() throws Exception {
+        PKCE pkce = Mockito.mock(PKCE.class);
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
 
@@ -1761,7 +1248,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
                 .withNonce(EXPECTED_NONCE)
-                .withResponseType(ResponseType.ID_TOKEN | ResponseType.TOKEN)
+                .withPKCE(pkce)
                 .start(activity, authCallback);
 
         OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
@@ -1771,7 +1258,15 @@ public class WebAuthProviderTest {
         jwtBody.put("iss", proxyAccount.getDomainUrl());
         String expectedIdToken = createTestJWT("RS256", jwtBody);
 
-        Intent intent = createAuthIntent(createHash(expectedIdToken, "aToken", null, "urlType", 1111L, "1234567890", null, null, null));
+        Intent intent = createAuthIntent(createHash(null, null, null, null, null, "1234567890", null, null, "1234"));
+        final Credentials codeCredentials = new Credentials(expectedIdToken, "aToken", "codeType", "codeRefresh", null, "codeScope");
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                callbackCaptor.getValue().onSuccess(codeCredentials);
+                return null;
+            }
+        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
         assertTrue(WebAuthProvider.resume(intent));
         mockAPI.takeRequest();
 
@@ -1786,6 +1281,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldResumeLoginIgnoringEmptyCustomIDTokenVerificationIssuer() throws Exception {
+        PKCE pkce = Mockito.mock(PKCE.class);
         // if specifying a null issuer for token verification, should use the domain URL of the account
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
@@ -1795,8 +1291,8 @@ public class WebAuthProviderTest {
         MockAuthCallback authCallback = new MockAuthCallback();
 
         WebAuthProvider.login(proxyAccount)
-                .withResponseType(ResponseType.ID_TOKEN)
                 .withIdTokenVerificationIssuer(null)
+                .withPKCE(pkce)
                 .start(activity, authCallback);
 
         OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
@@ -1816,7 +1312,15 @@ public class WebAuthProviderTest {
         jwtBody.put("iss", proxyAccount.getDomainUrl());
         String expectedIdToken = createTestJWT("RS256", jwtBody);
 
-        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, sentState, null, null, null));
+        Intent intent = createAuthIntent(createHash(null, null, null, null, null, sentState, null, null, "1234"));
+        final Credentials codeCredentials = new Credentials(expectedIdToken, "codeAccess", "codeType", "codeRefresh", null, "codeScope");
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                callbackCaptor.getValue().onSuccess(codeCredentials);
+                return null;
+            }
+        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
         assertTrue(WebAuthProvider.resume(intent));
 
         mockAPI.takeRequest();
@@ -1832,6 +1336,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldResumeLoginUsingCustomIDTokenVerificationIssuer() throws Exception {
+        PKCE pkce = Mockito.mock(PKCE.class);
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
 
@@ -1840,8 +1345,8 @@ public class WebAuthProviderTest {
         Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
-                .withResponseType(ResponseType.ID_TOKEN)
                 .withIdTokenVerificationIssuer("https://some.different.issuer/")
+                .withPKCE(pkce)
                 .start(activity, authCallback);
 
         OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
@@ -1861,7 +1366,16 @@ public class WebAuthProviderTest {
         jwtBody.put("iss", "https://some.different.issuer/");
         String expectedIdToken = createTestJWT("RS256", jwtBody);
 
-        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, sentState, null, null, null));
+        Intent intent = createAuthIntent(createHash(null, null, null, null, null, sentState, null, null, "1234"));
+        final Credentials codeCredentials = new Credentials(expectedIdToken, "codeAccess", "codeType", "codeRefresh", null, "codeScope");
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                callbackCaptor.getValue().onSuccess(codeCredentials);
+                return null;
+            }
+        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
+
         assertTrue(WebAuthProvider.resume(intent));
 
         mockAPI.takeRequest();
@@ -1877,6 +1391,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldFailToResumeLoginWithHS256IdTokenAndOIDCConformantConfiguration() throws Exception {
+        PKCE pkce = Mockito.mock(PKCE.class);
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
 
@@ -1887,7 +1402,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
                 .withNonce(EXPECTED_NONCE)
-                .withResponseType(ResponseType.ID_TOKEN | ResponseType.TOKEN)
+                .withPKCE(pkce)
                 .start(activity, authCallback);
 
         OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
@@ -1897,7 +1412,16 @@ public class WebAuthProviderTest {
         jwtBody.put("iss", proxyAccount.getDomainUrl());
         String expectedIdToken = createTestJWT("HS256", jwtBody);
 
-        Intent intent = createAuthIntent(createHash(expectedIdToken, "aToken", null, "urlType", 1111L, "1234567890", null, null, null));
+        final Credentials codeCredentials = new Credentials(expectedIdToken, "codeAccess", "codeType", "codeRefresh", null, "codeScope");
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                callbackCaptor.getValue().onSuccess(codeCredentials);
+                return null;
+            }
+        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
+
+        Intent intent = createAuthIntent(createHash(null, null, null, null, null, "1234567890", null, null, "1234"));
         assertTrue(WebAuthProvider.resume(intent));
         mockAPI.takeRequest();
 
@@ -1915,7 +1439,6 @@ public class WebAuthProviderTest {
     public void shouldFailToResumeLoginWithIntentWithLoginRequired() {
         WebAuthProvider.login(account)
                 .withState("1234567890")
-                .withResponseType(ResponseType.TOKEN)
                 .start(activity, callback);
         Intent intent = createAuthIntent(createHash(null, "aToken", null, "urlType", 1111L, "1234567890", "login_required", "Login Required", null));
         assertTrue(WebAuthProvider.resume(intent));
@@ -1931,7 +1454,6 @@ public class WebAuthProviderTest {
     public void shouldFailToResumeLoginWithRequestCodeWithLoginRequired() {
         WebAuthProvider.login(account)
                 .withState("1234567890")
-                .withResponseType(ResponseType.TOKEN)
                 .start(activity, callback);
         Intent intent = createAuthIntent(createHash(null, "aToken", null, "urlType", 1111L, "1234567890", "login_required", "Login Required", null));
         assertTrue(WebAuthProvider.resume(intent));
@@ -1947,7 +1469,6 @@ public class WebAuthProviderTest {
     public void shouldFailToResumeLoginWithIntentWithInvalidState() {
         WebAuthProvider.login(account)
                 .withState("abcdefghijk")
-                .withResponseType(ResponseType.TOKEN)
                 .start(activity, callback);
         Intent intent = createAuthIntent(createHash(null, "aToken", null, "urlType", 1111L, "1234567890", null, null, null));
         assertTrue(WebAuthProvider.resume(intent));
@@ -1957,78 +1478,11 @@ public class WebAuthProviderTest {
         assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
         assertThat(authExceptionCaptor.getValue().getCode(), is("access_denied"));
         assertThat(authExceptionCaptor.getValue().getDescription(), is("The received state is invalid. Try again."));
-    }
-
-    @Test
-    public void shouldFailToResumeLoginWithRequestCodeWithInvalidState() {
-        WebAuthProvider.login(account)
-                .withState("abcdefghijk")
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-        Intent intent = createAuthIntent(createHash(null, "aToken", null, "urlType", 1111L, "1234567890", null, null, null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        verify(callback).onFailure(authExceptionCaptor.capture());
-
-        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(authExceptionCaptor.getValue().getCode(), is("access_denied"));
-        assertThat(authExceptionCaptor.getValue().getDescription(), is("The received state is invalid. Try again."));
-    }
-
-    @Test
-    public void shouldFailToResumeLoginWithIntentWithInvalidIdTokenWithImplicitGrant() {
-        WebAuthProvider.login(account)
-                .withState("state")
-                .withResponseType(ResponseType.ID_TOKEN)
-                .start(activity, callback);
-        OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
-        managerInstance.setCurrentTimeInMillis(FIXED_CLOCK_CURRENT_TIME_MS);
-
-        Intent intent = createAuthIntent(createHash("not.valid", null, null, null, null, "state", null, null, null));
-        assertTrue(WebAuthProvider.resume(intent));
-
-        verify(callback).onFailure(authExceptionCaptor.capture());
-
-        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(authExceptionCaptor.getValue().getCause(), is(Matchers.<Throwable>instanceOf(TokenValidationException.class)));
-        assertThat(authExceptionCaptor.getValue().getCause().getMessage(), is("ID token could not be decoded"));
-    }
-
-    @Test
-    public void shouldFailToResumeLoginWithIntentWithInvalidIdTokenWithHybridGrant() {
-        Date expiresAt = new Date();
-        PKCE pkce = Mockito.mock(PKCE.class);
-        WebAuthProvider.login(account)
-                .withResponseType(ResponseType.TOKEN | ResponseType.CODE)
-                .withState("state")
-                .withPKCE(pkce)
-                .start(activity, callback);
-        OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
-        managerInstance.setCurrentTimeInMillis(FIXED_CLOCK_CURRENT_TIME_MS);
-
-        verify(activity).startActivity(intentCaptor.capture());
-
-        Intent intent = createAuthIntent(createHash(null, "urlAccess", null, null, null, "state", null, null, "1234"));
-        final Credentials codeCredentials = new Credentials("not.valid", "codeAccess", "codeType", "codeRefresh", expiresAt, "codeScope");
-        Mockito.doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) {
-                callbackCaptor.getValue().onSuccess(codeCredentials);
-                return null;
-            }
-        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
-
-        assertTrue(WebAuthProvider.resume(intent));
-
-        verify(callback).onFailure(authExceptionCaptor.capture());
-
-        assertThat(authExceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(authExceptionCaptor.getValue().getCause(), is(Matchers.<Throwable>instanceOf(TokenValidationException.class)));
-        assertThat(authExceptionCaptor.getValue().getCause().getMessage(), is("ID token could not be decoded"));
     }
 
     @Test
     public void shouldFailToResumeLoginWithIntentWithInvalidMaxAge() throws Exception {
+        PKCE pkce = Mockito.mock(PKCE.class);
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
 
@@ -2041,7 +1495,7 @@ public class WebAuthProviderTest {
                 .withNonce(EXPECTED_NONCE)
                 .withIdTokenVerificationLeeway(0)
                 .withMaxAge(5) //5 secs
-                .withResponseType(ResponseType.ID_TOKEN)
+                .withPKCE(pkce)
                 .start(activity, authCallback);
 
         OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
@@ -2055,7 +1509,18 @@ public class WebAuthProviderTest {
         jwtBody.put("iss", proxyAccount.getDomainUrl());
         String expectedIdToken = createTestJWT("RS256", jwtBody);
 
-        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, "state", null, null, null));
+        Intent intent = createAuthIntent(createHash(null, null, null, null, null, "state", null, null, "1234"));
+
+        final Credentials codeCredentials = new Credentials(expectedIdToken, "codeAccess", "codeType", "codeRefresh", null, "codeScope");
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                callbackCaptor.getValue().onSuccess(codeCredentials);
+                return null;
+            }
+        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
+
+
         assertTrue(WebAuthProvider.resume(intent));
 
         mockAPI.takeRequest();
@@ -2070,6 +1535,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldFailToResumeLoginWithIntentWithInvalidNonce() throws Exception {
+        PKCE pkce = Mockito.mock(PKCE.class);
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
 
@@ -2080,7 +1546,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.login(proxyAccount)
                 .withState("state")
                 .withNonce("0987654321")
-                .withResponseType(ResponseType.ID_TOKEN)
+                .withPKCE(pkce)
                 .start(activity, authCallback);
 
         OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
@@ -2090,44 +1556,16 @@ public class WebAuthProviderTest {
         jwtBody.put("iss", proxyAccount.getDomainUrl());
         String expectedIdToken = createTestJWT("RS256", jwtBody);
 
-        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, "state", null, null, null));
-        assertTrue(WebAuthProvider.resume(intent));
+        Intent intent = createAuthIntent(createHash(null, null, null, null, null, "state", null, null, "1234"));
+        final Credentials codeCredentials = new Credentials(expectedIdToken, "codeAccess", "codeType", "codeRefresh", null, "codeScope");
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                callbackCaptor.getValue().onSuccess(codeCredentials);
+                return null;
+            }
+        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
 
-        mockAPI.takeRequest();
-
-        assertThat(authCallback, AuthCallbackMatcher.hasError());
-
-        AuthenticationException error = authCallback.getError();
-        assertThat(error, is(notNullValue()));
-        assertThat(error.getCause(), is(Matchers.<Throwable>instanceOf(TokenValidationException.class)));
-        assertThat(error.getCause().getMessage(), is("Nonce (nonce) claim mismatch in the ID token; expected \"0987654321\", found \"" + EXPECTED_NONCE + "\""));
-
-        mockAPI.shutdown();
-    }
-
-    @Test
-    public void shouldFailToResumeLoginWithRequestCodeWithInvalidNonce() throws Exception {
-        AuthenticationAPI mockAPI = new AuthenticationAPI();
-        mockAPI.willReturnValidJsonWebKeys();
-
-        MockAuthCallback authCallback = new MockAuthCallback();
-
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
-
-        WebAuthProvider.login(proxyAccount)
-                .withState("state")
-                .withNonce("0987654321")
-                .withResponseType(ResponseType.ID_TOKEN)
-                .start(activity, authCallback);
-
-        OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
-        managerInstance.setCurrentTimeInMillis(FIXED_CLOCK_CURRENT_TIME_MS);
-
-        Map<String, Object> jwtBody = createJWTBody();
-        jwtBody.put("iss", proxyAccount.getDomainUrl());
-        String expectedIdToken = createTestJWT("RS256", jwtBody);
-
-        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, "state", null, null, null));
         assertTrue(WebAuthProvider.resume(intent));
 
         mockAPI.takeRequest();
@@ -2144,6 +1582,7 @@ public class WebAuthProviderTest {
 
     @Test
     public void shouldFailToResumeLoginWithNotSupportedSigningAlgorithm() throws Exception {
+        PKCE pkce = Mockito.mock(PKCE.class);
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
 
@@ -2153,7 +1592,7 @@ public class WebAuthProviderTest {
         WebAuthProvider.login(proxyAccount)
                 .withState("state")
                 .withNonce(EXPECTED_NONCE)
-                .withResponseType(ResponseType.ID_TOKEN)
+                .withPKCE(pkce)
                 .start(activity, callback);
 
         OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
@@ -2163,7 +1602,16 @@ public class WebAuthProviderTest {
         jwtBody.put("iss", proxyAccount.getDomainUrl());
         String expectedIdToken = createTestJWT("none", jwtBody);
 
-        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, "state", null, null, null));
+        Intent intent = createAuthIntent(createHash(null, null, null, null, null, "state", null, null, "1234"));
+        final Credentials codeCredentials = new Credentials(expectedIdToken, "codeAccess", "codeType", "codeRefresh", null, "codeScope");
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                callbackCaptor.getValue().onSuccess(codeCredentials);
+                return null;
+            }
+        }).when(pkce).getToken(eq("1234"), callbackCaptor.capture());
+
         assertTrue(WebAuthProvider.resume(intent));
 
         assertThat(callback, AuthCallbackMatcher.hasError());
@@ -2181,19 +1629,6 @@ public class WebAuthProviderTest {
         verifyNoMoreInteractions(callback);
         WebAuthProvider.login(account)
                 .withState("abcdefghijk")
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-
-        Intent intent = createAuthIntent("");
-        assertFalse(WebAuthProvider.resume(intent));
-    }
-
-    @Test
-    public void shouldFailToResumeLoginWithRequestCodeWithEmptyUriValues() {
-        verifyNoMoreInteractions(callback);
-        WebAuthProvider.login(account)
-                .withState("abcdefghijk")
-                .withResponseType(ResponseType.TOKEN)
                 .start(activity, callback);
 
         Intent intent = createAuthIntent("");
@@ -2212,16 +1647,6 @@ public class WebAuthProviderTest {
     public void shouldResumeLoginWithIntentWithNullIntent() {
         WebAuthProvider.login(account)
                 .withState("abcdefghijk")
-                .withResponseType(ResponseType.TOKEN)
-                .start(activity, callback);
-        assertFalse(WebAuthProvider.resume(null));
-    }
-
-    @Test
-    public void shouldFailToResumeLoginWithRequestCodeWithNullIntent() {
-        WebAuthProvider.login(account)
-                .withState("abcdefghijk")
-                .withResponseType(ResponseType.TOKEN)
                 .start(activity, callback);
         assertFalse(WebAuthProvider.resume(null));
     }


### PR DESCRIPTION
### Changes

This change removes the ability to use the `WebAuthProvider` to authenticate using any flow other than Authorization Code + PKCE. 

**Removed (public) methods:**

- `WebAuthProvider.Builder#withResponseType(@ResponseType int type)` has been removed, as the `code` response type will be now be supported.

Logic that handled non-code response type processing has been removed. Tests were either removed where there was already coverage for the code response type in place, and updated where there was not.

### Testing

In addition to updating unit tests to accommodate this change, I verified successful login using the sample app with these changes.

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
