### PR TITLE
Receive NetworkingClient through the Auth0 instance

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.kt
+++ b/auth0/src/main/java/com/auth0/android/Auth0.kt
@@ -3,6 +3,7 @@ package com.auth0.android
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.auth0.android.request.DefaultClient
+import com.auth0.android.request.NetworkingClient
 import com.auth0.android.util.Auth0UserAgent
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -34,9 +35,14 @@ public open class Auth0 @JvmOverloads constructor(
     private val configurationUrl: HttpUrl
 
     /**
-     * @return Auth0 user agent info sent in every request
+     * @return Auth0 user agent information sent in every request
      */
     public var auth0UserAgent: Auth0UserAgent
+
+    /**
+     * The networking client instance used to make HTTP requests.
+     */
+    public var networkingClient: NetworkingClient = recreateNetworkingClient()
 
     /**
      * Whether HTTP request and response info should be logged.
@@ -44,25 +50,37 @@ public open class Auth0 @JvmOverloads constructor(
      * Defaults to `false`.
      */
     @Deprecated(
-        "Create a DefaultClient and specify enableLogging = true|false instead. This can then be included when creating the WebAuthProvider or the API clients"
+        "Create a DefaultClient and specify enableLogging = true|false instead."
     )
     public var isLoggingEnabled: Boolean = false
+        set(value) {
+            field = value
+            recreateNetworkingClient()
+        }
 
     /**
      * The connection timeout for network requests, in seconds. Defaults to 10 seconds.
      */
     @Deprecated(
-        "Create a DefaultClient and specify the connectTimeout instead. This can then be included when creating the WebAuthProvider or the API clients"
+        "Create a DefaultClient and specify the connectTimeout instead."
     )
     public var connectTimeoutInSeconds: Int = DefaultClient.DEFAULT_TIMEOUT_SECONDS
+        set(value) {
+            field = value
+            recreateNetworkingClient()
+        }
 
     /**
      * The read timeout, in seconds, to use when executing requests. Default is ten seconds.
      */
     @Deprecated(
-        "Create a DefaultClient and specify the readTimeout instead. This can then be included when creating the WebAuthProvider or the API clients"
+        "Create a DefaultClient and specify the readTimeout instead."
     )
     public var readTimeoutInSeconds: Int = DefaultClient.DEFAULT_TIMEOUT_SECONDS
+        set(value) {
+            field = value
+            recreateNetworkingClient()
+        }
 
     /**
      * Creates a new Auth0 instance with the 'com_auth0_client_id' and 'com_auth0_domain' values
@@ -165,4 +183,11 @@ public open class Auth0 @JvmOverloads constructor(
         configurationUrl = resolveConfiguration(configurationDomain, domainUrl)
         auth0UserAgent = Auth0UserAgent()
     }
+
+    private fun recreateNetworkingClient() = DefaultClient(
+        connectTimeout = connectTimeoutInSeconds,
+        readTimeout = readTimeoutInSeconds,
+        defaultHeaders = emptyMap(),
+        enableLogging = isLoggingEnabled
+    )
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -35,27 +35,19 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 ) {
 
     /**
-     * Creates a new API client instance providing Auth0 account info and a custom Networking Client.
+     * Creates a new API client instance providing Auth0 account info.
      *
      * ```
      * val auth0 = Auth0("YOUR_CLIENT_ID", "YOUR_DOMAIN")
      * val client = AuthenticationAPIClient(auth0)
      * ```
-     * @param auth0            account information
-     * @param networkingClient the networking client implementation
+     * @param auth0 account information
      */
-    @JvmOverloads
     public constructor(
-        auth0: Auth0,
-        @Suppress("DEPRECATION")
-        networkingClient: NetworkingClient = DefaultClient(
-            connectTimeout = auth0.connectTimeoutInSeconds,
-            readTimeout = auth0.readTimeoutInSeconds,
-            enableLogging = auth0.isLoggingEnabled
-        )
+        auth0: Auth0
     ) : this(
         auth0,
-        RequestFactory<AuthenticationException>(networkingClient, createErrorAdapter()),
+        RequestFactory<AuthenticationException>(auth0.networkingClient, createErrorAdapter()),
         GsonProvider.gson
     )
 
@@ -686,8 +678,6 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     init {
         val auth0UserAgent = auth0.auth0UserAgent
-        if (auth0UserAgent != null) {
-            factory.setClientInfo(auth0UserAgent.value)
-        }
+        factory.setAuth0ClientInfo(auth0UserAgent.value)
     }
 }

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
@@ -4,7 +4,10 @@ import androidx.annotation.VisibleForTesting
 import com.auth0.android.Auth0
 import com.auth0.android.Auth0Exception
 import com.auth0.android.authentication.ParameterBuilder
-import com.auth0.android.request.*
+import com.auth0.android.request.ErrorAdapter
+import com.auth0.android.request.JsonAdapter
+import com.auth0.android.request.NetworkingClient
+import com.auth0.android.request.Request
 import com.auth0.android.request.internal.BaseRequest
 import com.auth0.android.request.internal.GsonAdapter
 import com.auth0.android.request.internal.GsonAdapter.Companion.forListOf
@@ -33,25 +36,17 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
     private val gson: Gson
 ) {
     /**
-     * Creates a new API client instance providing Auth0 account info and a custom Networking Client.
+     * Creates a new API client instance providing the Auth0 account info and the access token.
      *
      * @param auth0            account information
      * @param token            of the primary identity
-     * @param networkingClient the networking client implementation
      */
-    @JvmOverloads
     public constructor(
         auth0: Auth0,
         token: String,
-        @Suppress("DEPRECATION")
-        networkingClient: NetworkingClient = DefaultClient(
-            connectTimeout = auth0.connectTimeoutInSeconds,
-            readTimeout = auth0.readTimeoutInSeconds,
-            enableLogging = auth0.isLoggingEnabled
-        )
     ) : this(
         auth0,
-        factoryForToken(token, networkingClient),
+        factoryForToken(token, auth0.networkingClient),
         GsonProvider.gson
     )
 
@@ -252,9 +247,6 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
     }
 
     init {
-        val auth0UserAgent = auth0.auth0UserAgent
-        if (auth0UserAgent != null) {
-            factory.setClientInfo(auth0UserAgent.value)
-        }
+        factory.setAuth0ClientInfo(auth0.auth0UserAgent.value)
     }
 }

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -13,7 +13,6 @@ import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
 import com.auth0.android.jwt.DecodeException
 import com.auth0.android.jwt.JWT
-import com.auth0.android.request.NetworkingClient
 import com.auth0.android.result.Credentials
 import java.security.SecureRandom
 import java.util.*
@@ -22,8 +21,7 @@ internal class OAuthManager(
     private val account: Auth0,
     private val callback: Callback<Credentials, AuthenticationException>,
     parameters: Map<String, String>,
-    ctOptions: CustomTabsOptions,
-    networkingClient: NetworkingClient?
+    ctOptions: CustomTabsOptions
 ) : ResumableManager() {
     private val parameters: MutableMap<String, String>
     private val headers: MutableMap<String, String>
@@ -251,7 +249,7 @@ internal class OAuthManager(
     }
 
     private fun addClientParameters(parameters: MutableMap<String, String>, redirectUri: String) {
-        parameters[KEY_USER_AGENT] = account.auth0UserAgent.value
+        parameters[KEY_AUTH0_CLIENT_INFO] = account.auth0UserAgent.value
         parameters[KEY_CLIENT_ID] = account.clientId
         parameters[KEY_REDIRECT_URI] = redirectUri
     }
@@ -289,7 +287,7 @@ internal class OAuthManager(
         private const val KEY_CODE_CHALLENGE_METHOD = "code_challenge_method"
         private const val KEY_CLIENT_ID = "client_id"
         private const val KEY_REDIRECT_URI = "redirect_uri"
-        private const val KEY_USER_AGENT = "auth0Client"
+        private const val KEY_AUTH0_CLIENT_INFO = "auth0Client"
         private const val KEY_ERROR = "error"
         private const val KEY_ERROR_DESCRIPTION = "error_description"
         private const val KEY_CODE = "code"
@@ -334,12 +332,7 @@ internal class OAuthManager(
         headers = HashMap()
         this.parameters = parameters.toMutableMap()
         this.parameters[KEY_RESPONSE_TYPE] = RESPONSE_TYPE_CODE
-        apiClient = if (networkingClient == null) {
-            // Delegate the creation of defaults to the constructor
-            AuthenticationAPIClient(account)
-        } else {
-            AuthenticationAPIClient(account, networkingClient)
-        }
+        apiClient = AuthenticationAPIClient(account)
         this.ctOptions = ctOptions
     }
 }

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -7,7 +7,6 @@ import androidx.annotation.VisibleForTesting
 import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
-import com.auth0.android.request.NetworkingClient
 import com.auth0.android.result.Credentials
 import java.util.*
 
@@ -164,23 +163,11 @@ public object WebAuthProvider {
         private val values: MutableMap<String, String> = mutableMapOf()
         private val headers: MutableMap<String, String> = mutableMapOf()
         private var pkce: PKCE? = null
-        private var networkingClient: NetworkingClient? = null
         private var issuer: String? = null
         private var scheme: String = "https"
         private var redirectUri: String? = null
         private var ctOptions: CustomTabsOptions = CustomTabsOptions.newBuilder().build()
         private var leeway: Int? = null
-
-        /**
-         * Use a custom networking client to handle the API calls.
-         *
-         * @param networkingClient to use in the requests
-         * @return the current builder instance
-         */
-        public fun withNetworkingClient(networkingClient: NetworkingClient): Builder {
-            this.networkingClient = networkingClient
-            return this
-        }
 
         /**
          * Use a custom state in the requests
@@ -388,7 +375,7 @@ public object WebAuthProvider {
                 callback.onFailure(ex)
                 return
             }
-            val manager = OAuthManager(account, callback, values, ctOptions, networkingClient)
+            val manager = OAuthManager(account, callback, values, ctOptions)
             manager.setHeaders(headers)
             manager.setPKCE(pkce)
             manager.setIdTokenVerificationLeeway(leeway)

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
@@ -16,7 +16,7 @@ internal class RequestFactory<U : Auth0Exception> internal constructor(
         private const val DEFAULT_LOCALE_IF_MISSING = "en_US"
         private const val USER_AGENT_HEADER = "User-Agent"
         private const val ACCEPT_LANGUAGE_HEADER = "Accept-Language"
-        private const val CLIENT_INFO_HEADER = Auth0UserAgent.HEADER_NAME
+        private const val AUTH0_CLIENT_INFO_HEADER = Auth0UserAgent.HEADER_NAME
 
         val defaultLocale: String
             get() {
@@ -58,8 +58,8 @@ internal class RequestFactory<U : Auth0Exception> internal constructor(
         baseHeaders[name] = value
     }
 
-    fun setClientInfo(clientInfo: String) {
-        baseHeaders[CLIENT_INFO_HEADER] = clientInfo
+    fun setAuth0ClientInfo(clientInfo: String) {
+        baseHeaders[AUTH0_CLIENT_INFO_HEADER] = clientInfo
     }
 
     fun setUserAgent(userAgent: String) {

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -109,7 +109,8 @@ public class AuthenticationAPIClientTest {
         ServerResponse response = new ServerResponse(200, inputStream, Collections.emptyMap());
         NetworkingClient networkingClient = mock(NetworkingClient.class);
         when(networkingClient.load(anyString(), any(RequestOptions.class))).thenReturn(response);
-        AuthenticationAPIClient client = new AuthenticationAPIClient(account, networkingClient);
+        account.setNetworkingClient(networkingClient);
+        AuthenticationAPIClient client = new AuthenticationAPIClient(account);
 
         AuthenticationRequest request = client.login("johndoe", "secret");
         request.execute();
@@ -125,7 +126,7 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public void shouldSetUserAgent() {
-        Auth0 account = mock(Auth0.class);
+        Auth0 account = new Auth0("client-id", "https://tenant.auth0.com/");
         //noinspection unchecked
         RequestFactory<AuthenticationException> factory = mock(RequestFactory.class);
         AuthenticationAPIClient client = new AuthenticationAPIClient(account, factory, gson);
@@ -141,7 +142,7 @@ public class AuthenticationAPIClientTest {
         Auth0 account = new Auth0(CLIENT_ID, DOMAIN);
         account.setAuth0UserAgent(auth0UserAgent);
         new AuthenticationAPIClient(account, factory, gson);
-        verify(factory).setClientInfo("the-user-agent-data");
+        verify(factory).setAuth0ClientInfo("the-user-agent-data");
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
@@ -109,7 +109,8 @@ public class UsersAPIClientTest {
         ServerResponse response = new ServerResponse(200, inputStream, Collections.emptyMap());
         NetworkingClient networkingClient = mock(NetworkingClient.class);
         when(networkingClient.load(anyString(), any(RequestOptions.class))).thenReturn(response);
-        UsersAPIClient client = new UsersAPIClient(account, "token.token", networkingClient);
+        account.setNetworkingClient(networkingClient);
+        UsersAPIClient client = new UsersAPIClient(account, "token.token");
 
         Request<UserProfile, ManagementException> request = client.getProfile("undercover");
         request.execute();
@@ -125,7 +126,7 @@ public class UsersAPIClientTest {
 
     @Test
     public void shouldSetUserAgent() {
-        Auth0 account = mock(Auth0.class);
+        Auth0 account = new Auth0("client-id", "https://tenant.auth0.com/");
         //noinspection unchecked
         RequestFactory<ManagementException> factory = mock(RequestFactory.class);
         final UsersAPIClient client = new UsersAPIClient(account, factory, gson);
@@ -140,7 +141,7 @@ public class UsersAPIClientTest {
         Auth0 account = new Auth0(CLIENT_ID, DOMAIN);
         account.setAuth0UserAgent(auth0UserAgent);
         new UsersAPIClient(account, factory, gson);
-        verify(factory).setClientInfo("the-user-agent-data");
+        verify(factory).setAuth0ClientInfo("the-user-agent-data");
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -999,8 +999,8 @@ public class WebAuthProviderTest {
 
         // 1. start the webauth flow. the browser would open
         val proxyAccount = Auth0(JwtTestUtils.EXPECTED_AUDIENCE, JwtTestUtils.EXPECTED_BASE_DOMAIN)
+        proxyAccount.networkingClient = networkingClient
         login(proxyAccount)
-            .withNetworkingClient(networkingClient)
             .start(activity, authCallback)
         val managerInstance = WebAuthProvider.managerInstance as OAuthManager
         managerInstance.currentTimeInMillis = JwtTestUtils.FIXED_CLOCK_CURRENT_TIME_MS

--- a/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
@@ -121,7 +121,7 @@ public class RequestFactoryTest {
     @Test
     public void shouldHaveClientInfoHeader() {
         RequestFactory<Auth0Exception> factory = createRequestFactory();
-        factory.setClientInfo(CLIENT_INFO);
+        factory.setAuth0ClientInfo(CLIENT_INFO);
 
         factory.get(BASE_URL, resultAdapter);
         verify(getRequest).addHeader("Auth0-Client", CLIENT_INFO);


### PR DESCRIPTION
### Changes

This refactor simplifies the use case where a custom networking client is to be used. 

Instead of having to configure it in 3 different places (API and WebAuth clients), the instance can be set on the Auth0 account instance.

```diff
val networkingClient = MyOwnNetworkingClient()
val account = Auth0(domain, clientId)
+account.networkingClient = networkingClient

// auth api
-val auth = AuthAPIClient(account, networkingClient)
+val auth = AuthAPIClient(account)
auth.login(username, password)
   .start(callback)

// mgmt api
-val users = UsersAPIClient(account, token, networkingClient)
+val users = UsersAPIClient(account, token)
users.patchMetadata(userId, metadata)
   .start(callback)

// webauth
WebAuthProvider.login(account)
-  .withNetworkingClient(networkingClient)
   .start(callback)
```

### Current drawbacks
Because of retro-compatibility, every time the networking client properties that the Auth0 class accepts are changed, the networking client needs to be recreated with them. 

Since these properties are strictly tied to the DefaultClient implementation rather than the NetworkingClient interface, I'd consider removing these setters in favor of keeping the implementation details that extend the interface defined in the DefaultClient class itself rather than external classes like Auth0.

### References 
The usage documentation of this feature #436 needs to be updated if this is merged.
