### PR TITLE
Add timeout and logging configurability to DefaultClient

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.kt
+++ b/auth0/src/main/java/com/auth0/android/Auth0.kt
@@ -25,6 +25,7 @@ package com.auth0.android
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
+import com.auth0.android.request.DefaultClient
 import com.auth0.android.util.Auth0UserAgent
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -88,7 +89,7 @@ public open class Auth0 @JvmOverloads constructor(
      *
      * @param timeout the new timeout value in seconds
      */
-    public var connectTimeoutInSeconds: Int = 10
+    public var connectTimeoutInSeconds: Int = DefaultClient.DEFAULT_TIMEOUT_SECONDS
     /**
      * @return Auth0 request readTimeoutInSeconds
      */
@@ -98,7 +99,7 @@ public open class Auth0 @JvmOverloads constructor(
      *
      * @param timeout the new timeout value in seconds
      */
-    public var readTimeoutInSeconds: Int = 10
+    public var readTimeoutInSeconds: Int = DefaultClient.DEFAULT_TIMEOUT_SECONDS
     /**
      * @return Auth0 request writeTimeoutInSeconds
      */
@@ -108,6 +109,7 @@ public open class Auth0 @JvmOverloads constructor(
      *
      * @param timeout the new timeout value in seconds
      */
+    // TODO - remove this, only expose connect and read timeouts
     public var writeTimeoutInSeconds: Int = 0
 
     /**

--- a/auth0/src/main/java/com/auth0/android/Auth0.kt
+++ b/auth0/src/main/java/com/auth0/android/Auth0.kt
@@ -88,7 +88,7 @@ public open class Auth0 @JvmOverloads constructor(
      *
      * @param timeout the new timeout value in seconds
      */
-    public var connectTimeoutInSeconds: Int = 0
+    public var connectTimeoutInSeconds: Int = 10
     /**
      * @return Auth0 request readTimeoutInSeconds
      */
@@ -98,7 +98,7 @@ public open class Auth0 @JvmOverloads constructor(
      *
      * @param timeout the new timeout value in seconds
      */
-    public var readTimeoutInSeconds: Int = 0
+    public var readTimeoutInSeconds: Int = 10
     /**
      * @return Auth0 request writeTimeoutInSeconds
      */

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -73,8 +73,8 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     public constructor(
         auth0: Auth0,
         networkingClient: NetworkingClient = DefaultClient(
-            connectTimeout = auth0.connectTimeoutInSeconds.toLong(),
-            readTimeout = auth0.readTimeoutInSeconds.toLong(),
+            connectTimeout = auth0.connectTimeoutInSeconds,
+            readTimeout = auth0.readTimeoutInSeconds,
             enableLogging = auth0.isLoggingEnabled
         )
     ) : this(

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -72,7 +72,11 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     @JvmOverloads
     public constructor(
         auth0: Auth0,
-        networkingClient: NetworkingClient = DefaultClient()
+        networkingClient: NetworkingClient = DefaultClient(
+            connectTimeout = auth0.connectTimeoutInSeconds.toLong(),
+            readTimeout = auth0.readTimeoutInSeconds.toLong(),
+            enableLogging = auth0.isLoggingEnabled
+        )
     ) : this(
         auth0,
         RequestFactory<AuthenticationException>(networkingClient, createErrorAdapter()),

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
@@ -67,8 +67,8 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
         auth0: Auth0,
         token: String,
         networkingClient: NetworkingClient = DefaultClient(
-            connectTimeout = auth0.connectTimeoutInSeconds.toLong(),
-            readTimeout = auth0.readTimeoutInSeconds.toLong(),
+            connectTimeout = auth0.connectTimeoutInSeconds,
+            readTimeout = auth0.readTimeoutInSeconds,
             enableLogging = auth0.isLoggingEnabled
         )
     ) : this(

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
@@ -66,7 +66,11 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
     public constructor(
         auth0: Auth0,
         token: String,
-        networkingClient: NetworkingClient = DefaultClient()
+        networkingClient: NetworkingClient = DefaultClient(
+            connectTimeout = auth0.connectTimeoutInSeconds.toLong(),
+            readTimeout = auth0.readTimeoutInSeconds.toLong(),
+            enableLogging = auth0.isLoggingEnabled
+        )
     ) : this(
         auth0,
         factoryForToken(token, networkingClient),

--- a/auth0/src/main/java/com/auth0/android/request/DefaultClient.kt
+++ b/auth0/src/main/java/com/auth0/android/request/DefaultClient.kt
@@ -22,8 +22,8 @@ import java.util.concurrent.TimeUnit
  * @param enableLogging whether HTTP request and response info should be logged. This should only be set to `true` for debugging purposes in non-production environments, as sensitive information is included in the logs. Defaults to `false`.
  */
 public class DefaultClient(
-        private val connectTimeout: Long = DEFAULT_TIMEOUT_SECONDS,
-        private val readTimeout: Long = DEFAULT_TIMEOUT_SECONDS,
+        private val connectTimeout: Int = DEFAULT_TIMEOUT_SECONDS,
+        private val readTimeout: Int = DEFAULT_TIMEOUT_SECONDS,
         private val defaultHeaders: Map<String, String> = mapOf(),
         private val enableLogging: Boolean = false
 ) : NetworkingClient {
@@ -32,7 +32,7 @@ public class DefaultClient(
     private val gson: Gson = GsonProvider.buildGson()
 
     @get:VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal var okHttpClient: OkHttpClient
+    internal val okHttpClient: OkHttpClient
 
     @Throws(IllegalArgumentException::class, IOException::class)
     override fun load(url: String, options: RequestOptions): ServerResponse {
@@ -84,16 +84,16 @@ public class DefaultClient(
         }
 
         // timeouts
-        builder.connectTimeout(connectTimeout, TimeUnit.SECONDS)
-        builder.readTimeout(readTimeout, TimeUnit.SECONDS)
+        builder.connectTimeout(connectTimeout.toLong(), TimeUnit.SECONDS)
+        builder.readTimeout(readTimeout.toLong(), TimeUnit.SECONDS)
 
         okHttpClient = builder.build()
     }
 
 
-    private companion object {
-        private const val DEFAULT_TIMEOUT_SECONDS: Long = 10
-        private val APPLICATION_JSON_UTF8: MediaType =
+    internal companion object {
+        const val DEFAULT_TIMEOUT_SECONDS: Int = 10
+        val APPLICATION_JSON_UTF8: MediaType =
             "application/json; charset=utf-8".toMediaType()
     }
 

--- a/auth0/src/test/java/com/auth0/android/request/DefaultClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/DefaultClientTest.kt
@@ -94,14 +94,14 @@ public class DefaultClientTest {
     public fun shouldHaveDefaultTimeoutValues() {
         val client = DefaultClient()
         assertThat(client.okHttpClient.connectTimeoutMillis, equalTo(10 * 1000))
-        assertThat(client.okHttpClient.connectTimeoutMillis, equalTo(10 * 1000))
+        assertThat(client.okHttpClient.readTimeoutMillis, equalTo(10 * 1000))
     }
 
     @Test
     public fun shouldUseTimeoutConfigIfSpecified() {
-        val client = DefaultClient(connectTimeout = 100, readTimeout = 100)
+        val client = DefaultClient(connectTimeout = 100, readTimeout = 200)
         assertThat(client.okHttpClient.connectTimeoutMillis, equalTo(100 * 1000))
-        assertThat(client.okHttpClient.connectTimeoutMillis, equalTo(100 * 1000))
+        assertThat(client.okHttpClient.readTimeoutMillis, equalTo(200 * 1000))
     }
 
     @Test
@@ -230,12 +230,14 @@ public class DefaultClientTest {
             assertThat(requestUri.query, nullValue())
             assertThat(request.bodyFromJson(), hasEntry("customer", "john-doe"))
         }
-
         val requestHeaders = request.headers.toMultimap()
         headers.forEach { (k, v) ->
-            assertThat(requestHeaders, hasEntry(
-                equalTo(k), hasItem(v)
-            ))
+            assertThat(
+                requestHeaders, hasEntry(
+                    equalTo(k), hasItem(v)
+                )
+            )
+            assertThat(requestHeaders[k], hasSize(1))
         }
     }
 

--- a/auth0/src/test/java/com/auth0/android/request/DefaultClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/DefaultClientTest.kt
@@ -3,11 +3,15 @@ package com.auth0.android.request
 import android.net.Uri
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import okhttp3.Interceptor
+import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.hasSize
 import org.hamcrest.collection.IsMapContaining.hasEntry
 import org.hamcrest.collection.IsMapWithSize.anEmptyMap
 import org.junit.After
@@ -33,7 +37,6 @@ public class DefaultClientTest {
 
     private lateinit var BASE_URL: String
     private lateinit var mockServer: MockWebServer
-    private val client: NetworkingClient = DefaultClient()
     private val gson = Gson()
 
     @Before
@@ -46,6 +49,59 @@ public class DefaultClientTest {
     @After
     public fun tearDown() {
         mockServer.shutdown()
+    }
+
+    @Test
+    public fun shouldAddDefaultHeadersToRequests() {
+        enqueueMockResponse(STATUS_SUCCESS, JSON_OK)
+        executeRequest(
+            HttpMethod.GET,
+            DefaultClient(defaultHeaders = mapOf("custom-header" to "custom-value"))
+        )
+
+        val sentRequest = mockServer.takeRequest()
+        requestAssertions(sentRequest, HttpMethod.GET, mapOf("custom-header" to "custom-value"))
+    }
+
+    @Test
+    public fun shouldOverrideDefaultHeadersWithRequestHeadersIfSameKey() {
+        enqueueMockResponse(STATUS_SUCCESS, JSON_OK)
+
+        executeRequest(
+            HttpMethod.GET,
+            DefaultClient(defaultHeaders = mapOf("a-header" to "a-value")),
+            requestHeaders = mutableMapOf("a-header" to "updated-value"))
+
+        val sentRequest = mockServer.takeRequest()
+        requestAssertions(sentRequest, HttpMethod.GET, mapOf("a-header" to "updated-value"))
+    }
+
+    @Test
+    public fun shouldHaveLoggingDisabledByDefault() {
+        assertThat(DefaultClient().okHttpClient.interceptors, empty())
+    }
+
+    @Test
+    public fun shouldHaveLoggingEnabledIfSpecified() {
+        val netClient = DefaultClient(enableLogging = true)
+        assertThat(netClient.okHttpClient.interceptors, hasSize(1))
+
+        val interceptor: Interceptor = netClient.okHttpClient.interceptors[0]
+        assertThat((interceptor as HttpLoggingInterceptor).level, equalTo(HttpLoggingInterceptor.Level.BODY))
+    }
+
+    @Test
+    public fun shouldHaveDefaultTimeoutValues() {
+        val client = DefaultClient()
+        assertThat(client.okHttpClient.connectTimeoutMillis, equalTo(10 * 1000))
+        assertThat(client.okHttpClient.connectTimeoutMillis, equalTo(10 * 1000))
+    }
+
+    @Test
+    public fun shouldUseTimeoutConfigIfSpecified() {
+        val client = DefaultClient(connectTimeout = 100, readTimeout = 100)
+        assertThat(client.okHttpClient.connectTimeoutMillis, equalTo(100 * 1000))
+        assertThat(client.okHttpClient.connectTimeoutMillis, equalTo(100 * 1000))
     }
 
     @Test
@@ -154,7 +210,10 @@ public class DefaultClientTest {
 
 
     //Helper methods
-    private fun requestAssertions(request: RecordedRequest, method: HttpMethod) {
+    private fun requestAssertions(
+        request: RecordedRequest,
+        method: HttpMethod,
+        headers: Map<String, String> = mapOf("a-header" to "b-value")) {
         val requestUri = Uri.parse(request.path)
         when (method) {
             HttpMethod.GET -> assertThat(request.method, equalTo("GET"))
@@ -163,6 +222,7 @@ public class DefaultClientTest {
             HttpMethod.DELETE -> assertThat(request.method, equalTo("DELETE"))
         }
         assertThat(requestUri.path, equalTo(URL_PATH))
+
         if (method == HttpMethod.GET) {
             assertThat(requestUri.getQueryParameter("customer"), equalTo("john-doe"))
             assertThat(request.bodyFromJson(), anEmptyMap())
@@ -170,13 +230,13 @@ public class DefaultClientTest {
             assertThat(requestUri.query, nullValue())
             assertThat(request.bodyFromJson(), hasEntry("customer", "john-doe"))
         }
-        assertThat(
-            request.headers.toMultimap(),
-            hasEntry(
-                equalTo("a-header"),
-                hasItem("b-value")
-            )
-        )
+
+        val requestHeaders = request.headers.toMultimap()
+        headers.forEach { (k, v) ->
+            assertThat(requestHeaders, hasEntry(
+                equalTo(k), hasItem(v)
+            ))
+        }
     }
 
     private fun responseAssertions(response: ServerResponse, httpStatus: Int, bodyJson: String) {
@@ -191,10 +251,14 @@ public class DefaultClientTest {
         )
     }
 
-    private fun executeRequest(method: HttpMethod): ServerResponse {
+    private fun executeRequest(
+        method: HttpMethod,
+        client: NetworkingClient = DefaultClient(),
+        requestHeaders: MutableMap<String, String> = mutableMapOf("a-header" to "b-value")
+    ): ServerResponse {
         val options = RequestOptions(method)
         options.parameters["customer"] = "john-doe"
-        options.headers["a-header"] = "b-value"
+        options.headers.putAll(requestHeaders)
 
         //Server response
         val destination = Uri.parse(BASE_URL).buildUpon()


### PR DESCRIPTION
### Changes

This change adds some named constructor parameters to `DefaultClient`, all with default values, to enable easier customization of some more common configurations, without needing to resort to implementing a custom `NetworkingClient`. The configuration options included in this PR are:

- `connectTimeout` - The connect timeout when making requests. Default is 10 seconds
- `readTimeout` - The read timeout when making requests. Default is 10 seconds
- `defaultHeaders` - Any headers that should be sent on all requests. Default is an empty map
- `enableLogging` - Whether to log HTTP request/response info. Default is false

As the configurations listed above are currently available on the `Auth0` class, the API clients have been updated to use these values when constructing the `DefaultClient` if a custom client is not specified.

Changes **not** in this PR, but planned to come soon, are:

- deprecations of the above configuration points on `Auth0`, in favor of using the networking client.
- removal of the `writeTimeoutInSeconds` configuration on `Auth0`. This is too tightly coupled to a specific networking client, and will likely be removed without replacement.
- possible removal of `isTLS12Enforced`. Investigation needs to be done to understand if this is still applicable with API version 21+ and OkHttp4.
- updated README documentation that demonstrates the configuration options of the networking client.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
