### PR TITLE
Deprecate isAuthenticationCanceled in favor of isCanceled

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
@@ -143,7 +143,11 @@ public class AuthenticationException : Auth0Exception {
         get() = "a0.invalid_configuration" == code
 
     // When a user closes the browser app and in turn, cancels the authentication
+    @Deprecated("This property can refer to both log in and log out actions.", replaceWith = ReplaceWith("isCanceled"))
     public val isAuthenticationCanceled: Boolean
+        get() = isCanceled
+
+    public val isCanceled: Boolean
         get() = "a0.authentication_canceled" == code
 
     /// When MFA code is required to authenticate

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
@@ -409,6 +409,15 @@ public class AuthenticationExceptionTest {
     }
 
     @Test
+    public fun shouldHaveCanceled() {
+        values[CODE_KEY] = "a0.authentication_canceled"
+        val ex = AuthenticationException(
+            values
+        )
+        MatcherAssert.assertThat(ex.isCanceled, CoreMatchers.`is`(true))
+    }
+
+    @Test
     public fun shouldHavePasswordLeaked() {
         values[CODE_KEY] = "password_leaked"
         val ex = AuthenticationException(


### PR DESCRIPTION
### Changes

When reusing this `AuthenticationException` failure case for logout we noticed the name wasn't accurate enough. We have since renamed this to `isCanceled` and deprecated `isAuthenticationCanceled`.

### References

See #424 