### PR TITLE
Rename Telemetry class and its usage

### DIFF
--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -58,6 +58,7 @@ Additionally, any classes that implemented `ParameterizableRequest` or `AuthRequ
 - The `com.auth0.android.provider.WebAuthActivity` class has been removed. External browser applications will always be used for authentication.
 - The `com.auth0.android.result.Delegation` class has been removed. This was used as the result of the request to the [/delegation](https://auth0.com/docs/api/authentication#delegation) Authentication API legacy endpoint, disabled as of June 2017.
 - The `com.auth0.android.authentication.request.DelegationRequest` class has been removed. This was used to represent the request to the legacy Authentication API [/delegation](https://auth0.com/docs/api/authentication#delegation) endpoint, disabled as of June 2017.
+- The `com.auth0.android.util.Telemetry` class has been renamed to `com.auth0.android.util.Auth0UserAgent`.
 - The `com.auth0.android.request.AuthorizableRequest` class has been removed. You can achieve the same result using the method in Request: `Request#addHeader("Authorization", "Bearer TOKEN_VALUE")`.
 
 ### Class changes

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -183,7 +183,7 @@ public class Auth0 {
      * Setter for the user agent info to send in every request to Auth0.
      *
      * @param auth0UserAgent to send in every request to Auth0.
-     * @see #doNotSendTelemetry()
+     * @see #doNotSendAuth0UserAgent()
      */
     public void setAuth0UserAgent(@Nullable Auth0UserAgent auth0UserAgent) {
         this.auth0UserAgent = auth0UserAgent;
@@ -193,7 +193,7 @@ public class Auth0 {
      * Avoid sending any user agent info in every request to Auth0
      */
     // TODO - this should be removed
-    public void doNotSendTelemetry() {
+    public void doNotSendAuth0UserAgent() {
         this.auth0UserAgent = null;
     }
 

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -31,7 +31,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.auth0.android.auth0.BuildConfig;
-import com.auth0.android.util.Telemetry;
+import com.auth0.android.util.Auth0UserAgent;
 import com.squareup.okhttp.HttpUrl;
 
 /**
@@ -52,7 +52,7 @@ public class Auth0 {
     private final String clientId;
     private final HttpUrl domainUrl;
     private final HttpUrl configurationUrl;
-    private Telemetry telemetry;
+    private Auth0UserAgent auth0UserAgent;
     private boolean loggingEnabled;
     private boolean tls12Enforced;
     private int connectTimeoutInSeconds;
@@ -96,7 +96,7 @@ public class Auth0 {
             throw new IllegalArgumentException(String.format("Invalid domain url: '%s'", domain));
         }
         this.configurationUrl = resolveConfiguration(configurationDomain, this.domainUrl);
-        this.telemetry = new Telemetry(BuildConfig.LIBRARY_NAME, BuildConfig.VERSION_NAME);
+        this.auth0UserAgent = new Auth0UserAgent(BuildConfig.LIBRARY_NAME, BuildConfig.VERSION_NAME);
     }
 
     /**
@@ -151,11 +151,11 @@ public class Auth0 {
     }
 
     /**
-     * @return Auth0 telemetry info sent in every request
+     * @return Auth0 user agent info sent in every request
      */
     @Nullable
-    public Telemetry getTelemetry() {
-        return telemetry;
+    public Auth0UserAgent getAuth0UserAgent() {
+        return auth0UserAgent;
     }
 
     /**
@@ -180,20 +180,21 @@ public class Auth0 {
     }
 
     /**
-     * Setter for the Telemetry to send in every request to Auth0.
+     * Setter for the user agent info to send in every request to Auth0.
      *
-     * @param telemetry to send in every request to Auth0.
+     * @param auth0UserAgent to send in every request to Auth0.
      * @see #doNotSendTelemetry()
      */
-    public void setTelemetry(@Nullable Telemetry telemetry) {
-        this.telemetry = telemetry;
+    public void setAuth0UserAgent(@Nullable Auth0UserAgent auth0UserAgent) {
+        this.auth0UserAgent = auth0UserAgent;
     }
 
     /**
-     * Avoid sending telemetry in every request to Auth0
+     * Avoid sending any user agent info in every request to Auth0
      */
+    // TODO - this should be removed
     public void doNotSendTelemetry() {
-        this.telemetry = null;
+        this.auth0UserAgent = null;
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -45,7 +45,7 @@ import com.auth0.android.request.internal.RequestFactory;
 import com.auth0.android.result.Credentials;
 import com.auth0.android.result.DatabaseUser;
 import com.auth0.android.result.UserProfile;
-import com.auth0.android.util.Telemetry;
+import com.auth0.android.util.Auth0UserAgent;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.HttpUrl;
@@ -141,9 +141,9 @@ public class AuthenticationAPIClient {
         this.gson = gson;
         this.factory = factory;
         this.authErrorBuilder = new AuthenticationErrorBuilder();
-        final Telemetry telemetry = auth0.getTelemetry();
-        if (telemetry != null) {
-            factory.setClientInfo(telemetry.getValue());
+        final Auth0UserAgent auth0UserAgent = auth0.getAuth0UserAgent();
+        if (auth0UserAgent != null) {
+            factory.setClientInfo(auth0UserAgent.getValue());
         }
     }
 

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
@@ -40,7 +40,7 @@ import com.auth0.android.request.internal.OkHttpClientFactory;
 import com.auth0.android.request.internal.RequestFactory;
 import com.auth0.android.result.UserIdentity;
 import com.auth0.android.result.UserProfile;
-import com.auth0.android.util.Telemetry;
+import com.auth0.android.util.Auth0UserAgent;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.HttpUrl;
@@ -112,9 +112,9 @@ public class UsersAPIClient {
         this.gson = gson;
         this.factory = factory;
         this.mgmtErrorBuilder = new ManagementErrorBuilder();
-        final Telemetry telemetry = auth0.getTelemetry();
-        if (telemetry != null) {
-            factory.setClientInfo(telemetry.getValue());
+        final Auth0UserAgent auth0UserAgent = auth0.getAuth0UserAgent();
+        if (auth0UserAgent != null) {
+            factory.setClientInfo(auth0UserAgent.getValue());
         }
     }
 

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.java
@@ -2,8 +2,9 @@ package com.auth0.android.provider;
 
 import android.content.Context;
 import android.net.Uri;
-import androidx.annotation.NonNull;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.Auth0Exception;
@@ -17,7 +18,7 @@ class LogoutManager extends ResumableManager {
     private static final String TAG = LogoutManager.class.getSimpleName();
 
     private static final String KEY_CLIENT_ID = "client_id";
-    private static final String KEY_TELEMETRY = "auth0Client";
+    private static final String KEY_USER_AGENT = "auth0Client";
     private static final String KEY_RETURN_TO_URL = "returnTo";
 
     private final Auth0 account;
@@ -64,8 +65,8 @@ class LogoutManager extends ResumableManager {
     }
 
     private void addClientParameters(Map<String, String> parameters) {
-        if (account.getTelemetry() != null) {
-            parameters.put(KEY_TELEMETRY, account.getTelemetry().getValue());
+        if (account.getAuth0UserAgent() != null) {
+            parameters.put(KEY_USER_AGENT, account.getAuth0UserAgent().getValue());
         }
         parameters.put(KEY_CLIENT_ID, account.getClientId());
     }

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -47,7 +47,7 @@ class OAuthManager extends ResumableManager {
     private static final String KEY_CODE_CHALLENGE_METHOD = "code_challenge_method";
     private static final String KEY_CLIENT_ID = "client_id";
     private static final String KEY_REDIRECT_URI = "redirect_uri";
-    private static final String KEY_TELEMETRY = "auth0Client";
+    private static final String KEY_USER_AGENT = "auth0Client";
     private static final String KEY_ERROR = "error";
     private static final String KEY_ERROR_DESCRIPTION = "error_description";
     private static final String KEY_CODE = "code";
@@ -258,8 +258,8 @@ class OAuthManager extends ResumableManager {
     }
 
     private void addClientParameters(Map<String, String> parameters, String redirectUri) {
-        if (account.getTelemetry() != null) {
-            parameters.put(KEY_TELEMETRY, account.getTelemetry().getValue());
+        if (account.getAuth0UserAgent() != null) {
+            parameters.put(KEY_USER_AGENT, account.getAuth0UserAgent().getValue());
         }
         parameters.put(KEY_CLIENT_ID, account.getClientId());
         parameters.put(KEY_REDIRECT_URI, redirectUri);

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
@@ -30,7 +30,7 @@ import com.auth0.android.Auth0Exception;
 import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.request.ErrorBuilder;
 import com.auth0.android.request.Request;
-import com.auth0.android.util.Telemetry;
+import com.auth0.android.util.Auth0UserAgent;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.HttpUrl;
@@ -47,7 +47,7 @@ public class RequestFactory {
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String USER_AGENT_HEADER = "User-Agent";
     private static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
-    private static final String CLIENT_INFO_HEADER = Telemetry.HEADER_NAME;
+    private static final String CLIENT_INFO_HEADER = Auth0UserAgent.HEADER_NAME;
 
     private final HashMap<String, String> headers;
 

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.java
@@ -47,7 +47,7 @@ public class RequestFactory {
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String USER_AGENT_HEADER = "User-Agent";
     private static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
-    private static final String CLIENT_INFO_HEADER = Auth0UserAgent.HEADER_NAME;
+    private static final String AUTH0_USER_AGENT_HEADER = Auth0UserAgent.HEADER_NAME;
 
     private final HashMap<String, String> headers;
 
@@ -62,7 +62,7 @@ public class RequestFactory {
     }
 
     public void setClientInfo(@NonNull String clientInfo) {
-        headers.put(CLIENT_INFO_HEADER, clientInfo);
+        headers.put(AUTH0_USER_AGENT_HEADER, clientInfo);
     }
 
     public void setUserAgent(@NonNull String userAgent) {

--- a/auth0/src/main/java/com/auth0/android/util/Auth0UserAgent.java
+++ b/auth0/src/main/java/com/auth0/android/util/Auth0UserAgent.java
@@ -1,10 +1,11 @@
 package com.auth0.android.util;
 
+import android.text.TextUtils;
+import android.util.Base64;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import android.text.TextUtils;
-import android.util.Base64;
 
 import com.google.gson.Gson;
 
@@ -13,8 +14,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-
-public class Telemetry {
+/**
+ * Responsible for building the custom user agent header data sent on requests to Auth0.
+ */
+public class Auth0UserAgent {
     public static final String HEADER_NAME = "Auth0-Client";
 
     private static final String NAME_KEY = "name";
@@ -28,11 +31,11 @@ public class Telemetry {
     private final Map<String, String> env;
     private final String value;
 
-    public Telemetry(@NonNull String name, @NonNull String version) {
+    public Auth0UserAgent(@NonNull String name, @NonNull String version) {
         this(name, version, null);
     }
 
-    public Telemetry(@NonNull String name, @NonNull String version, @Nullable String libraryVersion) {
+    public Auth0UserAgent(@NonNull String name, @NonNull String version, @Nullable String libraryVersion) {
         this.name = name;
         this.version = version;
         if (TextUtils.isEmpty(name)) {

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -262,7 +262,7 @@ public class Auth0Test {
     @Test
     public void shouldNotReturnTelemetryWhenExplicitlyDisabledThem() {
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.doNotSendTelemetry();
+        auth0.doNotSendAuth0UserAgent();
         assertThat(auth0.getAuth0UserAgent(), is(nullValue()));
     }
 

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -27,7 +27,7 @@ package com.auth0.android;
 import android.content.Context;
 import android.content.res.Resources;
 
-import com.auth0.android.util.Telemetry;
+import com.auth0.android.util.Auth0UserAgent;
 import com.squareup.okhttp.HttpUrl;
 
 import org.junit.Before;
@@ -263,14 +263,14 @@ public class Auth0Test {
     public void shouldNotReturnTelemetryWhenExplicitlyDisabledThem() {
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
         auth0.doNotSendTelemetry();
-        assertThat(auth0.getTelemetry(), is(nullValue()));
+        assertThat(auth0.getAuth0UserAgent(), is(nullValue()));
     }
 
     @Test
     public void shouldSetCustomTelemetry() {
-        Telemetry customTelemetry = new Telemetry("custom", "9.9.9", "1.1.1");
+        Auth0UserAgent customAuth0UserAgent = new Auth0UserAgent("custom", "9.9.9", "1.1.1");
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.setTelemetry(customTelemetry);
-        assertThat(auth0.getTelemetry(), is(equalTo(customTelemetry)));
+        auth0.setAuth0UserAgent(customAuth0UserAgent);
+        assertThat(auth0.getAuth0UserAgent(), is(equalTo(customAuth0UserAgent)));
     }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -119,19 +119,19 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSetTelemetryIfPresent() {
+    public void shouldSetAuth0UserAgentIfPresent() {
         final Auth0UserAgent auth0UserAgent = mock(Auth0UserAgent.class);
-        when(auth0UserAgent.getValue()).thenReturn("the-telemetry-data");
+        when(auth0UserAgent.getValue()).thenReturn("the-user-agent-data");
         RequestFactory factory = mock(RequestFactory.class);
         OkHttpClientFactory clientFactory = mock(OkHttpClientFactory.class);
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
         auth0.setAuth0UserAgent(auth0UserAgent);
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0, factory, clientFactory);
-        verify(factory).setClientInfo("the-telemetry-data");
+        verify(factory).setClientInfo("the-user-agent-data");
     }
 
     @Test
-    public void shouldNotSetTelemetryIfMissing() {
+    public void shouldNotSetAuth0UserAgentIfMissing() {
         RequestFactory factory = mock(RequestFactory.class);
         OkHttpClientFactory clientFactory = mock(OkHttpClientFactory.class);
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -135,7 +135,7 @@ public class AuthenticationAPIClientTest {
         RequestFactory factory = mock(RequestFactory.class);
         OkHttpClientFactory clientFactory = mock(OkHttpClientFactory.class);
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.doNotSendTelemetry();
+        auth0.doNotSendAuth0UserAgent();
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0, factory, clientFactory);
         verify(factory, never()).setClientInfo(any(String.class));
     }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -37,7 +37,7 @@ import com.auth0.android.result.DatabaseUser;
 import com.auth0.android.result.UserProfile;
 import com.auth0.android.util.AuthenticationAPI;
 import com.auth0.android.util.MockAuthenticationCallback;
-import com.auth0.android.util.Telemetry;
+import com.auth0.android.util.Auth0UserAgent;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -120,12 +120,12 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldSetTelemetryIfPresent() {
-        final Telemetry telemetry = mock(Telemetry.class);
-        when(telemetry.getValue()).thenReturn("the-telemetry-data");
+        final Auth0UserAgent auth0UserAgent = mock(Auth0UserAgent.class);
+        when(auth0UserAgent.getValue()).thenReturn("the-telemetry-data");
         RequestFactory factory = mock(RequestFactory.class);
         OkHttpClientFactory clientFactory = mock(OkHttpClientFactory.class);
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.setTelemetry(telemetry);
+        auth0.setAuth0UserAgent(auth0UserAgent);
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0, factory, clientFactory);
         verify(factory).setClientInfo("the-telemetry-data");
     }

--- a/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
@@ -34,7 +34,7 @@ import com.auth0.android.request.internal.RequestFactory;
 import com.auth0.android.result.UserIdentity;
 import com.auth0.android.result.UserProfile;
 import com.auth0.android.util.MockManagementCallback;
-import com.auth0.android.util.Telemetry;
+import com.auth0.android.util.Auth0UserAgent;
 import com.auth0.android.util.TypeTokenMatcher;
 import com.auth0.android.util.UsersAPI;
 import com.google.gson.Gson;
@@ -64,7 +64,6 @@ import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -121,12 +120,12 @@ public class UsersAPIClientTest {
 
     @Test
     public void shouldSetTelemetryIfPresent() {
-        final Telemetry telemetry = mock(Telemetry.class);
-        when(telemetry.getValue()).thenReturn("the-telemetry-data");
+        final Auth0UserAgent auth0UserAgent = mock(Auth0UserAgent.class);
+        when(auth0UserAgent.getValue()).thenReturn("the-telemetry-data");
         RequestFactory factory = mock(RequestFactory.class);
         OkHttpClientFactory clientFactory = mock(OkHttpClientFactory.class);
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.setTelemetry(telemetry);
+        auth0.setAuth0UserAgent(auth0UserAgent);
         new UsersAPIClient(auth0, factory, clientFactory);
         verify(factory).setClientInfo("the-telemetry-data");
     }

--- a/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
@@ -135,7 +135,7 @@ public class UsersAPIClientTest {
         RequestFactory factory = mock(RequestFactory.class);
         OkHttpClientFactory clientFactory = mock(OkHttpClientFactory.class);
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.doNotSendTelemetry();
+        auth0.doNotSendAuth0UserAgent();
         new UsersAPIClient(auth0, factory, clientFactory);
         verify(factory, never()).setClientInfo(any(String.class));
     }

--- a/auth0/src/test/java/com/auth0/android/util/Auth0UserAgentTest.java
+++ b/auth0/src/test/java/com/auth0/android/util/Auth0UserAgentTest.java
@@ -19,57 +19,57 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 @RunWith(RobolectricTestRunner.class)
-public class TelemetryTest {
+public class Auth0UserAgentTest {
 
     //Testing Android version only for a few SDKs
 
     @Test
     @Config(sdk = 21)
     public void shouldAlwaysIncludeAndroidVersionAPI21() {
-        Telemetry telemetry = new Telemetry("auth0-java", null);
-        assertThat(telemetry.getEnvironment(), is(notNullValue()));
-        assertThat(telemetry.getEnvironment().get("android"), is("21"));
+        Auth0UserAgent auth0UserAgent = new Auth0UserAgent("auth0-java", null);
+        assertThat(auth0UserAgent.getEnvironment(), is(notNullValue()));
+        assertThat(auth0UserAgent.getEnvironment().get("android"), is("21"));
     }
 
     @Test
     @Config(sdk = 23)
     public void shouldAlwaysIncludeAndroidVersionAPI23() {
-        Telemetry telemetry = new Telemetry("auth0-java", null);
-        assertThat(telemetry.getEnvironment(), is(notNullValue()));
-        assertThat(telemetry.getEnvironment().get("android"), is("23"));
+        Auth0UserAgent auth0UserAgent = new Auth0UserAgent("auth0-java", null);
+        assertThat(auth0UserAgent.getEnvironment(), is(notNullValue()));
+        assertThat(auth0UserAgent.getEnvironment().get("android"), is("23"));
     }
 
     @Test
     public void shouldNotAcceptNullName() {
-        Telemetry telemetry = new Telemetry(null, null);
-        assertThat(telemetry.getValue(), is(nullValue()));
-        assertThat(telemetry.getEnvironment(), is(notNullValue()));
+        Auth0UserAgent auth0UserAgent = new Auth0UserAgent(null, null);
+        assertThat(auth0UserAgent.getValue(), is(nullValue()));
+        assertThat(auth0UserAgent.getEnvironment(), is(notNullValue()));
     }
 
     @Test
     public void shouldNotIncludeLibraryVersionIfNotProvided() {
-        Telemetry telemetry = new Telemetry(null, null);
-        assertThat(telemetry.getEnvironment(), is(notNullValue()));
-        assertThat(telemetry.getEnvironment().containsKey("auth0.android"), is(false));
+        Auth0UserAgent auth0UserAgent = new Auth0UserAgent(null, null);
+        assertThat(auth0UserAgent.getEnvironment(), is(notNullValue()));
+        assertThat(auth0UserAgent.getEnvironment().containsKey("auth0.android"), is(false));
     }
 
     @Test
     public void shouldGetName() {
-        Telemetry telemetry = new Telemetry("auth0-java", "1.0.0", "1.2.3");
-        assertThat(telemetry.getName(), is("auth0-java"));
+        Auth0UserAgent auth0UserAgent = new Auth0UserAgent("auth0-java", "1.0.0", "1.2.3");
+        assertThat(auth0UserAgent.getName(), is("auth0-java"));
     }
 
     @Test
     public void shouldGetVersion() {
-        Telemetry telemetry = new Telemetry("auth0-java", "1.0.0", "1.2.3");
-        assertThat(telemetry.getVersion(), is("1.0.0"));
+        Auth0UserAgent auth0UserAgent = new Auth0UserAgent("auth0-java", "1.0.0", "1.2.3");
+        assertThat(auth0UserAgent.getVersion(), is("1.0.0"));
     }
 
     @Test
     public void shouldGetLibraryVersion() {
-        Telemetry telemetry = new Telemetry("auth0-java", "1.0.0", "1.2.3");
-        assertThat(telemetry.getLibraryVersion(), is("1.2.3"));
-        assertThat(telemetry.getEnvironment().get("auth0.android"), is("1.2.3"));
+        Auth0UserAgent auth0UserAgent = new Auth0UserAgent("auth0-java", "1.0.0", "1.2.3");
+        assertThat(auth0UserAgent.getLibraryVersion(), is("1.2.3"));
+        assertThat(auth0UserAgent.getEnvironment().get("auth0.android"), is("1.2.3"));
     }
 
     @Test
@@ -79,8 +79,8 @@ public class TelemetryTest {
         Type mapType = new TypeToken<Map<String, Object>>() {
         }.getType();
 
-        Telemetry telemetryComplete = new Telemetry("auth0-java", "1.0.0", "1.2.3");
-        String value = telemetryComplete.getValue();
+        Auth0UserAgent auth0UserAgentComplete = new Auth0UserAgent("auth0-java", "1.0.0", "1.2.3");
+        String value = auth0UserAgentComplete.getValue();
         assertThat(value, is("eyJuYW1lIjoiYXV0aDAtamF2YSIsImVudiI6eyJhbmRyb2lkIjoiMjMiLCJhdXRoMC5hbmRyb2lkIjoiMS4yLjMifSwidmVyc2lvbiI6IjEuMC4wIn0="));
         String completeString = new String(Base64.decode(value, Base64.URL_SAFE | Base64.NO_WRAP), "UTF-8");
         Map<String, Object> complete = gson.fromJson(completeString, mapType);
@@ -98,8 +98,8 @@ public class TelemetryTest {
         Type mapType = new TypeToken<Map<String, Object>>() {
         }.getType();
 
-        Telemetry telemetryBasic = new Telemetry("auth0-python", "99.3.1");
-        String value = telemetryBasic.getValue();
+        Auth0UserAgent auth0UserAgentBasic = new Auth0UserAgent("auth0-python", "99.3.1");
+        String value = auth0UserAgentBasic.getValue();
         assertThat(value, is("eyJuYW1lIjoiYXV0aDAtcHl0aG9uIiwiZW52Ijp7ImFuZHJvaWQiOiIyMyJ9LCJ2ZXJzaW9uIjoiOTkuMy4xIn0="));
         String basicString = new String(Base64.decode(value, Base64.URL_SAFE | Base64.NO_WRAP), "UTF-8");
         Map<String, Object> basic = gson.fromJson(basicString, mapType);


### PR DESCRIPTION
### Changes

This change renames the `Telemetry` class to `Auth0UserAgent`, and updates its usages accordingly.

**Classes renamed:**
- `Telemetry` -> `Auth0UserAgent`

**Methods renamed:**
- `Auth0#setTelemetry` -> `Auth0#setAuth0UserAgent`
- `Auth0#doNotSendTelemetry` -> `Auth0#doNotSendAuth0UserAgent`

Note that while the ability to turn off user agent info data will be removed in version 2, this PR does rename that method to ensure the repo is in a consistent state.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
