### PR TITLE
Remove doNotSendTelemetry method

### DIFF
--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -101,6 +101,7 @@ Additionally, any classes that implemented `ParameterizableRequest` or `AuthRequ
 
 - `public void setOIDCConformant(boolean enabled)`. The SDK now only supports OIDC-Conformant applications.
 - `public boolean isOIDCConformant()`. The SDK now only supports OIDC-Conformant applications.
+- `public void doNotSendTelemetry()` has been removed. There is no replacement.
 
 #### AuthenticationAPIClient
 

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -30,7 +30,6 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.auth0.android.auth0.BuildConfig;
 import com.auth0.android.util.Auth0UserAgent;
 import com.squareup.okhttp.HttpUrl;
 
@@ -96,7 +95,7 @@ public class Auth0 {
             throw new IllegalArgumentException(String.format("Invalid domain url: '%s'", domain));
         }
         this.configurationUrl = resolveConfiguration(configurationDomain, this.domainUrl);
-        this.auth0UserAgent = new Auth0UserAgent(BuildConfig.LIBRARY_NAME, BuildConfig.VERSION_NAME);
+        this.auth0UserAgent = new Auth0UserAgent();
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -183,18 +183,9 @@ public class Auth0 {
      * Setter for the user agent info to send in every request to Auth0.
      *
      * @param auth0UserAgent to send in every request to Auth0.
-     * @see #doNotSendAuth0UserAgent()
      */
     public void setAuth0UserAgent(@Nullable Auth0UserAgent auth0UserAgent) {
         this.auth0UserAgent = auth0UserAgent;
-    }
-
-    /**
-     * Avoid sending any user agent info in every request to Auth0
-     */
-    // TODO - this should be removed
-    public void doNotSendAuth0UserAgent() {
-        this.auth0UserAgent = null;
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/Auth0.java
+++ b/auth0/src/main/java/com/auth0/android/Auth0.java
@@ -183,7 +183,7 @@ public class Auth0 {
      *
      * @param auth0UserAgent to send in every request to Auth0.
      */
-    public void setAuth0UserAgent(@Nullable Auth0UserAgent auth0UserAgent) {
+    public void setAuth0UserAgent(@NonNull Auth0UserAgent auth0UserAgent) {
         this.auth0UserAgent = auth0UserAgent;
     }
 

--- a/auth0/src/main/java/com/auth0/android/util/Auth0UserAgent.java
+++ b/auth0/src/main/java/com/auth0/android/util/Auth0UserAgent.java
@@ -32,6 +32,10 @@ public class Auth0UserAgent {
     private final Map<String, String> env;
     private final String value;
 
+    public Auth0UserAgent() {
+        this(BuildConfig.LIBRARY_NAME, BuildConfig.VERSION_NAME);
+    }
+
     public Auth0UserAgent(@NonNull String name, @NonNull String version) {
         this(name, version, null);
     }

--- a/auth0/src/main/java/com/auth0/android/util/Auth0UserAgent.java
+++ b/auth0/src/main/java/com/auth0/android/util/Auth0UserAgent.java
@@ -7,9 +7,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
+import com.auth0.android.auth0.BuildConfig;
 import com.google.gson.Gson;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,31 +37,24 @@ public class Auth0UserAgent {
     }
 
     public Auth0UserAgent(@NonNull String name, @NonNull String version, @Nullable String libraryVersion) {
-        this.name = name;
-        this.version = version;
-        if (TextUtils.isEmpty(name)) {
-            env = Collections.emptyMap();
-            value = null;
-            return;
-        }
+        this.name = TextUtils.isEmpty(name) ? BuildConfig.LIBRARY_NAME : name;
+        this.version = TextUtils.isEmpty(version) ? BuildConfig.VERSION_NAME : version;
+
         Map<String, String> tmpEnv = new HashMap<>();
         tmpEnv.put(ANDROID_KEY, String.valueOf(android.os.Build.VERSION.SDK_INT));
         if (!TextUtils.isEmpty(libraryVersion)) {
-            //noinspection ConstantConditions
             tmpEnv.put(LIBRARY_VERSION_KEY, libraryVersion);
         }
         this.env = Collections.unmodifiableMap(tmpEnv);
 
         Map<String, Object> values = new HashMap<>();
         values.put(NAME_KEY, name);
-        if (!TextUtils.isEmpty(version)) {
-            values.put(VERSION_KEY, version);
-        }
+        values.put(VERSION_KEY, version);
         values.put(ENV_KEY, env);
         String json = new Gson().toJson(values);
-        Charset utf8 = Charset.forName("UTF-8");
-        byte[] bytes = json.getBytes(utf8);
-        value = new String(Base64.encode(bytes, Base64.URL_SAFE | Base64.NO_WRAP), utf8);
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        value = new String(Base64.encode(bytes, Base64.URL_SAFE | Base64.NO_WRAP),
+                StandardCharsets.UTF_8);
     }
 
     @NonNull

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -47,7 +47,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -257,13 +256,6 @@ public class Auth0Test {
         assertThat(url, hasScheme("https"));
         assertThat(url, hasHost(DOMAIN));
         assertThat(url, hasPath("v2", "logout"));
-    }
-
-    @Test
-    public void shouldNotReturnTelemetryWhenExplicitlyDisabledThem() {
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.doNotSendAuth0UserAgent();
-        assertThat(auth0.getAuth0UserAgent(), is(nullValue()));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -131,16 +131,6 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldNotSetAuth0UserAgentIfMissing() {
-        RequestFactory factory = mock(RequestFactory.class);
-        OkHttpClientFactory clientFactory = mock(OkHttpClientFactory.class);
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.doNotSendAuth0UserAgent();
-        AuthenticationAPIClient client = new AuthenticationAPIClient(auth0, factory, clientFactory);
-        verify(factory, never()).setClientInfo(any(String.class));
-    }
-
-    @Test
     public void shouldCreateClientWithAccountInfo() {
         AuthenticationAPIClient client = new AuthenticationAPIClient(new Auth0(CLIENT_ID, DOMAIN));
         assertThat(client, is(notNullValue()));

--- a/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
@@ -33,8 +33,8 @@ import com.auth0.android.request.internal.OkHttpClientFactory;
 import com.auth0.android.request.internal.RequestFactory;
 import com.auth0.android.result.UserIdentity;
 import com.auth0.android.result.UserProfile;
-import com.auth0.android.util.MockManagementCallback;
 import com.auth0.android.util.Auth0UserAgent;
+import com.auth0.android.util.MockManagementCallback;
 import com.auth0.android.util.TypeTokenMatcher;
 import com.auth0.android.util.UsersAPI;
 import com.google.gson.Gson;
@@ -63,10 +63,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -128,16 +126,6 @@ public class UsersAPIClientTest {
         auth0.setAuth0UserAgent(auth0UserAgent);
         new UsersAPIClient(auth0, factory, clientFactory);
         verify(factory).setClientInfo("the-telemetry-data");
-    }
-
-    @Test
-    public void shouldNotSetTelemetryIfMissing() {
-        RequestFactory factory = mock(RequestFactory.class);
-        OkHttpClientFactory clientFactory = mock(OkHttpClientFactory.class);
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.doNotSendAuth0UserAgent();
-        new UsersAPIClient(auth0, factory, clientFactory);
-        verify(factory, never()).setClientInfo(any(String.class));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/util/Auth0UserAgentTest.java
+++ b/auth0/src/test/java/com/auth0/android/util/Auth0UserAgentTest.java
@@ -42,7 +42,17 @@ public class Auth0UserAgentTest {
     }
 
     @Test
-    public void shouldUseDefaultNameIfNameIsEmpty() throws Exception {
+    public void shouldUseDefaultValuesWithDefaultConstructor() {
+        Auth0UserAgent auth0UserAgent = new Auth0UserAgent();
+        assertThat(auth0UserAgent.getValue(), is(notNullValue()));
+        assertThat(auth0UserAgent.getName(), is(BuildConfig.LIBRARY_NAME));
+        assertThat(auth0UserAgent.getVersion(), is(BuildConfig.VERSION_NAME));
+        assertThat(auth0UserAgent.getEnvironment(), is(notNullValue()));
+        assertThat(auth0UserAgent.getLibraryVersion(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldUseDefaultNameEmpty() throws Exception {
         Auth0UserAgent auth0UserAgent = new Auth0UserAgent("", "2.0");
         assertThat(auth0UserAgent.getValue(), is(notNullValue()));
         assertThat(auth0UserAgent.getName(), is(BuildConfig.LIBRARY_NAME));
@@ -52,7 +62,7 @@ public class Auth0UserAgentTest {
     }
 
     @Test
-    public void shouldUseDefaultVersionIfNameIsEmpty() throws Exception {
+    public void shouldUseDefaultVersionIfEmpty() throws Exception {
         Auth0UserAgent auth0UserAgent = new Auth0UserAgent("auth0-java", "");
         assertThat(auth0UserAgent.getValue(), is(notNullValue()));
         assertThat(auth0UserAgent.getName(), is("auth0-java"));

--- a/auth0/src/test/java/com/auth0/android/util/Auth0UserAgentTest.java
+++ b/auth0/src/test/java/com/auth0/android/util/Auth0UserAgentTest.java
@@ -2,6 +2,7 @@ package com.auth0.android.util;
 
 import android.util.Base64;
 
+import com.auth0.android.auth0.BuildConfig;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
@@ -11,6 +12,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,10 +42,23 @@ public class Auth0UserAgentTest {
     }
 
     @Test
-    public void shouldNotAcceptNullName() {
-        Auth0UserAgent auth0UserAgent = new Auth0UserAgent(null, null);
-        assertThat(auth0UserAgent.getValue(), is(nullValue()));
+    public void shouldUseDefaultNameIfNameIsEmpty() throws Exception {
+        Auth0UserAgent auth0UserAgent = new Auth0UserAgent("", "2.0");
+        assertThat(auth0UserAgent.getValue(), is(notNullValue()));
+        assertThat(auth0UserAgent.getName(), is(BuildConfig.LIBRARY_NAME));
+        assertThat(auth0UserAgent.getVersion(), is("2.0"));
         assertThat(auth0UserAgent.getEnvironment(), is(notNullValue()));
+        assertThat(auth0UserAgent.getLibraryVersion(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldUseDefaultVersionIfNameIsEmpty() throws Exception {
+        Auth0UserAgent auth0UserAgent = new Auth0UserAgent("auth0-java", "");
+        assertThat(auth0UserAgent.getValue(), is(notNullValue()));
+        assertThat(auth0UserAgent.getName(), is("auth0-java"));
+        assertThat(auth0UserAgent.getVersion(), is(BuildConfig.VERSION_NAME));
+        assertThat(auth0UserAgent.getEnvironment(), is(notNullValue()));
+        assertThat(auth0UserAgent.getLibraryVersion(), is(nullValue()));
     }
 
     @Test
@@ -82,7 +97,7 @@ public class Auth0UserAgentTest {
         Auth0UserAgent auth0UserAgentComplete = new Auth0UserAgent("auth0-java", "1.0.0", "1.2.3");
         String value = auth0UserAgentComplete.getValue();
         assertThat(value, is("eyJuYW1lIjoiYXV0aDAtamF2YSIsImVudiI6eyJhbmRyb2lkIjoiMjMiLCJhdXRoMC5hbmRyb2lkIjoiMS4yLjMifSwidmVyc2lvbiI6IjEuMC4wIn0="));
-        String completeString = new String(Base64.decode(value, Base64.URL_SAFE | Base64.NO_WRAP), "UTF-8");
+        String completeString = new String(Base64.decode(value, Base64.URL_SAFE | Base64.NO_WRAP), StandardCharsets.UTF_8);
         Map<String, Object> complete = gson.fromJson(completeString, mapType);
         assertThat((String) complete.get("name"), is("auth0-java"));
         assertThat((String) complete.get("version"), is("1.0.0"));
@@ -101,7 +116,7 @@ public class Auth0UserAgentTest {
         Auth0UserAgent auth0UserAgentBasic = new Auth0UserAgent("auth0-python", "99.3.1");
         String value = auth0UserAgentBasic.getValue();
         assertThat(value, is("eyJuYW1lIjoiYXV0aDAtcHl0aG9uIiwiZW52Ijp7ImFuZHJvaWQiOiIyMyJ9LCJ2ZXJzaW9uIjoiOTkuMy4xIn0="));
-        String basicString = new String(Base64.decode(value, Base64.URL_SAFE | Base64.NO_WRAP), "UTF-8");
+        String basicString = new String(Base64.decode(value, Base64.URL_SAFE | Base64.NO_WRAP), StandardCharsets.UTF_8);
         Map<String, Object> basic = gson.fromJson(basicString, mapType);
         assertThat((String) basic.get("name"), is("auth0-python"));
         assertThat((String) basic.get("version"), is("99.3.1"));


### PR DESCRIPTION
### Changes

- Removed `Auth0#doNotSendTelemetry`
- If empty values passed to `Auth0UserAgent`, default values will be used for the name and version
- Adds no-arg constructor to `Auth0UserAgent`, which will construct an instance using default values
- Updates `Auth0` to use the new no-arg constructor, removing the need to specify the values there

### Testing

Unit tests added for the new constructor as well as the behavior to use defaults if empty values passed.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
