### PR TITLE
Make callback interfaces take non-null arguments

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.kt
@@ -101,12 +101,12 @@ public class ProfileRequest
      */
     override fun start(callback: BaseCallback<Authentication, AuthenticationException>) {
         authenticationRequest.start(object : BaseCallback<Credentials, AuthenticationException> {
-            override fun onSuccess(credentials: Credentials?) {
+            override fun onSuccess(credentials: Credentials) {
                 userInfoRequest
-                    .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials!!.accessToken)
+                    .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials.accessToken)
                     .start(object : BaseCallback<UserProfile, AuthenticationException> {
-                        override fun onSuccess(profile: UserProfile?) {
-                            callback.onSuccess(Authentication(profile!!, credentials))
+                        override fun onSuccess(profile: UserProfile) {
+                            callback.onSuccess(Authentication(profile, credentials))
                         }
 
                         override fun onFailure(error: AuthenticationException) {

--- a/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.kt
@@ -152,7 +152,7 @@ public class SignUpRequest
      */
     override fun start(callback: BaseCallback<Credentials, AuthenticationException>) {
         signUpRequest.start(object : BaseCallback<DatabaseUser, AuthenticationException> {
-            override fun onSuccess(user: DatabaseUser?) {
+            override fun onSuccess(user: DatabaseUser) {
                 authenticationRequest.start(callback)
             }
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -111,8 +111,8 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
             request.addParameter("scope", scope)
         }
         request.start(object : AuthenticationCallback<Credentials> {
-            override fun onSuccess(fresh: Credentials?) {
-                val expiresAt = fresh!!.expiresAt!!.time
+            override fun onSuccess(fresh: Credentials) {
+                val expiresAt = fresh.expiresAt!!.time
                 val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
                 if (willAccessTokenExpire) {
                     val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -335,8 +335,8 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
             request.addParameter("scope", scope)
         }
         request.start(object : AuthenticationCallback<Credentials> {
-            override fun onSuccess(fresh: Credentials?) {
-                val expiresAt = fresh!!.expiresAt!!.time
+            override fun onSuccess(fresh: Credentials) {
+                val expiresAt = fresh.expiresAt!!.time
                 val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
                 if (willAccessTokenExpire) {
                     val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000

--- a/auth0/src/main/java/com/auth0/android/callback/BaseCallback.kt
+++ b/auth0/src/main/java/com/auth0/android/callback/BaseCallback.kt
@@ -31,9 +31,9 @@ import com.auth0.android.Auth0Exception
 //TODO [SDK-2185]: Merge this interface into Callback
 public interface BaseCallback<T, U : Auth0Exception> : Callback<U> {
     /**
-     * Method called on success with the payload or null.
+     * Method called on success with the payload.
      *
-     * @param payload Request payload or null
+     * @param payload Request payload
      */
     public fun onSuccess(payload: T)
 }

--- a/auth0/src/main/java/com/auth0/android/callback/BaseCallback.kt
+++ b/auth0/src/main/java/com/auth0/android/callback/BaseCallback.kt
@@ -35,5 +35,5 @@ public interface BaseCallback<T, U : Auth0Exception> : Callback<U> {
      *
      * @param payload Request payload or null
      */
-    public fun onSuccess(payload: T?)
+    public fun onSuccess(payload: T)
 }

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
@@ -27,7 +27,7 @@ internal class LogoutManager(
                 Auth0Exception("The user closed the browser app so the logout was cancelled.", null)
             callback.onFailure(exception)
         } else {
-            callback.onSuccess(null)
+            callback.onSuccess(Unit)
         }
         return true
     }

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -104,7 +104,7 @@ internal class OAuthManager(
         ) {
             override fun onSuccess(credentials: Credentials) {
                 assertValidIdToken(credentials.idToken, object : VoidCallback {
-                    override fun onSuccess(ignored: Unit?) {
+                    override fun onSuccess(ignored: Unit) {
                         callback.onSuccess(credentials)
                     }
 
@@ -137,11 +137,11 @@ internal class OAuthManager(
                     validationCallback.onFailure(error)
                 }
 
-                override fun onSuccess(signatureVerifier: SignatureVerifier?) {
+                override fun onSuccess(signatureVerifier: SignatureVerifier) {
                     val options = IdTokenVerificationOptions(
                         idTokenVerificationIssuer!!,
                         apiClient.clientId,
-                        signatureVerifier!!
+                        signatureVerifier
                     )
                     val maxAge = parameters[KEY_MAX_AGE]
                     if (!TextUtils.isEmpty(maxAge)) {
@@ -153,7 +153,7 @@ internal class OAuthManager(
                     try {
                         IdTokenVerifier().verify(decodedIdToken, options)
                         logDebug("Authenticated using web flow")
-                        validationCallback.onSuccess(null)
+                        validationCallback.onSuccess(Unit)
                     } catch (exc: TokenValidationException) {
                         validationCallback.onFailure(exc)
                     }
@@ -271,7 +271,7 @@ internal class OAuthManager(
         private const val KEY_CODE = "code"
 
         @JvmStatic
-        @VisibleForTesting
+        @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
         @Throws(AuthenticationException::class)
         fun assertValidState(requestState: String, responseState: String?) {
             if (requestState != responseState) {
@@ -290,7 +290,7 @@ internal class OAuthManager(
             }
         }
 
-        @VisibleForTesting
+        @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
         fun getRandomString(defaultValue: String?): String {
             return defaultValue ?: secureRandomString()
         }

--- a/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
@@ -11,6 +11,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
+import kotlin.Unit;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,7 +55,7 @@ public class LogoutManagerTest {
         AuthorizeResult result = mock(AuthorizeResult.class);
         when(result.isCanceled()).thenReturn(false);
         manager.resume(result);
-        verify(callback).onSuccess(eq(null));
+        verify(callback).onSuccess(eq(Unit.INSTANCE));
     }
 
 }

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -2345,7 +2345,7 @@ public class WebAuthProviderTest {
         MatcherAssert.assertThat(uri, `is`(notNullValue()))
         val intent = createAuthIntent("")
         Assert.assertTrue(resume(intent))
-        verify(voidCallback).onSuccess(eq<Unit?>(null))
+        verify(voidCallback).onSuccess(eq(Unit))
     }
 
     @Test

--- a/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
+++ b/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
@@ -45,7 +45,7 @@ class DatabaseLoginFragment : Fragment() {
                     Snackbar.make(requireView(), "Failure :(", Snackbar.LENGTH_LONG).show()
                 }
 
-                override fun onSuccess(payload: Credentials?) {
+                override fun onSuccess(payload: Credentials) {
                     Snackbar.make(requireView(), "Success :D", Snackbar.LENGTH_LONG).show()
                 }
             })


### PR DESCRIPTION
### Changes
Before this PR, the `onSuccess` method of the callback implementations received a "nullable" parameter as the result. This would never be the case, unless for representing a success that doesn't have a result (e.g. reset password method). This should help Kotlin callers to avoid null-checking the received value, when we know it's never going to be null. A failure when parsing the JSON would probably fire an exception via the callback's on error instead.

