### PR TITLE
Stop using kotlin.Unit in public APIs

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -430,11 +430,10 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @param connection of the database to request the reset password on
      * @return a request to configure and start
      */
-    //TODO: Document the signature change (Unit)
     public fun resetPassword(
         email: String,
         connection: String
-    ): DatabaseConnectionRequest<Unit, AuthenticationException> {
+    ): DatabaseConnectionRequest<Void, AuthenticationException> {
         val url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
             .addPathSegment(DB_CONNECTIONS_PATH)
             .addPathSegment(CHANGE_PASSWORD_PATH)
@@ -468,8 +467,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @param refreshToken the token to revoke
      * @return a request to start
      */
-    //TODO: Document the signature change (Unit)
-    public fun revokeToken(refreshToken: String): Request<Unit, AuthenticationException> {
+    public fun revokeToken(refreshToken: String): Request<Void, AuthenticationException> {
         val parameters = ParameterBuilder.newBuilder()
             .setClientId(clientId)
             .set(TOKEN_KEY, refreshToken)
@@ -543,12 +541,12 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @param connection       the passwordless connection to start the flow with.
      * @return a request to configure and start
      */
-    @JvmOverloads  //TODO: Document the signature change (Unit)
+    @JvmOverloads
     public fun passwordlessWithEmail(
         email: String,
         passwordlessType: PasswordlessType,
         connection: String = EMAIL_CONNECTION
-    ): Request<Unit, AuthenticationException> {
+    ): Request<Void, AuthenticationException> {
         val parameters = ParameterBuilder.newBuilder()
             .set(EMAIL_KEY, email)
             .setSend(passwordlessType)
@@ -579,12 +577,12 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @param connection       the passwordless connection to start the flow with.
      * @return a request to configure and start
      */
-    @JvmOverloads  //TODO: Document the signature change (Unit)
+    @JvmOverloads
     public fun passwordlessWithSMS(
         phoneNumber: String,
         passwordlessType: PasswordlessType,
         connection: String = SMS_CONNECTION
-    ): Request<Unit, AuthenticationException> {
+    ): Request<Void, AuthenticationException> {
         val parameters = ParameterBuilder.newBuilder()
             .set(PHONE_NUMBER_KEY, phoneNumber)
             .setSend(passwordlessType)
@@ -599,8 +597,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      *
      * @return a request to configure and start
      */
-    //TODO: Document the signature change (Unit)
-    private fun passwordless(): Request<Unit, AuthenticationException> {
+    private fun passwordless(): Request<Void, AuthenticationException> {
         val url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
             .addPathSegment(PASSWORDLESS_PATH)
             .addPathSegment(START_PATH)

--- a/auth0/src/main/java/com/auth0/android/authentication/request/DatabaseConnectionRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/DatabaseConnectionRequest.kt
@@ -72,7 +72,7 @@ public open class DatabaseConnectionRequest<T, U : Auth0Exception>(private val r
      * @throws Auth0Exception if the request failed
      */
     @Throws(Auth0Exception::class)
-    public fun execute(): T {
+    public fun execute(): T? {
         return request.execute()
     }
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/ProfileRequest.kt
@@ -129,11 +129,11 @@ public class ProfileRequest
      */
     @Throws(Auth0Exception::class)
     override fun execute(): Authentication {
-        val credentials = authenticationRequest.execute()
+        val credentials = authenticationRequest.execute()!!
         val profile = userInfoRequest
             .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials.accessToken)
             .execute()
-        return Authentication(profile, credentials)
+        return Authentication(profile!!, credentials)
     }
 
     private companion object {

--- a/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/request/SignUpRequest.kt
@@ -171,6 +171,6 @@ public class SignUpRequest
     @Throws(Auth0Exception::class)
     override fun execute(): Credentials {
         signUpRequest.execute()
-        return authenticationRequest.execute()
+        return authenticationRequest.execute()!!
     }
 }

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -104,7 +104,7 @@ internal class OAuthManager(
             object : BaseCallback<Credentials, AuthenticationException> {
                 override fun onSuccess(credentials: Credentials?) {
                     assertValidIdToken(credentials!!.idToken, object : VoidCallback {
-                        override fun onSuccess(payload: Unit?) {
+                        override fun onSuccess(payload: Void?) {
                             callback.onSuccess(credentials)
                         }
 
@@ -281,7 +281,7 @@ internal class OAuthManager(
         private const val KEY_CODE = "code"
 
         @JvmStatic
-        @VisibleForTesting
+        @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
         @Throws(AuthenticationException::class)
         fun assertValidState(requestState: String, responseState: String?) {
             if (requestState != responseState) {
@@ -300,7 +300,7 @@ internal class OAuthManager(
             }
         }
 
-        @VisibleForTesting
+        @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
         fun getRandomString(defaultValue: String?): String {
             return defaultValue ?: secureRandomString()
         }

--- a/auth0/src/main/java/com/auth0/android/provider/VoidCallback.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/VoidCallback.kt
@@ -29,4 +29,4 @@ import com.auth0.android.callback.BaseCallback
 /**
  * Generic callback called on success/failure, that receives no payload when succeeds.
  */
-public interface VoidCallback : BaseCallback<Unit, Auth0Exception>
+public interface VoidCallback : BaseCallback<Void, Auth0Exception>

--- a/auth0/src/main/java/com/auth0/android/request/JsonAdapter.kt
+++ b/auth0/src/main/java/com/auth0/android/request/JsonAdapter.kt
@@ -14,6 +14,6 @@ public interface JsonAdapter<T> {
      * @throws IOException could be thrown to signal that the input was invalid.
      */
     @Throws(IOException::class)
-    public fun fromJson(reader: Reader): T
+    public fun fromJson(reader: Reader): T?
 
 }

--- a/auth0/src/main/java/com/auth0/android/request/Request.kt
+++ b/auth0/src/main/java/com/auth0/android/request/Request.kt
@@ -47,7 +47,7 @@ public interface Request<T, U : Auth0Exception> {
      * @throws Auth0Exception on failure
      */
     @Throws(Auth0Exception::class)
-    public fun execute(): T
+    public fun execute(): T?
 
     /**
      * Add parameters to the request as a Map of Object with the keys as String

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.kt
@@ -86,6 +86,6 @@ public open class BaseAuthenticationRequest(private val request: Request<Credent
 
     @Throws(Auth0Exception::class)
     override fun execute(): Credentials {
-        return request.execute()
+        return request.execute()!!
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
@@ -80,7 +80,7 @@ public open class BaseRequest<T, U : Auth0Exception> internal constructor(
     override fun start(callback: BaseCallback<T, U>) {
         threadSwitcher.backgroundThread {
             try {
-                val result: T = execute()
+                val result: T? = execute()
                 threadSwitcher.mainThread {
                     callback.onSuccess(result)
                 }
@@ -99,7 +99,7 @@ public open class BaseRequest<T, U : Auth0Exception> internal constructor(
      * The result is parsed into a <T> value or a <U> exception is thrown if something went wrong.
      */
     @kotlin.jvm.Throws(Auth0Exception::class)
-    override fun execute(): T {
+    override fun execute(): T? {
         val response: ServerResponse
         try {
             response = client.load(url, options)
@@ -112,7 +112,7 @@ public open class BaseRequest<T, U : Auth0Exception> internal constructor(
         val reader = AwareInputStreamReader(response.body, Charset.defaultCharset())
         if (response.isSuccess()) {
             //2. Successful scenario. Response of type T
-            val result: T = resultAdapter.fromJson(reader)
+            val result: T? = resultAdapter.fromJson(reader)
             reader.close()
             return result
         }

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
@@ -55,9 +55,11 @@ public class RequestFactory<U : Auth0Exception> internal constructor(
         resultAdapter: JsonAdapter<T>
     ): Request<T, U> = setupRequest(HttpMethod.POST, url, resultAdapter, errorAdapter)
 
-    public fun post(url: String): Request<Unit, U> =
-        this.post(url, object : JsonAdapter<Unit> {
-            override fun fromJson(reader: Reader) {}
+    public fun post(url: String): Request<Void, U> =
+        this.post(url, object : JsonAdapter<Void> {
+            override fun fromJson(reader: Reader): Void? {
+                return null
+            }
         })
 
     public fun <T> patch(

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -70,8 +70,6 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 
-import kotlin.Unit;
-
 import static com.auth0.android.util.AuthenticationCallbackMatcher.hasError;
 import static com.auth0.android.util.AuthenticationCallbackMatcher.hasNoError;
 import static com.auth0.android.util.AuthenticationCallbackMatcher.hasPayload;
@@ -854,7 +852,7 @@ public class AuthenticationAPIClientTest {
     public void shouldChangePassword() throws Exception {
         mockAPI.willReturnSuccessfulChangePassword();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.resetPassword(SUPPORT_AUTH0_COM, MY_CONNECTION)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -892,7 +890,7 @@ public class AuthenticationAPIClientTest {
     public void shouldRequestChangePassword() throws Exception {
         mockAPI.willReturnSuccessfulChangePassword();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.resetPassword(SUPPORT_AUTH0_COM, MY_CONNECTION)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -932,7 +930,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendEmailCodeWithCustomConnection() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithEmail(SUPPORT_AUTH0_COM, PasswordlessType.CODE, MY_CONNECTION)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -954,7 +952,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendEmailCode() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithEmail(SUPPORT_AUTH0_COM, PasswordlessType.CODE)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -994,7 +992,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendEmailLink() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithEmail(SUPPORT_AUTH0_COM, PasswordlessType.WEB_LINK)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -1016,7 +1014,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendEmailLinkWithCustomConnection() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithEmail(SUPPORT_AUTH0_COM, PasswordlessType.WEB_LINK, MY_CONNECTION)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -1056,7 +1054,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendEmailLinkAndroidWithCustomConnection() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithEmail(SUPPORT_AUTH0_COM, PasswordlessType.ANDROID_LINK, MY_CONNECTION)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -1078,7 +1076,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendEmailLinkAndroid() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithEmail(SUPPORT_AUTH0_COM, PasswordlessType.ANDROID_LINK)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -1118,7 +1116,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendSMSCodeWithCustomConnection() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithSMS("+1123123123", PasswordlessType.CODE, MY_CONNECTION)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -1140,7 +1138,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendSMSCode() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithSMS("+1123123123", PasswordlessType.CODE)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -1180,7 +1178,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendSMSLinkWithCustomConnection() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithSMS("+1123123123", PasswordlessType.WEB_LINK, MY_CONNECTION)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -1202,7 +1200,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendSMSLink() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithSMS("+1123123123", PasswordlessType.WEB_LINK)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -1242,7 +1240,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendSMSLinkAndroidWithCustomConnection() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithSMS("+1123123123", PasswordlessType.ANDROID_LINK, MY_CONNECTION)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -1264,7 +1262,7 @@ public class AuthenticationAPIClientTest {
     public void shouldSendSMSLinkAndroid() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.passwordlessWithSMS("+1123123123", PasswordlessType.ANDROID_LINK)
                 .start(callback);
         ShadowLooper.idleMainLooper();
@@ -1365,7 +1363,7 @@ public class AuthenticationAPIClientTest {
         AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
         mockAPI.willReturnSuccessfulEmptyBody();
-        final MockAuthenticationCallback<Unit> callback = new MockAuthenticationCallback<>();
+        final MockAuthenticationCallback<Void> callback = new MockAuthenticationCallback<>();
         client.revokeToken("refreshToken")
                 .start(callback);
         ShadowLooper.idleMainLooper();

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -2313,7 +2313,7 @@ public class WebAuthProviderTest {
         MatcherAssert.assertThat(uri, `is`(notNullValue()))
         val intent = createAuthIntent("")
         Assert.assertTrue(resume(intent))
-        verify(voidCallback).onSuccess(eq<Unit?>(null))
+        verify(voidCallback).onSuccess(eq<Void?>(null))
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
@@ -19,8 +19,6 @@ import org.robolectric.RobolectricTestRunner;
 
 import java.util.Locale;
 
-import kotlin.Unit;
-
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -166,7 +164,7 @@ public class RequestFactoryTest {
 
     @Test
     public void shouldCreateVoidPostRequest() {
-        Request<Unit, Auth0Exception> request = factory.post(BASE_URL);
+        Request<Void, Auth0Exception> request = factory.post(BASE_URL);
 
         assertThat(request, is(notNullValue()));
         assertThat(request, is(emptyPostRequest));

--- a/auth0/src/test/java/com/auth0/android/util/AuthenticationCallbackMatcher.java
+++ b/auth0/src/test/java/com/auth0/android/util/AuthenticationCallbackMatcher.java
@@ -32,8 +32,6 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
-import kotlin.Unit;
-
 import static com.jayway.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -81,8 +79,8 @@ public class AuthenticationCallbackMatcher<T> extends BaseMatcher<Authentication
         return new AuthenticationCallbackMatcher<>(is(nullValue(tClazz)), is(notNullValue(AuthenticationException.class)));
     }
 
-    public static Matcher<AuthenticationCallback<Unit>> hasNoError() {
-        return new AuthenticationCallbackMatcher<>(is(notNullValue(Unit.class)), is(nullValue(AuthenticationException.class)));
+    public static Matcher<AuthenticationCallback<Void>> hasNoError() {
+        return new AuthenticationCallbackMatcher<>(is(nullValue(Void.class)), is(nullValue(AuthenticationException.class)));
     }
 
     public static <T> Matcher<AuthenticationCallback<T>> hasError(Class<T> tClazz) {

--- a/auth0/src/test/java/com/auth0/android/util/ManagementCallbackMatcher.java
+++ b/auth0/src/test/java/com/auth0/android/util/ManagementCallbackMatcher.java
@@ -33,8 +33,6 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
-import kotlin.Unit;
-
 import static com.jayway.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -90,11 +88,11 @@ public class ManagementCallbackMatcher<T> extends BaseMatcher<ManagementCallback
         return new ManagementCallbackMatcher<>(TypeTokenMatcher.isA(typeToken), is(nullValue(ManagementException.class)));
     }
 
-    public static Matcher<ManagementCallback<Unit>> hasNoError() {
-        return new ManagementCallbackMatcher<>(is(notNullValue(Unit.class)), is(nullValue(ManagementException.class)));
+    public static Matcher<ManagementCallback<Void>> hasNoError() {
+        return new ManagementCallbackMatcher<>(is(notNullValue(Void.class)), is(nullValue(ManagementException.class)));
     }
 
-    public static Matcher<ManagementCallback<Unit>> hasError() {
-        return new ManagementCallbackMatcher<>(is(nullValue(Unit.class)), is(notNullValue(ManagementException.class)));
+    public static Matcher<ManagementCallback<Void>> hasError() {
+        return new ManagementCallbackMatcher<>(is(nullValue(Void.class)), is(notNullValue(ManagementException.class)));
     }
 }


### PR DESCRIPTION
### Changes

`Unit` is not directly available on Java-only projects. To avoid compile issues, this PR changes the public APIs to use Void where Unit was used.
