### PR TITLE
Fix request to patch user metadata

### DIFF
--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
@@ -28,6 +28,7 @@ import com.auth0.android.Auth0
 import com.auth0.android.Auth0Exception
 import com.auth0.android.authentication.ParameterBuilder
 import com.auth0.android.request.*
+import com.auth0.android.request.internal.BaseRequest
 import com.auth0.android.request.internal.GsonAdapter
 import com.auth0.android.request.internal.GsonAdapter.Companion.forListOf
 import com.auth0.android.request.internal.GsonAdapter.Companion.forMap
@@ -186,8 +187,12 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
         val userProfileAdapter: JsonAdapter<UserProfile> = GsonAdapter(
             UserProfile::class.java, gson
         )
-        return factory.patch(url.toString(), userProfileAdapter)
-            .addParameter(USER_METADATA_KEY, gson.toJson(userMetadata))
+        val patch = factory.patch(
+            url.toString(),
+            userProfileAdapter
+        ) as BaseRequest<UserProfile, ManagementException>
+        patch.addParameter(USER_METADATA_KEY, userMetadata)
+        return patch
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/request/DefaultClient.kt
+++ b/auth0/src/main/java/com/auth0/android/request/DefaultClient.kt
@@ -40,7 +40,8 @@ public class DefaultClient() : NetworkingClient {
         when (options.method) {
             is HttpMethod.GET -> {
                 // add parameters as query
-                options.parameters.map { urlBuilder.addQueryParameter(it.key, it.value) }
+                options.parameters.filterValues { it is String }
+                    .map { urlBuilder.addQueryParameter(it.key, it.value as String) }
                 requestBuilder.method(options.method.toString(), null)
             }
             else -> {
@@ -66,6 +67,7 @@ public class DefaultClient() : NetworkingClient {
         val builder = OkHttpClient.Builder()
 
         // logging
+        //TODO: OFF by default!
         if (enableLogging) {
             val logger: Interceptor = HttpLoggingInterceptor()
                 .setLevel(HttpLoggingInterceptor.Level.BODY)

--- a/auth0/src/main/java/com/auth0/android/request/RequestOptions.kt
+++ b/auth0/src/main/java/com/auth0/android/request/RequestOptions.kt
@@ -4,6 +4,6 @@ package com.auth0.android.request
  * Holder for the information required to configure a request
  */
 public class RequestOptions(public val method: HttpMethod) {
-    public val parameters: MutableMap<String, String> = mutableMapOf()
+    public val parameters: MutableMap<String, Any> = mutableMapOf()
     public val headers: MutableMap<String, String> = mutableMapOf()
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
@@ -71,6 +71,11 @@ public open class BaseRequest<T, U : Auth0Exception> internal constructor(
         return this
     }
 
+    internal fun addParameter(name: String, value: Any): Request<T, U> {
+        options.parameters[name] = value
+        return this
+    }
+
     /**
      * Runs asynchronously and executes the network request, without blocking the current thread.
      * The result is parsed into a <T> value and posted in the callback's onSuccess method or a <U>

--- a/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
@@ -51,7 +51,6 @@ import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.collection.IsMapWithSize;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -288,7 +287,6 @@ public class UsersAPIClientTest {
     }
 
     @Test
-    @Ignore("PATCH method not supported by HttpUrlConnection")
     public void shouldUpdateUserMetadata() throws Exception {
         mockAPI.willReturnUserProfile();
 
@@ -316,7 +314,6 @@ public class UsersAPIClientTest {
     }
 
     @Test
-    @Ignore("PATCH method not supported by HttpUrlConnection")
     public void shouldUpdateUserMetadataSync() throws Exception {
         mockAPI.willReturnUserProfile();
 

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -1078,15 +1078,15 @@ public class WebAuthProviderTest {
                 )
             )
         )
-        MatcherAssert.assertThat<Map<String, String>>(
+        MatcherAssert.assertThat<Map<String, Any>>(
             codeOptionsCaptor.firstValue.parameters,
             IsMapContaining.hasEntry("code", "1234")
         )
-        MatcherAssert.assertThat<Map<String, String>>(
+        MatcherAssert.assertThat<Map<String, Any>>(
             codeOptionsCaptor.firstValue.parameters,
             IsMapContaining.hasEntry("grant_type", "authorization_code")
         )
-        MatcherAssert.assertThat<Map<String, String>>(
+        MatcherAssert.assertThat<Map<String, Any>>(
             codeOptionsCaptor.firstValue.parameters,
             IsMapContaining.hasKey("code_verifier")
         )

--- a/auth0/src/test/java/com/auth0/android/request/internal/BaseAuthenticationRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/BaseAuthenticationRequestTest.java
@@ -74,7 +74,7 @@ public class BaseAuthenticationRequestTest {
                 .execute();
 
         verify(client).load(eq(BASE_URL), optionsCaptor.capture());
-        Map<String, String> values = optionsCaptor.getValue().getParameters();
+        Map<String, Object> values = optionsCaptor.getValue().getParameters();
         assertThat(values, aMapWithSize(1));
         assertThat(values, hasEntry("grant_type", "grantType"));
     }
@@ -88,7 +88,7 @@ public class BaseAuthenticationRequestTest {
                 .execute();
 
         verify(client).load(eq(BASE_URL), optionsCaptor.capture());
-        Map<String, String> values = optionsCaptor.getValue().getParameters();
+        Map<String, Object> values = optionsCaptor.getValue().getParameters();
         assertThat(values, aMapWithSize(1));
         assertThat(values, hasEntry("connection", "my-connection"));
     }
@@ -102,7 +102,7 @@ public class BaseAuthenticationRequestTest {
                 .execute();
 
         verify(client).load(eq(BASE_URL), optionsCaptor.capture());
-        Map<String, String> values = optionsCaptor.getValue().getParameters();
+        Map<String, Object> values = optionsCaptor.getValue().getParameters();
         assertThat(values, aMapWithSize(1));
         assertThat(values, hasEntry("realm", "my-realm"));
     }
@@ -116,7 +116,7 @@ public class BaseAuthenticationRequestTest {
                 .execute();
 
         verify(client).load(eq(BASE_URL), optionsCaptor.capture());
-        Map<String, String> values = optionsCaptor.getValue().getParameters();
+        Map<String, Object> values = optionsCaptor.getValue().getParameters();
         assertThat(values, aMapWithSize(1));
         assertThat(values, hasEntry("scope", "email profile"));
     }
@@ -130,7 +130,7 @@ public class BaseAuthenticationRequestTest {
                 .execute();
 
         verify(client).load(eq(BASE_URL), optionsCaptor.capture());
-        Map<String, String> values = optionsCaptor.getValue().getParameters();
+        Map<String, Object> values = optionsCaptor.getValue().getParameters();
         assertThat(values, aMapWithSize(1));
         assertThat(values, hasEntry("audience", "my-api"));
     }
@@ -148,7 +148,7 @@ public class BaseAuthenticationRequestTest {
                 .execute();
 
         verify(client).load(eq(BASE_URL), optionsCaptor.capture());
-        Map<String, String> values = optionsCaptor.getValue().getParameters();
+        Map<String, Object> values = optionsCaptor.getValue().getParameters();
         assertThat(values, aMapWithSize(2));
         assertThat(values, hasEntry("extra", "value"));
         assertThat(values, hasEntry("123", "890"));

--- a/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.java
@@ -131,7 +131,7 @@ public class BaseRequestTest {
         baseRequest.execute();
 
         verify(client).load(eq(BASE_URL), optionsCaptor.capture());
-        Map<String, String> values = optionsCaptor.getValue().getParameters();
+        Map<String, Object> values = optionsCaptor.getValue().getParameters();
         assertThat(values, aMapWithSize(1));
         assertThat(values, hasEntry("A", "1"));
     }
@@ -148,7 +148,7 @@ public class BaseRequestTest {
         baseRequest.execute();
 
         verify(client).load(eq(BASE_URL), optionsCaptor.capture());
-        Map<String, String> values = optionsCaptor.getValue().getParameters();
+        Map<String, Object> values = optionsCaptor.getValue().getParameters();
         assertThat(values, aMapWithSize(2));
         assertThat(values, hasEntry("A", "1"));
         assertThat(values, hasEntry("B", "2"));


### PR DESCRIPTION
### Changes

The serialization of the `user_metadata` parameter was broken, as the internal classes required a String value to be passed, and the server expected an object / dictionary.

The solution proposed here involves an internal method (not exposed) and a cast to a type we know it's the right expected one, as the `RequestFactory` implementation that provides the request instance is ours as well.

The `RequestOptions` had to be changed to support being passed parameters of the `Any` (`Object`) type. This is this way since if we provide a hidden internal implementation that handles this one scenario and let the interface as it was, we could be leaving out those developers that decide to extend the NetworkingClient and implement their own PATCH requests; as they would still be receiving a String value.
