### PR TITLE
Stop using VoidCallback on WebAuth Logout 

### DIFF
--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -172,6 +172,10 @@ The ability to make requests to the [/delegation](https://auth0.com/docs/api/aut
 - `public void start(@NonNull Activity activity, @NonNull AuthCallback callback, int requestCode)`. Use `public void start(@NonNull Activity activity, @NonNull Callback<Credentials, AuthenticationException> callback)` instead.
 - `public Builder withResponseType(@ResponseType int type)`. There is no replacement; only Code + PKCE flow supported in v2.
 
+#### WebAuthProvider.LogoutBuilder
+
+- `public void start(@NonNull Context context, @NonNull VoidCallback callback)`. Use `public void start(@NonNull Context context, @NonNull Callback<Void, AuthenticationException> callback)` instead.
+
 #### UsersAPIClient
 
 - `public ParameterizableRequest<List<UserIdentity>, ManagementException> link(@NonNull String primaryUserId, @NonNull String secondaryToken)`. Use `public Request<List<UserIdentity>, ManagementException> link(@NonNull String primaryUserId, @NonNull String secondaryToken)` instead.

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
@@ -195,7 +195,8 @@ public class AuthenticationException : Auth0Exception {
     public val isLoginRequired: Boolean
         get() = "login_required" == code
 
-    private companion object {
+    internal companion object {
+        internal const val ERROR_VALUE_AUTHENTICATION_CANCELED = "a0.authentication_canceled"
         private const val ERROR_KEY = "error"
         private const val CODE_KEY = "code"
         private const val DESCRIPTION_KEY = "description"

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
@@ -4,12 +4,13 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import com.auth0.android.Auth0
-import com.auth0.android.Auth0Exception
+import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.callback.Callback
 import java.util.*
 
 internal class LogoutManager(
     private val account: Auth0,
-    private val callback: VoidCallback,
+    private val callback: Callback<Void, AuthenticationException>,
     returnToUrl: String,
     ctOptions: CustomTabsOptions
 ) : ResumableManager() {
@@ -23,8 +24,10 @@ internal class LogoutManager(
 
     public override fun resume(result: AuthorizeResult): Boolean {
         if (result.isCanceled) {
-            val exception =
-                Auth0Exception("The user closed the browser app so the logout was cancelled.", null)
+            val exception = AuthenticationException(
+                AuthenticationException.ERROR_VALUE_AUTHENTICATION_CANCELED,
+                "The user closed the browser app so the logout was cancelled."
+            )
             callback.onFailure(exception)
         } else {
             callback.onSuccess(null)

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -78,7 +78,7 @@ internal class OAuthManager(
         if (result.isCanceled) {
             //User cancelled the authentication
             val exception = AuthenticationException(
-                ERROR_VALUE_AUTHENTICATION_CANCELED,
+                AuthenticationException.ERROR_VALUE_AUTHENTICATION_CANCELED,
                 "The user closed the browser app and the authentication was canceled."
             )
             callback.onFailure(exception)
@@ -265,7 +265,6 @@ internal class OAuthManager(
         const val KEY_CONNECTION = "connection"
         const val RESPONSE_TYPE_CODE = "code"
         private const val ERROR_VALUE_INVALID_CONFIGURATION = "a0.invalid_configuration"
-        private const val ERROR_VALUE_AUTHENTICATION_CANCELED = "a0.authentication_canceled"
         private const val ERROR_VALUE_ACCESS_DENIED = "access_denied"
         private const val ERROR_VALUE_UNAUTHORIZED = "unauthorized"
         private const val ERROR_VALUE_LOGIN_REQUIRED = "login_required"

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -152,13 +152,15 @@ public object WebAuthProvider {
 
         /**
          * Request the user session to be cleared. When successful, the callback will get invoked.
-         * An error is raised if there are no browser applications installed in the device.
+         * An error is raised if there are no browser applications installed in the device or if
+         * the user closed the browser before completing the logout.
          *
          * @param context  to run the log out
          * @param callback to invoke when log out is successful
          * @see AuthenticationException.isBrowserAppNotAvailable
+         * @see AuthenticationException.isAuthenticationCanceled
          */
-        public fun start(context: Context, callback: VoidCallback) {
+        public fun start(context: Context, callback: Callback<Void, AuthenticationException>) {
             resetManagerInstance()
             if (!ctOptions.hasCompatibleBrowser(context.packageManager)) {
                 val ex = AuthenticationException(
@@ -393,12 +395,13 @@ public object WebAuthProvider {
          * Request user Authentication. The result will be received in the callback.
          * An error is raised if there are no browser applications installed in the device, or if
          * device does not support the necessary algorithms to support Proof of Key Exchange (PKCE)
-         * (this is not expected).
+         * (this is not expected), or if the user closed the browser before completing the authentication.
          *
          * @param context context to run the authentication
          * @param callback to receive the parsed results
          * @see AuthenticationException.isBrowserAppNotAvailable
          * @see AuthenticationException.isPKCENotAvailable
+         * @see AuthenticationException.isAuthenticationCanceled
          */
         public fun start(
             context: Context,

--- a/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
@@ -1,7 +1,8 @@
 package com.auth0.android.provider;
 
 import com.auth0.android.Auth0;
-import com.auth0.android.Auth0Exception;
+import com.auth0.android.authentication.AuthenticationException;
+import com.auth0.android.callback.Callback;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +27,7 @@ public class LogoutManagerTest {
     @Mock
     Auth0 account;
     @Mock
-    VoidCallback callback;
+    Callback<Void, AuthenticationException> callback;
     @Mock
     CustomTabsOptions customTabsOptions;
 
@@ -41,10 +42,11 @@ public class LogoutManagerTest {
         AuthorizeResult result = mock(AuthorizeResult.class);
         when(result.isCanceled()).thenReturn(true);
         manager.resume(result);
-        ArgumentCaptor<Auth0Exception> exceptionCaptor = ArgumentCaptor.forClass(Auth0Exception.class);
+        ArgumentCaptor<AuthenticationException> exceptionCaptor = ArgumentCaptor.forClass(AuthenticationException.class);
         verify(callback).onFailure(exceptionCaptor.capture());
         assertThat(exceptionCaptor.getValue(), is(notNullValue()));
-        assertThat(exceptionCaptor.getValue().getMessage(), is("The user closed the browser app so the logout was cancelled."));
+        assertThat(exceptionCaptor.getValue().getCode(), is("a0.authentication_canceled"));
+        assertThat(exceptionCaptor.getValue().getDescription(), is("The user closed the browser app so the logout was cancelled."));
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -8,7 +8,6 @@ import android.os.Parcelable
 import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.intent.matcher.UriMatchers
 import com.auth0.android.Auth0
-import com.auth0.android.Auth0Exception
 import com.auth0.android.MockAuth0
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
@@ -60,11 +59,10 @@ public class WebAuthProviderTest {
     private lateinit var callback: Callback<Credentials, AuthenticationException>
 
     @Mock
-    private lateinit var voidCallback: VoidCallback
+    private lateinit var voidCallback: Callback<Void, AuthenticationException>
     private lateinit var activity: Activity
     private lateinit var account: Auth0
 
-    private val auth0ExceptionCaptor: KArgumentCaptor<Auth0Exception> = argumentCaptor()
     private val authExceptionCaptor: KArgumentCaptor<AuthenticationException> = argumentCaptor()
     private val intentCaptor: KArgumentCaptor<Intent> = argumentCaptor()
     private val credentialsCaptor: KArgumentCaptor<Credentials> = argumentCaptor()
@@ -2326,13 +2324,13 @@ public class WebAuthProviderTest {
         //null data translates to result canceled
         val intent = createAuthIntent(null)
         Assert.assertTrue(resume(intent))
-        verify(voidCallback).onFailure(auth0ExceptionCaptor.capture())
+        verify(voidCallback).onFailure(authExceptionCaptor.capture())
         MatcherAssert.assertThat(
-            auth0ExceptionCaptor.firstValue,
+            authExceptionCaptor.firstValue,
             `is`(notNullValue())
         )
         MatcherAssert.assertThat(
-            auth0ExceptionCaptor.firstValue.message,
+            authExceptionCaptor.firstValue.getDescription(),
             `is`("The user closed the browser app so the logout was cancelled.")
         )
         assertThat(


### PR DESCRIPTION
### Changes

This `VoidCallback` usage is now replaced with a generic `Callback<Void, AuthenticationException>`. The "new" exception type has helpers to quickly check common error scenarios. e.g. browser app not available or user closed the browser. Besides the type change, the behavior of the class is the same.

The change is documented in the migration guide, and the tests have been updated.

Previously
```java
onFailure(Auth0Exception error){
  if (error) {
    // logout failed, cause unknown.
  }
}
```

Now

```java
onFailure(AuthenticationException error){
  if (error.isBrowserAppNotAvailable) {
    // Guide user to install a compatible browser app
  } else if (error.isAuthenticationCanceled) {
    // User closed the browser app and canceled the logout
  }
}
```
