### PR TITLE
Enforce the "openid" scope for the WebAuthProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ WebAuthProvider.login(account)
     .start(this, callback)
 ```
 
-> The default scope used is `openid`
+> Regardless of the scopes passed, the `openid` scope is always enforced.
 
 #### Specify Connection scope
 

--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ The sample above requests tokens with the audience required to call the [Managem
 
 ```kotlin
 WebAuthProvider.login(account)
-    .withScope("openid profile email")
+    .withScope("openid profile email read:users")
     .start(this, callback)
 ```
 
-> Regardless of the scopes passed, the `openid` scope is always enforced.
+> The default scope used is `openid profile email`. Regardless of the scopes passed here, the `openid` scope is always enforced.
 
 #### Specify Connection scope
 
@@ -313,7 +313,7 @@ authentication
     })
 ```
 
-> The default scope used is `openid`
+> The default scope used is `openid profile email`
 
 
 #### Login using MFA with One Time Password code
@@ -352,7 +352,7 @@ authentication
     })
 ```
 
-> The default scope used is `openid`
+> The default scope used is `openid profile email`
 
 Step 2: Input the code
 
@@ -537,7 +537,7 @@ The credentials to save **must have** `expires_in` and at least an `access_token
 ```kotlin
 authentication
     .login("info@auth0.com", "a secret password", "my-database-connection")
-    .setScope("openid offline_access")
+    .setScope("openid email profile offline_access")
     .start(object : Callback<Credentials, AuthenticationException> {
         override fun onFailure(exception: AuthenticationException) {
             // Error

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -225,8 +225,8 @@ internal class OAuthManager(
         }
         val existingScopes = parameters[KEY_SCOPE]!!.split(" ")
             .map { it.toLowerCase(Locale.ROOT) }
-        if (!existingScopes.contains(DEFAULT_SCOPE)) {
-            val requiredScopes = (existingScopes + DEFAULT_SCOPE).joinToString(separator = " ")
+        if (!existingScopes.contains(REQUIRED_SCOPE)) {
+            val requiredScopes = (existingScopes + REQUIRED_SCOPE).joinToString(separator = " ")
             parameters[KEY_SCOPE] = requiredScopes
         }
     }
@@ -279,7 +279,8 @@ internal class OAuthManager(
         const val KEY_CONNECTION = "connection"
         const val KEY_SCOPE = "scope"
         const val RESPONSE_TYPE_CODE = "code"
-        private const val DEFAULT_SCOPE = "openid"
+        private const val DEFAULT_SCOPE = "openid profile email"
+        private const val REQUIRED_SCOPE = "openid"
         private const val ERROR_VALUE_INVALID_CONFIGURATION = "a0.invalid_configuration"
         private const val ERROR_VALUE_ACCESS_DENIED = "access_denied"
         private const val ERROR_VALUE_UNAUTHORIZED = "unauthorized"

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -310,12 +310,13 @@ public object WebAuthProvider {
 
         /**
          * Give a scope for this request.
+         * Regardless of the scopes passed, the "openid" scope is always enforced.
          *
          * @param scope to request.
          * @return the current builder instance
          */
         public fun withScope(scope: String): Builder {
-            values[KEY_SCOPE] = scope
+            values[OAuthManager.KEY_SCOPE] = scope
             return this
         }
 
@@ -434,14 +435,7 @@ public object WebAuthProvider {
 
         private companion object {
             private const val KEY_AUDIENCE = "audience"
-            private const val KEY_SCOPE = "scope"
             private const val KEY_CONNECTION_SCOPE = "connection_scope"
-            private const val DEFAULT_SCOPE = "openid"
-            private const val DEFAULT_SCHEME = "https"
-        }
-
-        init {
-            withScope(DEFAULT_SCOPE)
         }
     }
 }

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -309,7 +309,7 @@ public object WebAuthProvider {
         }
 
         /**
-         * Give a scope for this request.
+         * Give a scope for this request. The default scope used is "openid profile email".
          * Regardless of the scopes passed, the "openid" scope is always enforced.
          *
          * @param scope to request.

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -289,7 +289,7 @@ public class WebAuthProviderTest {
         val uri =
             intentCaptor.firstValue.getParcelableExtra<Uri>(AuthenticationActivity.EXTRA_AUTHORIZE_URI)
         MatcherAssert.assertThat(uri, `is`(notNullValue()))
-        MatcherAssert.assertThat(uri, UriMatchers.hasParamWithValue("scope", "openid"))
+        MatcherAssert.assertThat(uri, UriMatchers.hasParamWithValue("scope", "openid profile email"))
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -320,7 +320,7 @@ public class WebAuthProviderTest {
         val uri =
             intentCaptor.firstValue.getParcelableExtra<Uri>(AuthenticationActivity.EXTRA_AUTHORIZE_URI)
         MatcherAssert.assertThat(uri, `is`(notNullValue()))
-        MatcherAssert.assertThat(uri, UriMatchers.hasParamWithValue("scope", "profile super_scope"))
+        MatcherAssert.assertThat(uri, UriMatchers.hasParamWithValue("scope", "profile super_scope openid"))
     }
 
     @Test
@@ -348,7 +348,7 @@ public class WebAuthProviderTest {
         val uri =
             intentCaptor.firstValue.getParcelableExtra<Uri>(AuthenticationActivity.EXTRA_AUTHORIZE_URI)
         MatcherAssert.assertThat(uri, `is`(notNullValue()))
-        MatcherAssert.assertThat(uri, UriMatchers.hasParamWithValue("scope", "profile super_scope"))
+        MatcherAssert.assertThat(uri, UriMatchers.hasParamWithValue("scope", "profile super_scope openid"))
     }
 
     //connection scope


### PR DESCRIPTION
### Changes

This PR enforces the scope of "openid", required as part of the ID Token validation that happens during Web Auth. 