### PR TITLE
Deprecate AuthorizableRequest

### DIFF
--- a/auth0/src/main/java/com/auth0/android/request/AuthorizableRequest.java
+++ b/auth0/src/main/java/com/auth0/android/request/AuthorizableRequest.java
@@ -33,7 +33,11 @@ import com.auth0.android.Auth0Exception;
  *
  * @param <T> the type this request will return on success.
  * @param <U> the {@link Auth0Exception} type this request will return on failure.
+ *
+ * @deprecated This interface will be removed in version 2 of this SDK. Use {@linkplain ParameterizableRequest}
+ * instead.
  */
+@Deprecated
 public interface AuthorizableRequest<T, U extends Auth0Exception> extends ParameterizableRequest<T, U> {
 
     /**
@@ -41,8 +45,12 @@ public interface AuthorizableRequest<T, U extends Auth0Exception> extends Parame
      *
      * @param jwt token to send to the API
      * @return itself
+     *
+     * @deprecated This interface will be removed in version 2 of this SDK.
+     * Use {@linkplain ParameterizableRequest#addHeader(String, String)} instead.
      */
     @NonNull
+    @Deprecated
     AuthorizableRequest<T, U> setBearer(@NonNull String jwt);
 
 }


### PR DESCRIPTION
### Changes

The `AuthorizableRequest` interface exposes one method, `setBearer`, which is not used. As it extends `ParameterizableRequest`, which allows setting a header, that can be used instead.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
