### PR TITLE
Fix auth0UserAgent property definition

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.kt
+++ b/auth0/src/main/java/com/auth0/android/Auth0.kt
@@ -55,7 +55,7 @@ public open class Auth0 @JvmOverloads constructor(
     /**
      * @return Auth0 user agent info sent in every request
      */
-    public var auth0UserAgent: Auth0UserAgent? = null
+    public var auth0UserAgent: Auth0UserAgent
 
     /**
      * Whether HTTP request and response info should be logged.

--- a/auth0/src/main/java/com/auth0/android/Auth0.kt
+++ b/auth0/src/main/java/com/auth0/android/Auth0.kt
@@ -56,7 +56,6 @@ public open class Auth0 @JvmOverloads constructor(
      * @return Auth0 user agent info sent in every request
      */
     public var auth0UserAgent: Auth0UserAgent? = null
-        private set
 
     /**
      * Whether HTTP request and response info should be logged.
@@ -132,15 +131,7 @@ public open class Auth0 @JvmOverloads constructor(
             .addEncodedPathSegment("logout")
             .build()
             .toString()
-
-    /**
-     * Setter for the user agent info to send in every request to Auth0.
-     *
-     * @param auth0UserAgent to send in every request to Auth0.
-     */
-    public fun setAuth0UserAgent(auth0UserAgent: Auth0UserAgent) {
-        this.auth0UserAgent = auth0UserAgent
-    }
+    
 
     private fun resolveConfiguration(configurationDomain: String?, domainUrl: HttpUrl): HttpUrl {
         var url = ensureValidUrl(configurationDomain)


### PR DESCRIPTION
### Changes

Currently, the `auth0UserAgent` parameter is defined with a private setter, but we also have an explicit method to set it (`setAuth0UserAgent()`). This change removes the manual setter, in favor of using the generated setter/getter for the property.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
