### PR TITLE
Deprecate API client constructors that take Context

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -129,7 +129,9 @@ public class AuthenticationAPIClient {
      * defined in the project String resources file.
      *
      * @param context a valid Context
+     * @deprecated This method will be removed in the next version. Please use {@link AuthenticationAPIClient(Auth0)}.
      */
+    @Deprecated
     public AuthenticationAPIClient(@NonNull Context context) {
         this(new Auth0(context));
     }

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
@@ -91,7 +91,9 @@ public class UsersAPIClient {
      *
      * @param context a valid Context
      * @param token   of the primary identity
+     * @deprecated This method will be removed in the next version. Please use {@link UsersAPIClient(Auth0, String)}.
      */
+    @Deprecated
     public UsersAPIClient(@NonNull Context context, @NonNull String token) {
         this(new Auth0(context), token);
     }


### PR DESCRIPTION
The constructors that take a Context are going to be removed in the next version of this SDK. If you have were using them to pass the account, you can achieve the same result with the following code:

```diff
-AuthenticationAPIClient client = new AuthenticationAPIClient(this);
+AuthenticationAPIClient client = new AuthenticationAPIClient(new Auth0(this));
```

```diff
-UsersAPIClient client = new UsersAPIClient(this, "token");
+UsersAPIClient client = new UsersAPIClient(new Auth0(this), "token");
```



The README is already making use of the Auth0 constructors in the guidance.