### PR TITLE
Revert "Make callback interfaces take non-null arguments"

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.kt
@@ -101,12 +101,12 @@ public class ProfileRequest
      */
     override fun start(callback: BaseCallback<Authentication, AuthenticationException>) {
         authenticationRequest.start(object : BaseCallback<Credentials, AuthenticationException> {
-            override fun onSuccess(credentials: Credentials) {
+            override fun onSuccess(credentials: Credentials?) {
                 userInfoRequest
-                    .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials.accessToken)
+                    .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials!!.accessToken)
                     .start(object : BaseCallback<UserProfile, AuthenticationException> {
-                        override fun onSuccess(profile: UserProfile) {
-                            callback.onSuccess(Authentication(profile, credentials))
+                        override fun onSuccess(profile: UserProfile?) {
+                            callback.onSuccess(Authentication(profile!!, credentials))
                         }
 
                         override fun onFailure(error: AuthenticationException) {

--- a/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.kt
@@ -152,7 +152,7 @@ public class SignUpRequest
      */
     override fun start(callback: BaseCallback<Credentials, AuthenticationException>) {
         signUpRequest.start(object : BaseCallback<DatabaseUser, AuthenticationException> {
-            override fun onSuccess(user: DatabaseUser) {
+            override fun onSuccess(user: DatabaseUser?) {
                 authenticationRequest.start(callback)
             }
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -111,8 +111,8 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
             request.addParameter("scope", scope)
         }
         request.start(object : AuthenticationCallback<Credentials> {
-            override fun onSuccess(fresh: Credentials) {
-                val expiresAt = fresh.expiresAt!!.time
+            override fun onSuccess(fresh: Credentials?) {
+                val expiresAt = fresh!!.expiresAt!!.time
                 val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
                 if (willAccessTokenExpire) {
                     val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -335,8 +335,8 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
             request.addParameter("scope", scope)
         }
         request.start(object : AuthenticationCallback<Credentials> {
-            override fun onSuccess(fresh: Credentials) {
-                val expiresAt = fresh.expiresAt!!.time
+            override fun onSuccess(fresh: Credentials?) {
+                val expiresAt = fresh!!.expiresAt!!.time
                 val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
                 if (willAccessTokenExpire) {
                     val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000

--- a/auth0/src/main/java/com/auth0/android/callback/BaseCallback.kt
+++ b/auth0/src/main/java/com/auth0/android/callback/BaseCallback.kt
@@ -31,9 +31,9 @@ import com.auth0.android.Auth0Exception
 //TODO [SDK-2185]: Merge this interface into Callback
 public interface BaseCallback<T, U : Auth0Exception> : Callback<U> {
     /**
-     * Method called on success with the payload.
+     * Method called on success with the payload or null.
      *
-     * @param payload Request payload
+     * @param payload Request payload or null
      */
-    public fun onSuccess(payload: T)
+    public fun onSuccess(payload: T?)
 }

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
@@ -27,7 +27,7 @@ internal class LogoutManager(
                 Auth0Exception("The user closed the browser app so the logout was cancelled.", null)
             callback.onFailure(exception)
         } else {
-            callback.onSuccess(Unit)
+            callback.onSuccess(null)
         }
         return true
     }

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -104,7 +104,7 @@ internal class OAuthManager(
         ) {
             override fun onSuccess(credentials: Credentials) {
                 assertValidIdToken(credentials.idToken, object : VoidCallback {
-                    override fun onSuccess(ignored: Unit) {
+                    override fun onSuccess(ignored: Unit?) {
                         callback.onSuccess(credentials)
                     }
 
@@ -137,11 +137,11 @@ internal class OAuthManager(
                     validationCallback.onFailure(error)
                 }
 
-                override fun onSuccess(signatureVerifier: SignatureVerifier) {
+                override fun onSuccess(signatureVerifier: SignatureVerifier?) {
                     val options = IdTokenVerificationOptions(
                         idTokenVerificationIssuer!!,
                         apiClient.clientId,
-                        signatureVerifier
+                        signatureVerifier!!
                     )
                     val maxAge = parameters[KEY_MAX_AGE]
                     if (!TextUtils.isEmpty(maxAge)) {
@@ -153,7 +153,7 @@ internal class OAuthManager(
                     try {
                         IdTokenVerifier().verify(decodedIdToken, options)
                         logDebug("Authenticated using web flow")
-                        validationCallback.onSuccess(Unit)
+                        validationCallback.onSuccess(null)
                     } catch (exc: TokenValidationException) {
                         validationCallback.onFailure(exc)
                     }
@@ -271,7 +271,7 @@ internal class OAuthManager(
         private const val KEY_CODE = "code"
 
         @JvmStatic
-        @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+        @VisibleForTesting
         @Throws(AuthenticationException::class)
         fun assertValidState(requestState: String, responseState: String?) {
             if (requestState != responseState) {
@@ -290,7 +290,7 @@ internal class OAuthManager(
             }
         }
 
-        @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+        @VisibleForTesting
         fun getRandomString(defaultValue: String?): String {
             return defaultValue ?: secureRandomString()
         }

--- a/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
@@ -11,8 +11,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
-import kotlin.Unit;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,7 +53,7 @@ public class LogoutManagerTest {
         AuthorizeResult result = mock(AuthorizeResult.class);
         when(result.isCanceled()).thenReturn(false);
         manager.resume(result);
-        verify(callback).onSuccess(eq(Unit.INSTANCE));
+        verify(callback).onSuccess(eq(null));
     }
 
 }

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -2345,7 +2345,7 @@ public class WebAuthProviderTest {
         MatcherAssert.assertThat(uri, `is`(notNullValue()))
         val intent = createAuthIntent("")
         Assert.assertTrue(resume(intent))
-        verify(voidCallback).onSuccess(eq(Unit))
+        verify(voidCallback).onSuccess(eq<Unit?>(null))
     }
 
     @Test

--- a/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
+++ b/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
@@ -45,7 +45,7 @@ class DatabaseLoginFragment : Fragment() {
                     Snackbar.make(requireView(), "Failure :(", Snackbar.LENGTH_LONG).show()
                 }
 
-                override fun onSuccess(payload: Credentials) {
+                override fun onSuccess(payload: Credentials?) {
                     Snackbar.make(requireView(), "Success :D", Snackbar.LENGTH_LONG).show()
                 }
             })


### PR DESCRIPTION
We faced some issues with `kotlin.Unit` not being available from Java-only projects. Those implementing the callback interface where a `Unit` response type was specified, would face compile errors. This PR reverts auth0/Auth0.Android#411. 

A follow-up PR will change `Unit` type in public APIs to `Void`, to keep Java compatibility, and make the onSuccess method be called with `null` instead of `Unit`. That implies that Kotlin will enforce with its nullability checks that we don't pass `null` to a method that has a non-null argument, the reason why we are reverting this PR to make the success scenario again optional.

We will revisit this during the Beta period.