### PR TITLE
Deprecate Legacy Authentication APIs

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -306,8 +306,15 @@ public class AuthenticationAPIClient {
      * @param token      obtained from the IdP
      * @param connection that will be used to authenticate the user, e.g. 'facebook'
      * @return a request to configure and start that will yield {@link Credentials}
+     * @deprecated The ability to exchange a third-party provider access token for Auth0 access tokens
+     *             is part of the [/oauth/access_token](https://auth0.com/docs/api/authentication#social-with-provider-s-access-token)
+     *             Authentication API legacy endpoint, disabled as of June 2017. For selected social providers,
+     *             there's support for a similar token exchange using the ["Native Social" token exchange](https://auth0.com/docs/api/authentication#token-exchange-for-native-social)
+     *             endpoint, using {@linkplain AuthenticationAPIClient#loginWithNativeSocialToken(String, String)}
+     *             instead.
      */
     @NonNull
+    @Deprecated
     public AuthRequest loginWithOAuthAccessToken(@NonNull String token, @NonNull String connection) {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(OAUTH_PATH)
@@ -839,8 +846,11 @@ public class AuthenticationAPIClient {
      *
      * @param idToken issued by Auth0 for the user. The token must not be expired.
      * @return a request to configure and start
+     * @deprecated The {@code /delegation} endpoint of the Auth0 Authorization API has been deprecated.
+     *             This method will be removed in version 2 of this SDK.
      */
     @NonNull
+    @Deprecated
     public DelegationRequest<Delegation> delegationWithIdToken(@NonNull String idToken) {
         ParameterizableRequest<Delegation, AuthenticationException> request = delegation(Delegation.class)
                 .addParameter(ParameterBuilder.ID_TOKEN_KEY, idToken);
@@ -868,8 +878,11 @@ public class AuthenticationAPIClient {
      *
      * @param refreshToken issued by Auth0 for the user when using the 'offline_access' scope when logging in.
      * @return a request to configure and start
+     * @deprecated The {@code /delegation} endpoint of the Auth0 Authorization API has been deprecated.
+     *             This method will be removed in version 2 of this SDK.
      */
     @NonNull
+    @Deprecated
     public DelegationRequest<Delegation> delegationWithRefreshToken(@NonNull String refreshToken) {
         ParameterizableRequest<Delegation, AuthenticationException> request = delegation(Delegation.class)
                 .addParameter(ParameterBuilder.REFRESH_TOKEN_KEY, refreshToken);
@@ -897,8 +910,11 @@ public class AuthenticationAPIClient {
      * @param idToken issued by Auth0 for the user. The token must not be expired.
      * @param apiType the delegation 'api_type' parameter
      * @return a request to configure and start
+     * @deprecated The {@code /delegation} endpoint of the Auth0 Authorization API has been deprecated.
+     *             This method will be removed in version 2 of this SDK.
      */
     @NonNull
+    @Deprecated
     public DelegationRequest<Map<String, Object>> delegationWithIdToken(@NonNull String idToken, @NonNull String apiType) {
         ParameterizableRequest<Map<String, Object>, AuthenticationException> request = delegation()
                 .addParameter(ParameterBuilder.ID_TOKEN_KEY, idToken);
@@ -1052,8 +1068,11 @@ public class AuthenticationAPIClient {
      * </pre>
      *
      * @return a request to configure and start
+     * @deprecated The {@code /delegation} endpoint of the Auth0 Authorization API has been deprecated.
+     *             This method will be removed in version 2 of this SDK.
      */
     @NonNull
+    @Deprecated
     public ParameterizableRequest<Map<String, Object>, AuthenticationException> delegation() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment(DELEGATION_PATH)

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -307,9 +307,9 @@ public class AuthenticationAPIClient {
      * @param connection that will be used to authenticate the user, e.g. 'facebook'
      * @return a request to configure and start that will yield {@link Credentials}
      * @deprecated The ability to exchange a third-party provider access token for Auth0 access tokens
-     *             is part of the [/oauth/access_token](https://auth0.com/docs/api/authentication#social-with-provider-s-access-token)
+     *             is part of the <a href="https://auth0.com/docs/api/authentication#social-with-provider-s-access-token">/oauth/access_token</a>
      *             Authentication API legacy endpoint, disabled as of June 2017. For selected social providers,
-     *             there's support for a similar token exchange using the ["Native Social" token exchange](https://auth0.com/docs/api/authentication#token-exchange-for-native-social)
+     *             there's support for a similar token exchange using the <a href="https://auth0.com/docs/api/authentication#token-exchange-for-native-social">Native Social token exchange</a>
      *             endpoint, using {@linkplain AuthenticationAPIClient#loginWithNativeSocialToken(String, String)}
      *             instead.
      */

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
@@ -54,7 +54,14 @@ public class ParameterBuilder {
     public static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
     public static final String GRANT_TYPE_PASSWORD = "password";
     public static final String GRANT_TYPE_PASSWORD_REALM = "http://auth0.com/oauth/grant-type/password-realm";
+
+    /**
+     * @deprecated The {@code urn:ietf:params:oauth:grant-type:jwt-bearer} grant type is for use with legacy Authentication
+     * APIs. This constant will be removed in version 2 of this SDK.
+     */
+    @Deprecated
     public static final String GRANT_TYPE_JWT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
     public static final String GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code";
     public static final String GRANT_TYPE_MFA_OTP = "http://auth0.com/oauth/grant-type/mfa-otp";
     public static final String GRANT_TYPE_PASSWORDLESS_OTP = "http://auth0.com/oauth/grant-type/passwordless/otp";
@@ -63,11 +70,22 @@ public class ParameterBuilder {
     public static final String SCOPE_OPENID = "openid";
     public static final String SCOPE_OFFLINE_ACCESS = "openid offline_access";
 
+    /**
+     * @deprecated The {@code id_token} parameter is only used when making requests to the legacy
+     * Authentication APIs. This constant will be removed in version 2 of this SDK.
+     */
+    @Deprecated
     public static final String ID_TOKEN_KEY = "id_token";
     public static final String SCOPE_KEY = "scope";
     public static final String REFRESH_TOKEN_KEY = "refresh_token";
     public static final String CONNECTION_KEY = "connection";
     public static final String REALM_KEY = "realm";
+
+    /**
+     * @deprecated The {@code access_token} parameter is only used when making requests to the legacy
+     * Authentication APIs. This constant will be removed in version 2 of this SDK.
+     */
+    @Deprecated
     public static final String ACCESS_TOKEN_KEY = "access_token";
     public static final String SEND_KEY = "send";
     public static final String CLIENT_ID_KEY = "client_id";
@@ -153,8 +171,11 @@ public class ParameterBuilder {
      *
      * @param device a device name
      * @return itself
+     *
+     * @deprecated TODO
      */
     @NonNull
+    @Deprecated
     public ParameterBuilder setDevice(@NonNull String device) {
         return set(DEVICE_KEY, device);
     }

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
@@ -164,8 +164,13 @@ public class ParameterBuilder {
      *
      * @param accessToken a access token
      * @return itself
+     *
+     * @deprecated This method sets the token on the request made to the [/oauth/access_token](https://auth0.com/docs/api/authentication#social-with-provider-s-access-token)
+     * Authentication API legacy endpoint, disabled as of June 2017. This method will be removed in
+     * version 2 of this SDK
      */
     @NonNull
+    @Deprecated
     public ParameterBuilder setAccessToken(@NonNull String accessToken) {
         return set(ACCESS_TOKEN_KEY, accessToken);
     }

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.java
@@ -72,7 +72,8 @@ public class ParameterBuilder {
 
     /**
      * @deprecated The {@code id_token} parameter is only used when making requests to the legacy
-     * Authentication APIs. This constant will be removed in version 2 of this SDK.
+     * <a href="https://auth0.com/docs/api/authentication#database-ad-ldap-active-">/oauth/ro</a> endpoint.
+     * This constant will be removed in version 2 of this SDK.
      */
     @Deprecated
     public static final String ID_TOKEN_KEY = "id_token";
@@ -90,6 +91,12 @@ public class ParameterBuilder {
     public static final String SEND_KEY = "send";
     public static final String CLIENT_ID_KEY = "client_id";
     public static final String GRANT_TYPE_KEY = "grant_type";
+
+    /**
+     * @deprecated The {@code device} parameter is only used when making requests to the legacy
+     * Authentication APIs. This constant will be removed in version 2 of this SDK.
+     */
+    @Deprecated
     public static final String DEVICE_KEY = "device";
     public static final String AUDIENCE_KEY = "audience";
 
@@ -172,7 +179,8 @@ public class ParameterBuilder {
      * @param device a device name
      * @return itself
      *
-     * @deprecated TODO
+     * @deprecated The {@code device} parameter is used in calls to the <a href="https://auth0.com/docs/api/authentication#database-ad-ldap-active-">/oauth/ro</a>
+     * Authentication API legacy endpoint. This method will be removed in version 2 of this SDK.
      */
     @NonNull
     @Deprecated
@@ -186,7 +194,7 @@ public class ParameterBuilder {
      * @param accessToken a access token
      * @return itself
      *
-     * @deprecated This method sets the token on the request made to the [/oauth/access_token](https://auth0.com/docs/api/authentication#social-with-provider-s-access-token)
+     * @deprecated This method sets the token on the request made to the <a href="https://auth0.com/docs/api/authentication#social-with-provider-s-access-token">/oauth/access_token</a>
      * Authentication API legacy endpoint, disabled as of June 2017. This method will be removed in
      * version 2 of this SDK
      */

--- a/auth0/src/main/java/com/auth0/android/authentication/request/DelegationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/DelegationRequest.java
@@ -43,7 +43,10 @@ import java.util.Map;
  * @param <T> type of object that will hold the delegation response. When requesting Auth0's 'id_token' you can
  *            use {@link Delegation}, otherwise you'll need to provide an object that can be created from the JSON
  *            payload or just use {@code Map<String, Object>}
+ * @deprecated The {@code /delegation} endpoint has been deprecated. This class and any methods that
+ *             make use of the {@code /delegation} endpoint will be removed in version 2 of this SDK.
  */
+@Deprecated
 public class DelegationRequest<T> implements Request<T, AuthenticationException> {
 
     private static final String API_TYPE_KEY = "api_type";

--- a/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.java
@@ -160,6 +160,7 @@ public class SignUpRequest implements Request<Credentials, AuthenticationExcepti
 
     @NonNull
     @Override
+    @Deprecated
     public SignUpRequest setAccessToken(@NonNull String accessToken) {
         getAuthRequest().setAccessToken(accessToken);
         return this;

--- a/auth0/src/main/java/com/auth0/android/request/AuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/AuthenticationRequest.java
@@ -72,7 +72,7 @@ public interface AuthenticationRequest extends Request<Credentials, Authenticati
      * @param accessToken a access token
      * @return itself
      *
-     * @deprecated This method sets the token on the request made to the [/oauth/access_token](https://auth0.com/docs/api/authentication#social-with-provider-s-access-token)
+     * @deprecated This method sets the token on the request made to the <a href="https://auth0.com/docs/api/authentication#social-with-provider-s-access-token">/oauth/access_token</a>
      * Authentication API legacy endpoint, disabled as of June 2017. This method will be removed in
      * version 2 of this SDK
      */

--- a/auth0/src/main/java/com/auth0/android/request/AuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/AuthenticationRequest.java
@@ -71,8 +71,13 @@ public interface AuthenticationRequest extends Request<Credentials, Authenticati
      *
      * @param accessToken a access token
      * @return itself
+     *
+     * @deprecated This method sets the token on the request made to the [/oauth/access_token](https://auth0.com/docs/api/authentication#social-with-provider-s-access-token)
+     * Authentication API legacy endpoint, disabled as of June 2017. This method will be removed in
+     * version 2 of this SDK
      */
     @NonNull
+    @Deprecated
     AuthenticationRequest setAccessToken(@NonNull String accessToken);
 
     /**

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
@@ -123,7 +123,7 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
      * @param accessToken a access token
      * @return itself
      *
-     * @deprecated This method sets the token on the request made to the <a href="/oauth/access_token">https://auth0.com/docs/api/authentication#social-with-provider-s-access-token</a>
+     * @deprecated This method sets the token on the request made to the <a href="https://auth0.com/docs/api/authentication#social-with-provider-s-access-token">/oauth/access_token</a>
      * Authentication API legacy endpoint, disabled as of June 2017. This method will be removed in
      * version 2 of this SDK
      */

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
@@ -122,8 +122,13 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
      *
      * @param accessToken a access token
      * @return itself
+     *
+     * @deprecated This method sets the token on the request made to the [/oauth/access_token](https://auth0.com/docs/api/authentication#social-with-provider-s-access-token)
+     * Authentication API legacy endpoint, disabled as of June 2017. This method will be removed in
+     * version 2 of this SDK
      */
     @NonNull
+    @Deprecated
     public AuthRequest setAccessToken(@NonNull String accessToken) {
         addParameter(ACCESS_TOKEN_KEY, accessToken);
         return this;

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.java
@@ -123,7 +123,7 @@ class BaseAuthenticationRequest extends SimpleRequest<Credentials, Authenticatio
      * @param accessToken a access token
      * @return itself
      *
-     * @deprecated This method sets the token on the request made to the [/oauth/access_token](https://auth0.com/docs/api/authentication#social-with-provider-s-access-token)
+     * @deprecated This method sets the token on the request made to the <a href="/oauth/access_token">https://auth0.com/docs/api/authentication#social-with-provider-s-access-token</a>
      * Authentication API legacy endpoint, disabled as of June 2017. This method will be removed in
      * version 2 of this SDK
      */

--- a/auth0/src/main/java/com/auth0/android/result/Delegation.java
+++ b/auth0/src/main/java/com/auth0/android/result/Delegation.java
@@ -32,7 +32,10 @@ import com.google.gson.annotations.SerializedName;
 /**
  * The result of a successful delegation to an Auth0 application that contains a new Auth0 'id_token'
  * See <a href="https://auth0.com/docs/api/authentication#delegation">delegation</a> docs
+ * @deprecated The {@code /delegation} endpoint has been deprecated. This class and any methods that
+ *             make use of the {@code /delegation} endpoint will be removed in version 2 of this SDK.
  */
+@Deprecated
 public class Delegation {
     @SerializedName("id_token")
     private final String idToken;


### PR DESCRIPTION
### Changes

Deprecates methods and classes associated with the legacy Auth0 Authentication APIs.

**Classes deprecated:**
- `Delegation`
- `DelegationRequest`

**Methods deprecated:**
- `AuthenticationAPIClient#loginWithOAuthAccessToken(@NonNull String token, @NonNull String connection)`
- `AuthenticationAPIClient#delegationWithIdToken(@NonNull String idToken)`
- `AuthenticationAPIClient#delegationWithRefreshToken(@NonNull String refreshToken)`
- `AuthenticationAPIClient#delegationWithIdToken(@NonNull String idToken, @NonNull String apiType)`
- `AuthenticationAPIClient#delegation()`
- `ParameterBuilder#setAccessToken(@NonNull String accessToken)`
- `SignupRequest#setAccessToken(@NonNull String accessToken)`
- `AuthenticationRequest#setAccessToken(@NonNull String accessToken)`
- `BaseAuthenticationRequest#setAccessToken(@NonNull String accessToken)`

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
