### PR TITLE
Fix JavaDocs Typo on RS256 Verifier

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/AsymmetricSignatureVerifier.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AsymmetricSignatureVerifier.java
@@ -1,8 +1,9 @@
 package com.auth0.android.provider;
 
+import android.util.Base64;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.util.Base64;
 
 import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
@@ -12,7 +13,7 @@ import java.security.Signature;
 import java.util.Collections;
 
 /**
- * Token signature verifier for HS256 algorithms.
+ * Token signature verifier for RS256 algorithms.
  */
 class AsymmetricSignatureVerifier extends SignatureVerifier {
 


### PR DESCRIPTION
### Changes

Updates class JavaDoc for RS256 signature verifier, as it incorrectly was documented for HS256 signatures.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
