### PR TITLE
Enforce HTTPS

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -29,6 +29,7 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.auth0.android.auth0.BuildConfig;
 import com.auth0.android.util.Telemetry;
@@ -281,11 +282,17 @@ public class Auth0 {
         return url;
     }
 
-    private HttpUrl ensureValidUrl(String url) {
+    @VisibleForTesting
+    HttpUrl ensureValidUrl(String url) {
         if (url == null) {
             return null;
         }
-        String safeUrl = url.startsWith("http") ? url : "https://" + url;
+
+        if (url.startsWith("http://")) {
+            throw new IllegalArgumentException("Invalid domain url: '" + url + "'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used.");
+        }
+
+        String safeUrl = url.startsWith("https://") ? url : "https://" + url;
         return HttpUrl.parse(safeUrl);
     }
 

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -273,4 +273,25 @@ public class Auth0Test {
         auth0.setTelemetry(customTelemetry);
         assertThat(auth0.getTelemetry(), is(equalTo(customTelemetry)));
     }
+
+    @Test
+    public void shouldThrowWhenHttpDomainUsed() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid domain url: 'http://" + DOMAIN + "'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used.");
+        new Auth0(CLIENT_ID, "http://" + DOMAIN);
+    }
+
+    @Test
+    public void shouldThrowWhenDomainIsNull() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid domain url: 'null'");
+        new Auth0(CLIENT_ID, null);
+    }
+
+    @Test
+    public void shouldThrowWhenConfigDomainIsHttp() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid domain url: 'http://" + OTHER_DOMAIN + "'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used.");
+        new Auth0(CLIENT_ID, DOMAIN, "http://" + OTHER_DOMAIN);
+    }
 }

--- a/auth0/src/test/java/com/auth0/android/MockAuth0.java
+++ b/auth0/src/test/java/com/auth0/android/MockAuth0.java
@@ -1,0 +1,35 @@
+package com.auth0.android;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.squareup.okhttp.HttpUrl;
+
+/**
+ * Mock implementation of {@linkplain Auth0} for tests.
+ */
+public class MockAuth0 extends Auth0 {
+
+    public MockAuth0(@NonNull String clientId, @NonNull String domain) {
+        this(clientId, domain, null);
+    }
+
+    public MockAuth0(@NonNull String clientId, @NonNull String domain, @Nullable String configurationDomain) {
+        super(clientId, domain, configurationDomain);
+    }
+
+    /**
+     * Returns the result of calling of {@linkplain HttpUrl#parse(String)} on the provided string.
+     * Overriden to not enforce HTTPS for tests.
+     *
+     * @param url The URL to parse
+     * @return The parsed URL, or null if the {@code url} parameter was null.
+     */
+    @Override
+    HttpUrl ensureValidUrl(String url) {
+        if (url == null) {
+            return null;
+        }
+        return HttpUrl.parse(url);
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -29,6 +29,7 @@ import android.content.Context;
 import android.content.res.Resources;
 
 import com.auth0.android.Auth0;
+import com.auth0.android.MockAuth0;
 import com.auth0.android.request.internal.RequestFactory;
 import com.auth0.android.result.Authentication;
 import com.auth0.android.result.Credentials;
@@ -100,7 +101,7 @@ public class AuthenticationAPIClientTest {
     public void setUp() throws Exception {
         mockAPI = new AuthenticationAPI();
         final String domain = mockAPI.getDomain();
-        Auth0 auth0 = new Auth0(CLIENT_ID, domain, domain);
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, domain, domain);
         client = new AuthenticationAPIClient(auth0);
         gson = new GsonBuilder().serializeNulls().create();
     }
@@ -178,7 +179,7 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin();
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
         client.loginWithOTP("ey30.the-mfa-token.value", "123456")
                 .start(callback);
@@ -222,7 +223,7 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin();
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
         client.login(SUPPORT_AUTH0_COM, "some-password", MY_CONNECTION)
                 .start(callback);
@@ -369,7 +370,7 @@ public class AuthenticationAPIClientTest {
     public void shouldLoginWithPhoneNumberWithCustomConnectionWithOTPGrant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
@@ -394,7 +395,7 @@ public class AuthenticationAPIClientTest {
     public void shouldLoginWithPhoneNumberWithOTPGrant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
@@ -419,7 +420,7 @@ public class AuthenticationAPIClientTest {
     public void shouldLoginWithPhoneNumberSyncWithOTPGrant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final Credentials credentials = client
@@ -444,7 +445,7 @@ public class AuthenticationAPIClientTest {
     public void shouldLoginWithEmailOnlyWithCustomConnectionWithOTPGrant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
@@ -469,7 +470,7 @@ public class AuthenticationAPIClientTest {
     public void shouldLoginWithEmailOnlyWithOTPGrant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
@@ -495,7 +496,7 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin()
                 .willReturnUserInfo();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final Credentials credentials = client
@@ -647,7 +648,7 @@ public class AuthenticationAPIClientTest {
                 .willReturnSuccessfulLogin();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, SUPPORT, MY_CONNECTION)
                 .start(callback);
@@ -779,7 +780,7 @@ public class AuthenticationAPIClientTest {
                 .willReturnUserInfo();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, MY_CONNECTION)
                 .start(callback);
@@ -1302,7 +1303,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldRevokeToken() throws Exception {
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         mockAPI.willReturnSuccessfulEmptyBody();
@@ -1323,7 +1324,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldRevokeTokenSync() throws Exception {
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         mockAPI.willReturnSuccessfulEmptyBody();
@@ -1341,7 +1342,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldRenewAuthWithOAuthToken() throws Exception {
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         mockAPI.willReturnSuccessfulLogin();
@@ -1363,7 +1364,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldRenewAuthWithOAuthTokenSync() throws Exception {
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         mockAPI.willReturnSuccessfulLogin();

--- a/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
@@ -29,6 +29,7 @@ import android.content.Context;
 import android.content.res.Resources;
 
 import com.auth0.android.Auth0;
+import com.auth0.android.MockAuth0;
 import com.auth0.android.request.internal.RequestFactory;
 import com.auth0.android.result.UserIdentity;
 import com.auth0.android.result.UserProfile;
@@ -98,7 +99,7 @@ public class UsersAPIClientTest {
     public void setUp() throws Exception {
         mockAPI = new UsersAPI();
         final String domain = mockAPI.getDomain();
-        Auth0 auth0 = new Auth0(CLIENT_ID, domain, domain);
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, domain, domain);
         client = new UsersAPIClient(auth0, TOKEN_PRIMARY);
         gson = new GsonBuilder().serializeNulls().create();
     }

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -11,6 +11,7 @@ import androidx.annotation.Nullable;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.Auth0Exception;
+import com.auth0.android.MockAuth0;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.result.Credentials;
 import com.auth0.android.util.AuthCallbackMatcher;
@@ -1021,7 +1022,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withResponseType(ResponseType.ID_TOKEN)
@@ -1064,7 +1065,7 @@ public class WebAuthProviderTest {
         mockAPI.willReturnValidJsonWebKeys();
 
         MockAuthCallback authCallback = new MockAuthCallback();
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withResponseType(ResponseType.ID_TOKEN)
@@ -1129,7 +1130,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withPKCE(pkce)
@@ -1192,7 +1193,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withResponseType(ResponseType.ID_TOKEN | ResponseType.CODE)
@@ -1256,7 +1257,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withPKCE(pkce)
@@ -1510,7 +1511,7 @@ public class WebAuthProviderTest {
         mockAPI.willReturnValidJsonWebKeys();
 
         MockAuthCallback authCallback = new MockAuthCallback();
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
@@ -1655,7 +1656,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
                 .withNonce(EXPECTED_NONCE)
@@ -1690,7 +1691,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
                 .withNonce(EXPECTED_NONCE)
@@ -1724,7 +1725,7 @@ public class WebAuthProviderTest {
         mockAPI.willReturnValidJsonWebKeys();
 
         MockAuthCallback authCallback = new MockAuthCallback();
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
@@ -1757,7 +1758,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
                 .withNonce(EXPECTED_NONCE)
@@ -1790,7 +1791,7 @@ public class WebAuthProviderTest {
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
@@ -1837,7 +1838,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withResponseType(ResponseType.ID_TOKEN)
@@ -1880,7 +1881,7 @@ public class WebAuthProviderTest {
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
@@ -2034,7 +2035,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withState("state")
@@ -2075,7 +2076,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withState("state")
@@ -2112,7 +2113,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withState("state")
@@ -2149,7 +2150,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback callback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
         WebAuthProvider.login(proxyAccount)
                 .withState("state")
                 .withNonce(EXPECTED_NONCE)


### PR DESCRIPTION
### Changes

Updates the `Auth0` construction to require domain to not allow protocol other than `https` (or we will still use `https` if no protocol is specified).

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
