### PR TITLE
Enforce HTTPS

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -288,11 +288,12 @@ public class Auth0 {
             return null;
         }
 
-        if (url.toLowerCase().startsWith("http://")) {
+        String normalizedUrl = url.toLowerCase();
+        if (normalizedUrl.startsWith("http://")) {
             throw new IllegalArgumentException("Invalid domain url: '" + url + "'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used.");
         }
 
-        String safeUrl = url.startsWith("https://") ? url : "https://" + url;
+        String safeUrl = normalizedUrl.startsWith("https://") ? normalizedUrl : "https://" + normalizedUrl;
         return HttpUrl.parse(safeUrl);
     }
 

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -29,6 +29,7 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.auth0.android.auth0.BuildConfig;
 import com.auth0.android.util.Telemetry;
@@ -281,11 +282,17 @@ public class Auth0 {
         return url;
     }
 
-    private HttpUrl ensureValidUrl(String url) {
+    @VisibleForTesting
+    HttpUrl ensureValidUrl(String url) {
         if (url == null) {
             return null;
         }
-        String safeUrl = url.startsWith("http") ? url : "https://" + url;
+
+        if (url.startsWith("http://")) {
+            throw new IllegalArgumentException("Invalid domain url: '" + url + "'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used.");
+        }
+
+        String safeUrl = url.startsWith("https://") ? url : "https://" + url;
         return HttpUrl.parse(safeUrl);
     }
 

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -288,7 +288,7 @@ public class Auth0 {
             return null;
         }
 
-        if (url.startsWith("http://")) {
+        if (url.toLowerCase().startsWith("http://")) {
             throw new IllegalArgumentException("Invalid domain url: '" + url + "'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used.");
         }
 

--- a/auth0/src/main/java/com/auth0/android/request/DefaultClient.kt
+++ b/auth0/src/main/java/com/auth0/android/request/DefaultClient.kt
@@ -39,7 +39,10 @@ public class DefaultClient(private val timeout: Int) : NetworkingClient {
             URL(url)
         }
 
-        val connection = getHttpUrlConnection(targetUrl)
+        // Auth0 constructor will enforce HTTPS scheme. This is here to enable running
+        // tests with MockWebServer using HTTP.
+        // TODO get tests running with MockWebServer using HTTPS, then use HttpsURLConnection
+        val connection: HttpURLConnection = targetUrl.openConnection() as HttpURLConnection
 
         //FIXME: setup timeout
 //        connection.connectTimeout = timeout
@@ -72,15 +75,5 @@ public class DefaultClient(private val timeout: Int) : NetworkingClient {
             connection.errorStream ?: connection.inputStream,
             connection.headerFields
         )
-    }
-
-    private fun getHttpUrlConnection(targetUrl: URL): HttpURLConnection {
-        // Auth0 constructor will enforce HTTPS scheme. This is here to enable running
-        // tests with MockWebServer using HTTP.
-        if (targetUrl.protocol == "http") {
-            return targetUrl.openConnection() as HttpURLConnection
-        } else {
-            return targetUrl.openConnection() as HttpsURLConnection
-        }
     }
 }

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -282,6 +282,13 @@ public class Auth0Test {
     }
 
     @Test
+    public void shouldThrowWhenHttpUppercaseDomainUsed() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid domain url: 'HTTP://" + DOMAIN + "'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used.");
+        new Auth0(CLIENT_ID, "HTTP://" + DOMAIN);
+    }
+
+    @Test
     public void shouldThrowWhenDomainIsNull() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Invalid domain url: 'null'");

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -282,6 +282,12 @@ public class Auth0Test {
     }
 
     @Test
+    public void shouldHandleUpperCaseHttpsDomain() {
+        Auth0 auth0 = new Auth0(CLIENT_ID, "Https://" + DOMAIN);
+        assertThat(auth0.getDomainUrl(), is("https://" + DOMAIN + "/"));
+    }
+
+    @Test
     public void shouldThrowWhenHttpUppercaseDomainUsed() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Invalid domain url: 'HTTP://" + DOMAIN + "'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used.");

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -273,4 +273,25 @@ public class Auth0Test {
         auth0.setTelemetry(customTelemetry);
         assertThat(auth0.getTelemetry(), is(equalTo(customTelemetry)));
     }
+
+    @Test
+    public void shouldThrowWhenHttpDomainUsed() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid domain url: 'http://" + DOMAIN + "'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used.");
+        new Auth0(CLIENT_ID, "http://" + DOMAIN);
+    }
+
+    @Test
+    public void shouldThrowWhenDomainIsNull() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid domain url: 'null'");
+        new Auth0(CLIENT_ID, null);
+    }
+
+    @Test
+    public void shouldThrowWhenConfigDomainIsHttp() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid domain url: 'http://" + OTHER_DOMAIN + "'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used.");
+        new Auth0(CLIENT_ID, DOMAIN, "http://" + OTHER_DOMAIN);
+    }
 }

--- a/auth0/src/test/java/com/auth0/android/MockAuth0.java
+++ b/auth0/src/test/java/com/auth0/android/MockAuth0.java
@@ -1,0 +1,35 @@
+package com.auth0.android;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.squareup.okhttp.HttpUrl;
+
+/**
+ * Mock implementation of {@linkplain Auth0} for tests.
+ */
+public class MockAuth0 extends Auth0 {
+
+    public MockAuth0(@NonNull String clientId, @NonNull String domain) {
+        this(clientId, domain, null);
+    }
+
+    public MockAuth0(@NonNull String clientId, @NonNull String domain, @Nullable String configurationDomain) {
+        super(clientId, domain, configurationDomain);
+    }
+
+    /**
+     * Returns the result of calling of {@linkplain HttpUrl#parse(String)} on the provided string.
+     * Overriden to not enforce HTTPS for tests.
+     *
+     * @param url The URL to parse
+     * @return The parsed URL, or null if the {@code url} parameter was null.
+     */
+    @Override
+    HttpUrl ensureValidUrl(String url) {
+        if (url == null) {
+            return null;
+        }
+        return HttpUrl.parse(url);
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/MockAuth0.java
+++ b/auth0/src/test/java/com/auth0/android/MockAuth0.java
@@ -7,6 +7,8 @@ import com.squareup.okhttp.HttpUrl;
 
 /**
  * Mock implementation of {@linkplain Auth0} for tests.
+ * This implementation does not enforce HTTPS, and should be removed after tests are able
+ * to run with the MockWebServer using HTTPS.
  */
 public class MockAuth0 extends Auth0 {
 
@@ -27,6 +29,8 @@ public class MockAuth0 extends Auth0 {
      */
     @Override
     HttpUrl ensureValidUrl(String url) {
+        // TODO get MockWebServer running with HTTPS and remove this class. Should be done
+        // after updating to more recent versions of OkHttp
         if (url == null) {
             return null;
         }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -29,6 +29,7 @@ import android.content.Context;
 import android.content.res.Resources;
 
 import com.auth0.android.Auth0;
+import com.auth0.android.MockAuth0;
 import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.request.HttpMethod;
 import com.auth0.android.request.NetworkingClient;
@@ -115,7 +116,7 @@ public class AuthenticationAPIClientTest {
     public void setUp() throws Exception {
         mockAPI = new AuthenticationAPI();
         final String domain = mockAPI.getDomain();
-        Auth0 auth0 = new Auth0(CLIENT_ID, domain, domain);
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, domain, domain);
         client = new AuthenticationAPIClient(auth0);
         gson = new GsonBuilder().serializeNulls().create();
     }
@@ -214,7 +215,7 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin();
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
         client.loginWithOTP("ey30.the-mfa-token.value", "123456")
                 .start(callback);
@@ -258,7 +259,7 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin();
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
         client.login(SUPPORT_AUTH0_COM, "some-password", MY_CONNECTION)
                 .start(callback);
@@ -405,7 +406,7 @@ public class AuthenticationAPIClientTest {
     public void shouldLoginWithPhoneNumberWithCustomConnectionWithOTPGrant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
@@ -430,7 +431,7 @@ public class AuthenticationAPIClientTest {
     public void shouldLoginWithPhoneNumberWithOTPGrant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
@@ -455,7 +456,7 @@ public class AuthenticationAPIClientTest {
     public void shouldLoginWithPhoneNumberSyncWithOTPGrant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final Credentials credentials = client
@@ -480,7 +481,7 @@ public class AuthenticationAPIClientTest {
     public void shouldLoginWithEmailOnlyWithCustomConnectionWithOTPGrant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
@@ -505,7 +506,7 @@ public class AuthenticationAPIClientTest {
     public void shouldLoginWithEmailOnlyWithOTPGrant() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
@@ -531,7 +532,7 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin()
                 .willReturnUserInfo();
 
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         final Credentials credentials = client
@@ -683,7 +684,7 @@ public class AuthenticationAPIClientTest {
                 .willReturnSuccessfulLogin();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, SUPPORT, MY_CONNECTION)
                 .start(callback);
@@ -815,7 +816,7 @@ public class AuthenticationAPIClientTest {
                 .willReturnUserInfo();
 
         final MockAuthenticationCallback<Credentials> callback = new MockAuthenticationCallback<>();
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
         client.signUp(SUPPORT_AUTH0_COM, PASSWORD, MY_CONNECTION)
                 .start(callback);
@@ -1338,7 +1339,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldRevokeToken() throws Exception {
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         mockAPI.willReturnSuccessfulEmptyBody();
@@ -1359,7 +1360,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldRevokeTokenSync() throws Exception {
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         mockAPI.willReturnSuccessfulEmptyBody();
@@ -1377,7 +1378,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldRenewAuthWithOAuthToken() throws Exception {
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         mockAPI.willReturnSuccessfulLogin();
@@ -1399,7 +1400,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldRenewAuthWithOAuthTokenSync() throws Exception {
-        Auth0 auth0 = new Auth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, mockAPI.getDomain(), mockAPI.getDomain());
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         mockAPI.willReturnSuccessfulLogin();

--- a/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
@@ -29,6 +29,7 @@ import android.content.Context;
 import android.content.res.Resources;
 
 import com.auth0.android.Auth0;
+import com.auth0.android.MockAuth0;
 import com.auth0.android.request.HttpMethod;
 import com.auth0.android.request.NetworkingClient;
 import com.auth0.android.request.Request;
@@ -115,7 +116,7 @@ public class UsersAPIClientTest {
     public void setUp() throws Exception {
         mockAPI = new UsersAPI();
         final String domain = mockAPI.getDomain();
-        Auth0 auth0 = new Auth0(CLIENT_ID, domain, domain);
+        Auth0 auth0 = new MockAuth0(CLIENT_ID, domain, domain);
         client = new UsersAPIClient(auth0, TOKEN_PRIMARY);
         gson = new GsonBuilder().serializeNulls().create();
     }

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.java
@@ -11,6 +11,7 @@ import androidx.annotation.Nullable;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.Auth0Exception;
+import com.auth0.android.MockAuth0;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.request.DefaultClient;
 import com.auth0.android.request.HttpMethod;
@@ -1036,7 +1037,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withResponseType(ResponseType.ID_TOKEN)
@@ -1079,7 +1080,7 @@ public class WebAuthProviderTest {
         mockAPI.willReturnValidJsonWebKeys();
 
         MockAuthCallback authCallback = new MockAuthCallback();
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withResponseType(ResponseType.ID_TOKEN)
@@ -1144,7 +1145,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withPKCE(pkce)
@@ -1264,7 +1265,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withResponseType(ResponseType.ID_TOKEN | ResponseType.CODE)
@@ -1328,7 +1329,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withPKCE(pkce)
@@ -1582,7 +1583,7 @@ public class WebAuthProviderTest {
         mockAPI.willReturnValidJsonWebKeys();
 
         MockAuthCallback authCallback = new MockAuthCallback();
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
@@ -1727,7 +1728,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
                 .withNonce(EXPECTED_NONCE)
@@ -1762,7 +1763,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
                 .withNonce(EXPECTED_NONCE)
@@ -1796,7 +1797,7 @@ public class WebAuthProviderTest {
         mockAPI.willReturnValidJsonWebKeys();
 
         MockAuthCallback authCallback = new MockAuthCallback();
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
@@ -1829,7 +1830,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
         WebAuthProvider.login(proxyAccount)
                 .withState("1234567890")
                 .withNonce(EXPECTED_NONCE)
@@ -1862,7 +1863,7 @@ public class WebAuthProviderTest {
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
@@ -1909,7 +1910,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withResponseType(ResponseType.ID_TOKEN)
@@ -1952,7 +1953,7 @@ public class WebAuthProviderTest {
         AuthenticationAPI mockAPI = new AuthenticationAPI();
         mockAPI.willReturnValidJsonWebKeys();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
@@ -2106,7 +2107,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withState("state")
@@ -2147,7 +2148,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withState("state")
@@ -2184,7 +2185,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback authCallback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
 
         WebAuthProvider.login(proxyAccount)
                 .withState("state")
@@ -2221,7 +2222,7 @@ public class WebAuthProviderTest {
 
         MockAuthCallback callback = new MockAuthCallback();
 
-        Auth0 proxyAccount = new Auth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
+        Auth0 proxyAccount = new MockAuth0(EXPECTED_AUDIENCE, mockAPI.getDomain());
         WebAuthProvider.login(proxyAccount)
                 .withState("state")
                 .withNonce(EXPECTED_NONCE)


### PR DESCRIPTION
### Changes

Updates the `Auth0` construction to require domain to not allow protocol other than `https` (or we will still use `https` if no protocol is specified).

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors