### PR TITLE
Remove obsolete config properties

### DIFF
--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -103,6 +103,8 @@ We will not provide support and will change these as required without any previo
 
 - `setOIDCConformant(boolean enabled)` and `isOIDCConformant()` have been removed. The SDK now only supports OIDC-Conformant applications.
 - `doNotSendTelemetry()` has been removed. There is no replacement.
+- `setWriteTimeoutInSeconds(seconds)` and `getWriteTimeoutInSeconds(seconds) have been removed. There is no replacement; only connect and read timeouts can be configured.
+- `setTLS12Enforced()` and `gisTLS12Enforced()` have been removed. The SDK now supports modern TLS by default.
 
 #### `AuthenticationAPIClient` methods removed or changed
 

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -103,8 +103,8 @@ We will not provide support and will change these as required without any previo
 
 - `setOIDCConformant(boolean enabled)` and `isOIDCConformant()` have been removed. The SDK now only supports OIDC-Conformant applications.
 - `doNotSendTelemetry()` has been removed. There is no replacement.
-- `setWriteTimeoutInSeconds(seconds)` and `getWriteTimeoutInSeconds(seconds) have been removed. There is no replacement; only connect and read timeouts can be configured.
-- `setTLS12Enforced()` and `gisTLS12Enforced()` have been removed. The SDK now supports modern TLS by default.
+- `setWriteTimeoutInSeconds(seconds)` and `getWriteTimeoutInSeconds(seconds)` have been removed. There is no replacement; only connect and read timeouts can be configured.
+- `setTLS12Enforced()` and `isTLS12Enforced()` have been removed. The SDK now supports modern TLS by default.
 
 #### `AuthenticationAPIClient` methods removed or changed
 

--- a/auth0/src/main/java/com/auth0/android/Auth0.kt
+++ b/auth0/src/main/java/com/auth0/android/Auth0.kt
@@ -57,6 +57,7 @@ public open class Auth0 @JvmOverloads constructor(
      */
     public var auth0UserAgent: Auth0UserAgent? = null
         private set
+
     /**
      * Whether HTTP request and response info should be logged.
      * This should only be set to `true` for debugging purposes in non-production environments, as sensitive information is included in the logs.
@@ -66,17 +67,6 @@ public open class Auth0 @JvmOverloads constructor(
         "Create a DefaultClient and specify enableLogging = true|false instead. This can then be included when creating the WebAuthProvider or the API clients"
     )
     public var isLoggingEnabled: Boolean = false
-    /**
-     * Getter for whether TLS 1.2 is enforced on devices with API 16-21.
-     *
-     * @return whether TLS 1.2 is enforced on devices with API 16-21.
-     */
-    /**
-     * Set whether to enforce TLS 1.2 on devices with API 16-21.
-     *
-     * @param enforced whether TLS 1.2 is enforced on devices with API 16-21.
-     */
-    public var isTLS12Enforced: Boolean = false
 
     /**
      * The connection timeout for network requests, in seconds. Defaults to 10 seconds.
@@ -93,18 +83,6 @@ public open class Auth0 @JvmOverloads constructor(
         "Create a DefaultClient and specify the readTimeout instead. This can then be included when creating the WebAuthProvider or the API clients"
     )
     public var readTimeoutInSeconds: Int = DefaultClient.DEFAULT_TIMEOUT_SECONDS
-
-    /**
-     * @return Auth0 request writeTimeoutInSeconds
-     */
-    /**
-     * Set the write timeout for network requests.
-     * By default, this value is 10 seconds.
-     *
-     * @param timeout the new timeout value in seconds
-     */
-    // TODO - remove this, only expose connect and read timeouts
-    public var writeTimeoutInSeconds: Int = 0
 
     /**
      * Creates a new Auth0 instance with the 'com_auth0_client_id' and 'com_auth0_domain' values

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -28,7 +28,6 @@ import android.content.Context;
 import android.content.res.Resources;
 
 import com.auth0.android.util.Auth0UserAgent;
-import okhttp3.HttpUrl;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -39,6 +38,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
+
+import okhttp3.HttpUrl;
 
 import static com.auth0.android.util.HttpUrlMatcher.hasHost;
 import static com.auth0.android.util.HttpUrlMatcher.hasPath;
@@ -91,28 +92,6 @@ public class Auth0Test {
     }
 
     @Test
-    public void shouldNotEnforceTLS12ByDefault() {
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        assertThat(auth0.isTLS12Enforced(), is(false));
-    }
-
-    @Test
-    public void shouldHaveTLS12Enforced() {
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.setTLS12Enforced(true);
-
-        assertThat(auth0.isTLS12Enforced(), is(true));
-    }
-
-    @Test
-    public void shouldNotHaveTLS12Enforced() {
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.setTLS12Enforced(false);
-
-        assertThat(auth0.isTLS12Enforced(), is(false));
-    }
-
-    @Test
     public void shouldHaveConnectTimeout() {
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
         auth0.setConnectTimeoutInSeconds(5);
@@ -126,14 +105,6 @@ public class Auth0Test {
         auth0.setReadTimeoutInSeconds(15);
 
         assertThat(auth0.getReadTimeoutInSeconds(), is(15));
-    }
-
-    @Test
-    public void shouldHaveWriteTimeout() {
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.setWriteTimeoutInSeconds(20);
-
-        assertThat(auth0.getWriteTimeoutInSeconds(), is(20));
     }
 
     @Test


### PR DESCRIPTION
### Changes

This change removes the following networking client customization methods on `Auth0`. From the migration guide:

- `setWriteTimeoutInSeconds(seconds)` and `getWriteTimeoutInSeconds(seconds)`
- `setTLS12Enforced()` and `isTLS12Enforced()`

The ability to configure the write timeout is being removed to simplify the networking client customization, and decouple from any specific client provider as much as possible. We will still support configuring the connect and read timeout settings.

TLS 1.2 is available on Android since API 16 but used by default since API 20. OkHttp v4 (the client this SDK uses internally) [defaults](https://square.github.io/okhttp/https/) to `MODERN_TLS` which is described as only accepting TLS 1.2 and 1.3.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
