### PR TITLE
Update WebAuthProvider#start required Context

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -1,6 +1,6 @@
 package com.auth0.android.provider
 
-import android.app.Activity
+import android.content.Context
 import android.net.Uri
 import android.text.TextUtils
 import android.util.Base64
@@ -57,13 +57,13 @@ internal class OAuthManager(
         idTokenVerificationIssuer = if (TextUtils.isEmpty(issuer)) apiClient.baseURL else issuer
     }
 
-    fun startAuthentication(activity: Activity?, redirectUri: String, requestCode: Int) {
+    fun startAuthentication(context: Context, redirectUri: String, requestCode: Int) {
         addPKCEParameters(parameters, redirectUri, headers)
         addClientParameters(parameters, redirectUri)
         addValidationParameters(parameters)
         val uri = buildAuthorizeUri()
         this.requestCode = requestCode
-        AuthenticationActivity.authenticateUsingBrowser(activity!!, uri, ctOptions)
+        AuthenticationActivity.authenticateUsingBrowser(context, uri, ctOptions)
     }
 
     fun setHeaders(headers: Map<String, String>) {

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -23,7 +23,6 @@
  */
 package com.auth0.android.provider
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.util.Log
@@ -396,17 +395,17 @@ public object WebAuthProvider {
          * device does not support the necessary algorithms to support Proof of Key Exchange (PKCE)
          * (this is not expected).
          *
-         * @param activity context to run the authentication
+         * @param context context to run the authentication
          * @param callback to receive the parsed results
          * @see AuthenticationException.isBrowserAppNotAvailable
          * @see AuthenticationException.isPKCENotAvailable
          */
         public fun start(
-            activity: Activity,
+            context: Context,
             callback: Callback<Credentials, AuthenticationException>
         ) {
             resetManagerInstance()
-            if (!ctOptions.hasCompatibleBrowser(activity.packageManager)) {
+            if (!ctOptions.hasCompatibleBrowser(context.packageManager)) {
                 val ex = AuthenticationException(
                     "a0.browser_not_available",
                     "No compatible Browser application is installed."
@@ -423,11 +422,11 @@ public object WebAuthProvider {
             if (redirectUri == null) {
                 redirectUri = CallbackHelper.getCallbackUri(
                     scheme,
-                    activity.applicationContext.packageName,
+                    context.applicationContext.packageName,
                     account.getDomainUrl()
                 )
             }
-            manager.startAuthentication(activity, redirectUri!!, 110)
+            manager.startAuthentication(context, redirectUri!!, 110)
         }
 
         private companion object {

--- a/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/OAuthManagerTest.java
@@ -1,32 +1,16 @@
 package com.auth0.android.provider;
 
-import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationException;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
 
 @RunWith(RobolectricTestRunner.class)
 public class OAuthManagerTest {
-
-    @Mock
-    Auth0 account;
-    @Mock
-    AuthCallback callback;
-    @Mock
-    CustomTabsOptions ctOptions;
-
-    @Before
-    public void setUp() {
-        MockitoAnnotations.initMocks(this);
-    }
 
     @Test
     public void shouldHaveValidState() {


### PR DESCRIPTION
### Changes
Before we required an `Activity` context because we were launching an internal activity for the web view scenario (legacy). This is no longer the case, so the required context can be changed to just Context. 

**This is not a breaking change.**


