### PR TITLE
Allow to set a custom networking client instance [SDK-2214]

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.java
@@ -40,6 +40,7 @@ import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.request.DefaultClient;
 import com.auth0.android.request.ErrorAdapter;
 import com.auth0.android.request.JsonAdapter;
+import com.auth0.android.request.NetworkingClient;
 import com.auth0.android.request.Request;
 import com.auth0.android.request.internal.BaseAuthenticationRequest;
 import com.auth0.android.request.internal.GsonAdapter;
@@ -141,6 +142,16 @@ public class AuthenticationAPIClient {
      */
     public AuthenticationAPIClient(@NonNull Auth0 auth0) {
         this(auth0, new RequestFactory<>(new DefaultClient(auth0.getConnectTimeoutInSeconds()), createErrorAdapter()), GsonProvider.buildGson());
+    }
+
+    /**
+     * Creates a new API client instance providing Auth0 account info and a custom Networking Client.
+     *
+     * @param auth0            account information
+     * @param networkingClient the networking client implementation
+     */
+    public AuthenticationAPIClient(@NonNull Auth0 auth0, @NonNull NetworkingClient networkingClient) {
+        this(auth0, new RequestFactory<>(networkingClient, createErrorAdapter()), GsonProvider.buildGson());
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.java
@@ -101,6 +101,17 @@ public class UsersAPIClient {
     }
 
     /**
+     * Creates a new API client instance providing Auth0 account info and a custom Networking Client.
+     *
+     * @param auth0            account information
+     * @param token            of the primary identity
+     * @param networkingClient the networking client implementation
+     */
+    public UsersAPIClient(@NonNull Auth0 auth0, @NonNull String token, @NonNull NetworkingClient networkingClient) {
+        this(auth0, factoryForToken(token, networkingClient), GsonProvider.buildGson());
+    }
+
+    /**
      * Creates a new API client instance providing Auth0 account info.
      *
      * @param auth0 account information

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.java
@@ -17,6 +17,7 @@ import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.BaseCallback;
 import com.auth0.android.jwt.DecodeException;
 import com.auth0.android.jwt.JWT;
+import com.auth0.android.request.NetworkingClient;
 import com.auth0.android.result.Credentials;
 
 import java.security.SecureRandom;
@@ -70,11 +71,16 @@ class OAuthManager extends ResumableManager {
     private Integer idTokenVerificationLeeway;
     private String idTokenVerificationIssuer;
 
-    OAuthManager(@NonNull Auth0 account, @NonNull AuthCallback callback, @NonNull Map<String, String> parameters, @NonNull CustomTabsOptions ctOptions) {
+    OAuthManager(@NonNull Auth0 account, @NonNull AuthCallback callback, @NonNull Map<String, String> parameters, @NonNull CustomTabsOptions ctOptions, @Nullable NetworkingClient networkingClient) {
         this.account = account;
         this.callback = callback;
         this.parameters = new HashMap<>(parameters);
-        this.apiClient = new AuthenticationAPIClient(account);
+        if (networkingClient == null) {
+            // Delegate the creation of defaults to the constructor
+            this.apiClient = new AuthenticationAPIClient(account);
+        } else {
+            this.apiClient = new AuthenticationAPIClient(account, networkingClient);
+        }
         this.ctOptions = ctOptions;
     }
 

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.java
@@ -35,6 +35,7 @@ import androidx.annotation.VisibleForTesting;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationException;
+import com.auth0.android.request.NetworkingClient;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -50,7 +51,7 @@ import static com.auth0.android.provider.OAuthManager.RESPONSE_TYPE_ID_TOKEN;
 
 /**
  * OAuth2 Web Authentication Provider.
- *
+ * <p>
  * It uses an external browser by sending the {@link android.content.Intent#ACTION_VIEW} intent.
  */
 @SuppressWarnings("WeakerAccess")
@@ -157,6 +158,7 @@ public class WebAuthProvider {
         private final Auth0 account;
         private final Map<String, String> values;
         private PKCE pkce;
+        private NetworkingClient networkingClient;
         private String issuer;
         private String scheme;
         private String redirectUri;
@@ -172,6 +174,18 @@ public class WebAuthProvider {
             this.ctOptions = CustomTabsOptions.newBuilder().build();
             withResponseType(ResponseType.CODE);
             withScope(SCOPE_TYPE_OPENID);
+        }
+
+        /**
+         * Use a custom networking client to handle the API calls.
+         *
+         * @param networkingClient to use in the requests
+         * @return the current builder instance
+         */
+        @NonNull
+        public Builder withNetworkingClient(@NonNull NetworkingClient networkingClient) {
+            this.networkingClient = networkingClient;
+            return this;
         }
 
         /**
@@ -394,7 +408,7 @@ public class WebAuthProvider {
                 return;
             }
 
-            OAuthManager manager = new OAuthManager(account, callback, values, ctOptions);
+            OAuthManager manager = new OAuthManager(account, callback, values, ctOptions, networkingClient);
             manager.setPKCE(pkce);
             manager.setIdTokenVerificationLeeway(leeway);
             manager.setIdTokenVerificationIssuer(issuer);

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -29,6 +29,11 @@ import android.content.Context;
 import android.content.res.Resources;
 
 import com.auth0.android.Auth0;
+import com.auth0.android.request.AuthenticationRequest;
+import com.auth0.android.request.HttpMethod;
+import com.auth0.android.request.NetworkingClient;
+import com.auth0.android.request.RequestOptions;
+import com.auth0.android.request.ServerResponse;
 import com.auth0.android.request.internal.RequestFactory;
 import com.auth0.android.request.internal.ThreadSwitcherShadow;
 import com.auth0.android.result.Authentication;
@@ -44,14 +49,19 @@ import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
+import org.apache.tools.ant.filters.StringInputStream;
+import org.hamcrest.collection.IsMapContaining;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.security.PublicKey;
 import java.util.Collections;
@@ -68,9 +78,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -111,6 +123,27 @@ public class AuthenticationAPIClientTest {
     @After
     public void tearDown() throws Exception {
         mockAPI.shutdown();
+    }
+
+    @Test
+    public void shouldUseCustomNetworkingClient() throws IOException {
+        Auth0 account = new Auth0("client-id", "https://tenant.auth0.com/");
+        InputStream inputStream = new StringInputStream("{\"access_token\":\"something\"}");
+        ServerResponse response = new ServerResponse(200, inputStream, Collections.emptyMap());
+        NetworkingClient networkingClient = mock(NetworkingClient.class);
+        when(networkingClient.load(anyString(), any(RequestOptions.class))).thenReturn(response);
+        AuthenticationAPIClient client = new AuthenticationAPIClient(account, networkingClient);
+
+        AuthenticationRequest request = client.login("johndoe", "secret");
+        request.execute();
+
+        ArgumentCaptor<RequestOptions> optionsCaptor = ArgumentCaptor.forClass(RequestOptions.class);
+        verify(networkingClient).load(eq("https://tenant.auth0.com/oauth/token"), optionsCaptor.capture());
+        assertThat(optionsCaptor.getValue(), is(notNullValue()));
+        assertThat(optionsCaptor.getValue().getMethod(), is(instanceOf(HttpMethod.POST.class)));
+        assertThat(optionsCaptor.getValue().getParameters(), IsMapContaining.hasEntry("username", "johndoe"));
+        assertThat(optionsCaptor.getValue().getParameters(), IsMapContaining.hasEntry("password", "secret"));
+        assertThat(optionsCaptor.getValue().getHeaders(), is(IsMapContaining.hasKey("Auth0-Client")));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -1135,7 +1135,7 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldResumeUsingCustomNetworkingClient() throws Exception {
+    public void shouldResumeLoginWithIntentWithCodeGrant() throws Exception {
         Date expiresAt = new Date();
         PKCE pkce = Mockito.mock(PKCE.class);
 
@@ -1198,7 +1198,7 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldResumeLoginWithIntentWithCodeGrant() throws Exception {
+    public void shouldResumeUsingCustomNetworkingClient() throws Exception {
         NetworkingClient networkingClient = spy(new DefaultClient(10));
         MockAuthCallback authCallback = new MockAuthCallback();
 

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -12,13 +12,20 @@ import androidx.annotation.Nullable;
 import com.auth0.android.Auth0;
 import com.auth0.android.Auth0Exception;
 import com.auth0.android.authentication.AuthenticationException;
+import com.auth0.android.request.DefaultClient;
+import com.auth0.android.request.HttpMethod;
+import com.auth0.android.request.NetworkingClient;
+import com.auth0.android.request.RequestOptions;
+import com.auth0.android.request.ServerResponse;
 import com.auth0.android.request.internal.ThreadSwitcherShadow;
 import com.auth0.android.result.Credentials;
 import com.auth0.android.util.AuthCallbackMatcher;
 import com.auth0.android.util.AuthenticationAPI;
 import com.auth0.android.util.MockAuthCallback;
 
+import org.apache.tools.ant.filters.StringInputStream;
 import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsMapContaining;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +40,10 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -60,6 +71,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -1123,7 +1135,7 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    public void shouldResumeLoginWithIntentWithCodeGrant() throws Exception {
+    public void shouldResumeUsingCustomNetworkingClient() throws Exception {
         Date expiresAt = new Date();
         PKCE pkce = Mockito.mock(PKCE.class);
 
@@ -1183,6 +1195,63 @@ public class WebAuthProviderTest {
         assertThat(credentials.getScope(), is("codeScope"));
 
         mockAPI.shutdown();
+    }
+
+    @Test
+    public void shouldResumeLoginWithIntentWithCodeGrant() throws Exception {
+        NetworkingClient networkingClient = spy(new DefaultClient(10));
+        MockAuthCallback authCallback = new MockAuthCallback();
+
+        // 1. start the webauth flow. the browser would open
+        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, EXPECTED_BASE_DOMAIN);
+        WebAuthProvider.login(proxyAccount)
+                .withNetworkingClient(networkingClient)
+                .start(activity, authCallback);
+
+        OAuthManager managerInstance = (OAuthManager) WebAuthProvider.getManagerInstance();
+        managerInstance.setCurrentTimeInMillis(FIXED_CLOCK_CURRENT_TIME_MS);
+
+        // 2. capture the intent filter to obtain the state and nonce sent
+        verify(activity).startActivity(intentCaptor.capture());
+        Uri uri = intentCaptor.getValue().getParcelableExtra(AuthenticationActivity.EXTRA_AUTHORIZE_URI);
+        assertThat(uri, is(notNullValue()));
+
+        String sentState = uri.getQueryParameter(KEY_STATE);
+        String sentNonce = uri.getQueryParameter(KEY_NONCE);
+
+        assertThat(sentState, is(not(isEmptyOrNullString())));
+        assertThat(sentNonce, is(not(isEmptyOrNullString())));
+        Intent intent = createAuthIntent(createHash(null, null, null, null, null, sentState, null, null, "1234"));
+
+        Map<String, Object> jwtBody = createJWTBody();
+        jwtBody.put("nonce", sentNonce);
+        jwtBody.put("aud", proxyAccount.getClientId());
+        jwtBody.put("iss", proxyAccount.getDomainUrl());
+        String expectedIdToken = createTestJWT("RS256", jwtBody);
+
+        // 3. craft a code response with a valid ID token
+        InputStream codeInputStream = new StringInputStream("{\"id_token\":\"" + expectedIdToken + "\"}");
+        ServerResponse codeResponse = new ServerResponse(200, codeInputStream, Collections.emptyMap());
+        doReturn(codeResponse).when(networkingClient).load(eq(proxyAccount.getDomainUrl() + "oauth/token"), any(RequestOptions.class));
+
+        // 4. craft a JWKS response with expected keys
+        byte[] encoded = Files.readAllBytes(Paths.get("src/test/resources/rsa_jwks.json"));
+        InputStream jwksInputStream = new ByteArrayInputStream(encoded);
+        ServerResponse jwksResponse = new ServerResponse(200, jwksInputStream, Collections.emptyMap());
+        doReturn(jwksResponse).when(networkingClient).load(eq(proxyAccount.getDomainUrl() + ".well-known/jwks.json"), any(RequestOptions.class));
+
+        // 5. resume, perform the code exchange, and make assertions
+        assertTrue(WebAuthProvider.resume(intent));
+        assertThat(authCallback, AuthCallbackMatcher.hasCredentials());
+
+        ArgumentCaptor<RequestOptions> codeOptionsCaptor = ArgumentCaptor.forClass(RequestOptions.class);
+        verify(networkingClient).load(eq("https://test.domain.com/oauth/token"), codeOptionsCaptor.capture());
+        assertThat(codeOptionsCaptor.getValue(), Matchers.is(Matchers.notNullValue()));
+        assertThat(codeOptionsCaptor.getValue().getMethod(), Matchers.is(instanceOf(HttpMethod.POST.class)));
+        assertThat(codeOptionsCaptor.getValue().getParameters(), IsMapContaining.hasEntry("code", "1234"));
+        assertThat(codeOptionsCaptor.getValue().getParameters(), IsMapContaining.hasEntry("grant_type", "authorization_code"));
+        assertThat(codeOptionsCaptor.getValue().getParameters(), IsMapContaining.hasKey("code_verifier"));
+        assertThat(codeOptionsCaptor.getValue().getHeaders(), Matchers.is(IsMapContaining.hasKey("Auth0-Client")));
     }
 
     @Test
@@ -1281,7 +1350,7 @@ public class WebAuthProviderTest {
         jwtBody.put("nonce", sentNonce);
         jwtBody.put("iss", proxyAccount.getDomainUrl());
         String expectedIdToken = createTestJWT("RS256", jwtBody);
-        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, sentState, null, null,"1234"));
+        Intent intent = createAuthIntent(createHash(expectedIdToken, null, null, null, null, sentState, null, null, "1234"));
 
         final Credentials codeCredentials = new Credentials(expectedIdToken, "codeAccess", "codeType", "codeRefresh", expiresAt, "codeScope");
         Mockito.doAnswer(new Answer() {


### PR DESCRIPTION
### Changes

This change adds the ability to pass a custom networking client to:

- AuthenticationAPIClient
- UsersAPIClient
- WebAuthProvider#login

### References

See SDK-2214



### Testing
I've added unit tests


