### PR TITLE
Update the Credentials class

### DIFF
--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -96,6 +96,7 @@ We will not provide support and will change these as required without any previo
 - `UsersAPIClient` can no longer be constructed from a `Context`. Use UsersAPIClient(auth0: Auth0, token: String)` instead. You can create an instance of `Auth0` using a `Context`.
 - `SignupRequest` now requires the second parameter to be an `AuthenticationRequest`.
 - `ProfileRequest` now requires an `AuthenticationRequest` and a `Request<UserProfile, AuthenticationException>`.
+- `Credentials` can no longer be constructed with an "expires in" value. The date of expiration or "expires at" should be given instead. You typically won't be constructing Credentials on your own.
 
 ### Methods removed or changed
 

--- a/auth0/src/main/java/com/auth0/android/result/Credentials.kt
+++ b/auth0/src/main/java/com/auth0/android/result/Credentials.kt
@@ -11,12 +11,11 @@ import java.util.*
  *  * *accessToken*: Access Token for Auth0 API
  *  * *refreshToken*: Refresh Token that can be used to request new tokens without signing in again
  *  * *type*: The type of the received Token.
- *  * *expiresIn*: The token lifetime in seconds.
  *  * *expiresAt*: The token expiration date.
  *  * *scope*: The token's granted scope.
  *
  */
-public open class Credentials private constructor(
+public open class Credentials(
     /**
      * Getter for the Identity Token with user information.
      *
@@ -35,16 +34,25 @@ public open class Credentials private constructor(
      * @return the token type.
      */
     @field:SerializedName("token_type") public val type: String?,
+
     /**
      * Getter for the Refresh Token that can be used to request new tokens without signing in again.
      *
      * @return the Refresh Token.
      */
     @field:SerializedName("refresh_token") public val refreshToken: String?,
-    expiresIn: Long?,
-    expiresAt: Date?,
+
     /**
-     * Getter for the token's granted scope. Only available if the requested scope differs from the granted one.
+     * Getter for the expiration date of the Access Token.
+     * Once expired, the Access Token can no longer be used to access an API and a new Access Token needs to be obtained.
+     *
+     * @return the expiration date of this Access Token
+     */
+    @SerializedName("expires_at")
+    public val expiresAt: Date?,
+
+    /**
+     * Getter for the access token's granted scope. Only available if the requested scope differs from the granted one.
      *
      * @return the granted scope.
      */
@@ -53,56 +61,7 @@ public open class Credentials private constructor(
     ) public val scope: String?
 ) {
 
-    /**
-     * Getter for the token lifetime in seconds.
-     * Once expired, the token can no longer be used to access an API and a new token needs to be obtained.
-     *
-     * @return the token lifetime in seconds.
-     */
-    @SerializedName("expires_in")
-    public var expiresIn: Long? = null
-
-    /**
-     * Getter for the expiration date of this token.
-     * Once expired, the token can no longer be used to access an API and a new token needs to be obtained.
-     *
-     * @return the expiration date of this token
-     */
-    @SerializedName("expires_at")
-    public var expiresAt: Date? = null
-
-    //TODO [SDK-1431]: Deprecate this constructor
-    public constructor(
-        idToken: String?,
-        accessToken: String?,
-        type: String?,
-        refreshToken: String?,
-        expiresIn: Long?
-    ) : this(idToken, accessToken, type, refreshToken, expiresIn, null, null)
-
-    public constructor(
-        idToken: String?,
-        accessToken: String?,
-        type: String?,
-        refreshToken: String?,
-        expiresAt: Date?,
-        scope: String?
-    ) : this(idToken, accessToken, type, refreshToken, null, expiresAt, scope)
-
     @get:VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal open val currentTimeInMillis: Long
         get() = System.currentTimeMillis()
-
-    init {
-        if (expiresAt == null && expiresIn != null) {
-            this.expiresAt = Date(currentTimeInMillis + expiresIn * 1000)
-        } else {
-            this.expiresAt = expiresAt
-        }
-        this.expiresIn = if (expiresIn == null && expiresAt != null) {
-            (expiresAt.time - currentTimeInMillis) / 1000
-        } else {
-            expiresIn
-        }
-    }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -9,7 +9,6 @@ import com.auth0.android.result.Credentials
 import com.auth0.android.result.CredentialsMock
 import com.auth0.android.util.Clock
 import com.nhaarman.mockitokotlin2.*
-import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.hamcrest.core.Is
@@ -170,7 +169,8 @@ public class CredentialsManagerTest {
     public fun shouldThrowOnSetIfCredentialsDoesNotHaveIdTokenOrAccessToken() {
         exception.expect(CredentialsManagerException::class.java)
         exception.expectMessage("Credentials must have a valid date of expiration and a valid access_token or id_token value.")
-        val credentials: Credentials = CredentialsMock(null, null, "type", "refreshToken", 123456L)
+        val credentials: Credentials =
+            CredentialsMock(null, null, "type", "refreshToken", Date(), null)
         manager.saveCredentials(credentials)
     }
 
@@ -178,23 +178,22 @@ public class CredentialsManagerTest {
     public fun shouldThrowOnSetIfCredentialsDoesNotHaveExpiresAt() {
         exception.expect(CredentialsManagerException::class.java)
         exception.expectMessage("Credentials must have a valid date of expiration and a valid access_token or id_token value.")
-        val date: Date? = null
         val credentials: Credentials =
-            CredentialsMock("idToken", "accessToken", "type", "refreshToken", date, "scope")
+            CredentialsMock("idToken", "accessToken", "type", "refreshToken", null, "scope")
         manager.saveCredentials(credentials)
     }
 
     @Test
-    public fun shouldNotThrowOnSetIfCredentialsHaveAccessTokenAndExpiresIn() {
+    public fun shouldNotThrowOnSetIfCredentialsHasAccessTokenAndExpiresAt() {
         val credentials: Credentials =
-            CredentialsMock(null, "accessToken", "type", "refreshToken", 123456L)
+            CredentialsMock(null, "accessToken", "type", "refreshToken", Date(), null)
         manager.saveCredentials(credentials)
     }
 
     @Test
-    public fun shouldNotThrowOnSetIfCredentialsHaveIdTokenAndExpiresIn() {
+    public fun shouldNotThrowOnSetIfCredentialsHasIdTokenAndExpiresAt() {
         val credentials: Credentials =
-            CredentialsMock("idToken", null, "type", "refreshToken", 123456L)
+            CredentialsMock("idToken", null, "type", "refreshToken", Date(), null)
         prepareJwtDecoderMock(Date())
         manager.saveCredentials(credentials)
     }
@@ -282,13 +281,6 @@ public class CredentialsManagerTest {
         MatcherAssert.assertThat(retrievedCredentials.idToken, Is.`is`("idToken"))
         MatcherAssert.assertThat(retrievedCredentials.refreshToken, Is.`is`("refreshToken"))
         MatcherAssert.assertThat(retrievedCredentials.type, Is.`is`("type"))
-        MatcherAssert.assertThat(retrievedCredentials.expiresIn, Is.`is`(Matchers.notNullValue()))
-        // TODO [SDK-2184]: fix clock mocking to avoid CredentialsManager expiresIn calculation
-        MatcherAssert.assertThat(
-            retrievedCredentials.expiresIn!!.toDouble(), CoreMatchers.`is`(
-                Matchers.closeTo(ONE_HOUR_SECONDS.toDouble(), 50.0)
-            )
-        )
         MatcherAssert.assertThat(retrievedCredentials.expiresAt, Is.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(retrievedCredentials.expiresAt!!.time, Is.`is`(expirationTime))
         MatcherAssert.assertThat(retrievedCredentials.scope, Is.`is`("scope"))
@@ -316,13 +308,6 @@ public class CredentialsManagerTest {
         MatcherAssert.assertThat(retrievedCredentials.idToken, Is.`is`("idToken"))
         MatcherAssert.assertThat(retrievedCredentials.refreshToken, Is.`is`("refreshToken"))
         MatcherAssert.assertThat(retrievedCredentials.type, Is.`is`("type"))
-        MatcherAssert.assertThat(retrievedCredentials.expiresIn, Is.`is`(Matchers.notNullValue()))
-        // TODO [SDK-2184]: fix clock mocking to avoid CredentialsManager expiresIn calculation
-        MatcherAssert.assertThat(
-            retrievedCredentials.expiresIn!!.toDouble(), CoreMatchers.`is`(
-                Matchers.closeTo(ONE_HOUR_SECONDS.toDouble(), 50.0)
-            )
-        )
         MatcherAssert.assertThat(retrievedCredentials.expiresAt, Is.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(retrievedCredentials.expiresAt!!.time, Is.`is`(expirationTime))
         MatcherAssert.assertThat(retrievedCredentials.scope, Is.`is`("scope"))
@@ -350,13 +335,6 @@ public class CredentialsManagerTest {
         MatcherAssert.assertThat(retrievedCredentials.idToken, Is.`is`(Matchers.nullValue()))
         MatcherAssert.assertThat(retrievedCredentials.refreshToken, Is.`is`("refreshToken"))
         MatcherAssert.assertThat(retrievedCredentials.type, Is.`is`("type"))
-        MatcherAssert.assertThat(retrievedCredentials.expiresIn, Is.`is`(Matchers.notNullValue()))
-        // TODO [SDK-2184]: fix clock mocking to avoid CredentialsManager expiresIn calculation
-        MatcherAssert.assertThat(
-            retrievedCredentials.expiresIn!!.toDouble(), CoreMatchers.`is`(
-                Matchers.closeTo(ONE_HOUR_SECONDS.toDouble(), 50.0)
-            )
-        )
         MatcherAssert.assertThat(retrievedCredentials.expiresAt, Is.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(retrievedCredentials.expiresAt!!.time, Is.`is`(expirationTime))
         MatcherAssert.assertThat(retrievedCredentials.scope, Is.`is`("scope"))

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -67,7 +67,8 @@ public class SecureCredentialsManagerTest {
 
     private val stringCaptor: KArgumentCaptor<String> = argumentCaptor()
 
-    private val requestCallbackCaptor: KArgumentCaptor<Callback<Credentials, AuthenticationException>> = argumentCaptor()
+    private val requestCallbackCaptor: KArgumentCaptor<Callback<Credentials, AuthenticationException>> =
+        argumentCaptor()
 
     @get:Rule
     public val exception: ExpectedException = ExpectedException.none()
@@ -313,7 +314,7 @@ public class SecureCredentialsManagerTest {
         exception.expect(CredentialsManagerException::class.java)
         exception.expectMessage("Credentials must have a valid date of expiration and a valid access_token or id_token value.")
         val credentials: Credentials =
-            CredentialsMock(null, null, "type", "refreshToken", ONE_HOUR_SECONDS)
+            CredentialsMock(null, null, "type", "refreshToken", Date(), "scope")
         manager.saveCredentials(credentials)
     }
 
@@ -331,7 +332,7 @@ public class SecureCredentialsManagerTest {
     @Test
     public fun shouldNotThrowOnSaveIfCredentialsHaveAccessTokenAndExpiresIn() {
         val credentials: Credentials =
-            CredentialsMock(null, "accessToken", "type", "refreshToken", ONE_HOUR_SECONDS)
+            CredentialsMock(null, "accessToken", "type", "refreshToken", Date(), "scope")
         Mockito.`when`(crypto.encrypt(any()))
             .thenReturn(byteArrayOf(12, 34, 56, 78))
         manager.saveCredentials(credentials)
@@ -340,7 +341,7 @@ public class SecureCredentialsManagerTest {
     @Test
     public fun shouldNotThrowOnSaveIfCredentialsHaveIdTokenAndExpiresIn() {
         val credentials: Credentials =
-            CredentialsMock("idToken", null, "type", "refreshToken", ONE_HOUR_SECONDS)
+            CredentialsMock("idToken", null, "type", "refreshToken", Date(), "scope")
         prepareJwtDecoderMock(Date())
         Mockito.`when`(crypto.encrypt(any()))
             .thenReturn(byteArrayOf(12, 34, 56, 78))

--- a/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CredentialsDeserializerTest.kt
@@ -30,10 +30,6 @@ public class CredentialsDeserializerTest {
         val credentials = gson.getAdapter(
             Credentials::class.java
         ).fromJson(FileReader(BASIC_CREDENTIALS))
-        MatcherAssert.assertThat(
-            credentials.expiresIn!!.toDouble(),
-            Is.`is`(Matchers.closeTo(86000.0, 1.0))
-        )
         MatcherAssert.assertThat(credentials.expiresAt, Is.`is`(CoreMatchers.notNullValue()))
         val expiresAt = credentials.expiresAt!!.time.toDouble()
         val expectedExpiresAt = (CredentialsMock.CURRENT_TIME_MS + 86000 * 1000).toDouble()
@@ -54,12 +50,6 @@ public class CredentialsDeserializerTest {
         val expiresAt = credentials.expiresAt!!.time.toDouble()
         val expectedExpiresAt = exp.time.toDouble()
         MatcherAssert.assertThat(expiresAt, Is.`is`(Matchers.closeTo(expectedExpiresAt, 1.0)))
-        MatcherAssert.assertThat(credentials.expiresIn, Is.`is`(CoreMatchers.notNullValue()))
-        val expectedExpiresIn = ((exp.time - CredentialsMock.CURRENT_TIME_MS) / 1000f).toDouble()
-        MatcherAssert.assertThat(
-            credentials.expiresIn!!.toDouble(),
-            Is.`is`(Matchers.closeTo(expectedExpiresIn, 1.0))
-        )
     }
 
     private fun generateExpiresAtCredentialsJSON(expiresAt: Date): String {

--- a/auth0/src/test/java/com/auth0/android/request/internal/CredentialsGsonTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CredentialsGsonTest.kt
@@ -58,11 +58,6 @@ public class CredentialsGsonTest : GsonBaseTest() {
         MatcherAssert.assertThat(credentials.idToken, Matchers.`is`(Matchers.nullValue()))
         MatcherAssert.assertThat(credentials.type, Matchers.equalTo("bearer"))
         MatcherAssert.assertThat(credentials.refreshToken, Matchers.`is`(Matchers.nullValue()))
-        MatcherAssert.assertThat(credentials.expiresIn, Matchers.`is`(Matchers.notNullValue()))
-        MatcherAssert.assertThat(
-            credentials.expiresIn!!.toDouble(),
-            Matchers.`is`(Matchers.closeTo(86000.0, 1.0))
-        )
         MatcherAssert.assertThat(credentials.expiresAt, Matchers.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(credentials.scope, Matchers.`is`(Matchers.nullValue()))
     }
@@ -79,13 +74,6 @@ public class CredentialsGsonTest : GsonBaseTest() {
         MatcherAssert.assertThat(credentials.accessToken, Matchers.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(credentials.type, Matchers.equalTo("bearer"))
         //The hardcoded value comes from the JSON file
-        MatcherAssert.assertThat(credentials.expiresIn, Matchers.`is`(Matchers.notNullValue()))
-        val expectedCalculatedExpiresIn =
-            ((exp.time - System.currentTimeMillis()) / 1000f).toDouble()
-        MatcherAssert.assertThat(
-            credentials.expiresIn!!.toDouble(),
-            Matchers.`is`(Matchers.closeTo(expectedCalculatedExpiresIn, 1.0))
-        )
         MatcherAssert.assertThat(credentials.expiresAt, Matchers.`is`(Matchers.notNullValue()))
         val expiresAt = credentials.expiresAt!!.time.toDouble()
         MatcherAssert.assertThat(
@@ -103,11 +91,6 @@ public class CredentialsGsonTest : GsonBaseTest() {
         MatcherAssert.assertThat(credentials.idToken, Matchers.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(credentials.type, Matchers.equalTo("bearer"))
         MatcherAssert.assertThat(credentials.refreshToken, Matchers.`is`(Matchers.nullValue()))
-        MatcherAssert.assertThat(credentials.expiresIn, Matchers.`is`(Matchers.notNullValue()))
-        MatcherAssert.assertThat(
-            credentials.expiresIn!!.toDouble(),
-            Matchers.`is`(Matchers.closeTo(86000.0, 1.0))
-        )
         MatcherAssert.assertThat(credentials.expiresAt, Matchers.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(credentials.scope, Matchers.`is`("openid profile"))
     }
@@ -121,11 +104,6 @@ public class CredentialsGsonTest : GsonBaseTest() {
         MatcherAssert.assertThat(credentials.idToken, Matchers.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(credentials.type, Matchers.equalTo("bearer"))
         MatcherAssert.assertThat(credentials.refreshToken, Matchers.`is`(Matchers.notNullValue()))
-        MatcherAssert.assertThat(credentials.expiresIn, Matchers.`is`(Matchers.notNullValue()))
-        MatcherAssert.assertThat(
-            credentials.expiresIn!!.toDouble(),
-            Matchers.`is`(Matchers.closeTo(86000.0, 1.0))
-        )
         MatcherAssert.assertThat(credentials.expiresAt, Matchers.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(credentials.scope, Matchers.`is`("openid profile"))
     }
@@ -135,7 +113,7 @@ public class CredentialsGsonTest : GsonBaseTest() {
         val expiresAt = Date(CredentialsMock.CURRENT_TIME_MS + 123456 * 1000)
         val expectedExpiresAt = formatDate(expiresAt)
         val expiresInCredentials: Credentials =
-            CredentialsMock("id", "access", "ty", "refresh", 123456L)
+            CredentialsMock("id", "access", "ty", "refresh", expiresAt, null)
         val expiresInJson = gson.toJson(expiresInCredentials)
         MatcherAssert.assertThat(expiresInJson, CoreMatchers.containsString("\"id_token\":\"id\""))
         MatcherAssert.assertThat(
@@ -152,7 +130,7 @@ public class CredentialsGsonTest : GsonBaseTest() {
         )
         MatcherAssert.assertThat(
             expiresInJson,
-            CoreMatchers.containsString("\"expires_in\":123456")
+            CoreMatchers.not(CoreMatchers.containsString("\"expires_in\""))
         )
         MatcherAssert.assertThat(
             expiresInJson, CoreMatchers.containsString(
@@ -181,7 +159,7 @@ public class CredentialsGsonTest : GsonBaseTest() {
         )
         MatcherAssert.assertThat(
             expiresAtJson,
-            CoreMatchers.containsString("\"expires_in\":123456")
+            CoreMatchers.not(CoreMatchers.containsString("\"expires_in\""))
         )
         MatcherAssert.assertThat(
             expiresInJson, CoreMatchers.containsString(

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsMock.kt
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsMock.kt
@@ -2,23 +2,14 @@ package com.auth0.android.result
 
 import java.util.*
 
-public class CredentialsMock : Credentials {
-    public constructor(
-        idToken: String?,
-        accessToken: String?,
-        type: String?,
-        refreshToken: String?,
-        expiresIn: Long?
-    ) : super(idToken, accessToken, type, refreshToken, expiresIn)
-
-    public constructor(
-        idToken: String?,
-        accessToken: String?,
-        type: String?,
-        refreshToken: String?,
-        expiresAt: Date?,
-        scope: String?
-    ) : super(idToken, accessToken, type, refreshToken, expiresAt, scope)
+public class CredentialsMock(
+    idToken: String?,
+    accessToken: String?,
+    type: String?,
+    refreshToken: String?,
+    expiresAt: Date?,
+    scope: String?
+) : Credentials(idToken, accessToken, type, refreshToken, expiresAt, scope) {
 
     override val currentTimeInMillis: Long
         get() = CURRENT_TIME_MS

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsTest.java
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsTest.java
@@ -1,43 +1,24 @@
 package com.auth0.android.result;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.util.Date;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
 public class CredentialsTest {
 
     @Test
-    public void shouldCreateWithExpiresAtDateAndSetExpiresIn() {
+    public void shouldCreate() {
         Date date = new Date();
-        long expiresIn = (date.getTime() - CredentialsMock.CURRENT_TIME_MS) / 1000;
         Credentials credentials = new CredentialsMock("idToken", "accessToken", "type", "refreshToken", date, "scope");
         assertThat(credentials.getIdToken(), is("idToken"));
         assertThat(credentials.getAccessToken(), is("accessToken"));
         assertThat(credentials.getType(), is("type"));
         assertThat(credentials.getRefreshToken(), is("refreshToken"));
-        assertThat(credentials.getExpiresIn(), is(notNullValue()));
-        assertThat(credentials.getExpiresIn().doubleValue(), CoreMatchers.is(closeTo(expiresIn, 1)));
         assertThat(credentials.getExpiresAt(), is(date));
         assertThat(credentials.getScope(), is("scope"));
-    }
-
-    @Test
-    public void shouldCreateWithExpiresInAndSetExpiresAt() {
-        Credentials credentials = new CredentialsMock("idToken", "accessToken", "type", "refreshToken", 86400L);
-        assertThat(credentials.getIdToken(), is("idToken"));
-        assertThat(credentials.getAccessToken(), is("accessToken"));
-        assertThat(credentials.getType(), is("type"));
-        assertThat(credentials.getRefreshToken(), is("refreshToken"));
-        assertThat(credentials.getExpiresIn(), is(notNullValue()));
-        assertThat(credentials.getExpiresIn().doubleValue(), CoreMatchers.is(closeTo(86400, 1)));
-        Date expirationDate = new Date(CredentialsMock.CURRENT_TIME_MS + 86400L * 1000);
-        assertThat(credentials.getExpiresAt(), is(expirationDate));
     }
 
     @Test


### PR DESCRIPTION
### Changes

This class was originally created using an expires_in value. This is no longer possible, and an expiration date should be passed instead. 

You probably will never be instantiating a Credentials on your own. This is a wrapper class intended to contain the tokens received from the server after a successfull authentication.
