### PR TITLE
Remove timeouts and logging setters from Auth0 class

### DIFF
--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -108,7 +108,10 @@ We will not provide support and will change these as required without any previo
 
 - `setOIDCConformant(boolean enabled)` and `isOIDCConformant()` have been removed. The SDK now only supports OIDC-Conformant applications.
 - `doNotSendTelemetry()` has been removed. There is no replacement.
-- `setWriteTimeoutInSeconds(seconds)` and `getWriteTimeoutInSeconds(seconds)` have been removed. There is no replacement; only connect and read timeouts can be configured.
+- `setWriteTimeoutInSeconds(seconds)` and `getWriteTimeoutInSeconds(seconds)` have been removed. There is no replacement.
+- `setReadTimeoutInSeconds(seconds)` and `getReadTimeoutInSeconds(seconds)` have been removed. You can customize the read timeout directly on the `DefaultClient` class. Use `DefaultClient(readTimeout = 123)`.
+- `setConnectTimeoutInSeconds(seconds)` and `getConnectTimeoutInSeconds(seconds)` have been removed. You can customize the connect timeout directly on the `DefaultClient` class. Use `DefaultClient(connectTimeout = 123)`.
+- `setLoggingEnabled(boolean enabled)` and `isLoggingEnabled()` have been removed. You can enable the network traffic logger directly on the `DefaultClient` class. Use `DefaultClient(enableLogging = true)`. Use it for debugging purposes and never enable it on production environments.
 - `setTLS12Enforced()` and `isTLS12Enforced()` have been removed. The SDK now supports modern TLS by default.
 
 #### `AuthenticationAPIClient` methods removed or changed

--- a/auth0/src/main/java/com/auth0/android/Auth0.kt
+++ b/auth0/src/main/java/com/auth0/android/Auth0.kt
@@ -42,45 +42,7 @@ public open class Auth0 @JvmOverloads constructor(
     /**
      * The networking client instance used to make HTTP requests.
      */
-    public var networkingClient: NetworkingClient = recreateNetworkingClient()
-
-    /**
-     * Whether HTTP request and response info should be logged.
-     * This should only be set to `true` for debugging purposes in non-production environments, as sensitive information is included in the logs.
-     * Defaults to `false`.
-     */
-    @Deprecated(
-        "Create a DefaultClient and specify enableLogging = true|false instead."
-    )
-    public var isLoggingEnabled: Boolean = false
-        set(value) {
-            field = value
-            recreateNetworkingClient()
-        }
-
-    /**
-     * The connection timeout for network requests, in seconds. Defaults to 10 seconds.
-     */
-    @Deprecated(
-        "Create a DefaultClient and specify the connectTimeout instead."
-    )
-    public var connectTimeoutInSeconds: Int = DefaultClient.DEFAULT_TIMEOUT_SECONDS
-        set(value) {
-            field = value
-            recreateNetworkingClient()
-        }
-
-    /**
-     * The read timeout, in seconds, to use when executing requests. Default is ten seconds.
-     */
-    @Deprecated(
-        "Create a DefaultClient and specify the readTimeout instead."
-    )
-    public var readTimeoutInSeconds: Int = DefaultClient.DEFAULT_TIMEOUT_SECONDS
-        set(value) {
-            field = value
-            recreateNetworkingClient()
-        }
+    public var networkingClient: NetworkingClient = DefaultClient()
 
     /**
      * Creates a new Auth0 instance with the 'com_auth0_client_id' and 'com_auth0_domain' values
@@ -183,11 +145,4 @@ public open class Auth0 @JvmOverloads constructor(
         configurationUrl = resolveConfiguration(configurationDomain, domainUrl)
         auth0UserAgent = Auth0UserAgent()
     }
-
-    private fun recreateNetworkingClient() = DefaultClient(
-        connectTimeout = connectTimeoutInSeconds,
-        readTimeout = readTimeoutInSeconds,
-        defaultHeaders = emptyMap(),
-        enableLogging = isLoggingEnabled
-    )
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -43,9 +43,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * @param auth0 account information
      */
-    public constructor(
-        auth0: Auth0
-    ) : this(
+    public constructor(auth0: Auth0) : this(
         auth0,
         RequestFactory<AuthenticationException>(auth0.networkingClient, createErrorAdapter()),
         GsonProvider.gson

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
@@ -43,7 +43,7 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
      */
     public constructor(
         auth0: Auth0,
-        token: String,
+        token: String
     ) : this(
         auth0,
         factoryForToken(token, auth0.networkingClient),

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
@@ -42,19 +42,13 @@ internal class LogoutManager(
             builder.appendQueryParameter(key, value)
         }
         val uri = builder.build()
-        logDebug("Using the following Logout URI: $uri")
+        Log.d(TAG, "Using the following Logout URI: $uri")
         return uri
     }
 
     private fun addClientParameters(parameters: MutableMap<String, String>) {
         parameters[KEY_USER_AGENT] = account.auth0UserAgent.value
         parameters[KEY_CLIENT_ID] = account.clientId
-    }
-
-    private fun logDebug(message: String) {
-        if (account.isLoggingEnabled) {
-            Log.d(TAG, message)
-        }
     }
 
     companion object {

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -88,7 +88,7 @@ internal class OAuthManager(
             Log.w(TAG, "The response didn't contain any of these values: code, state")
             return false
         }
-        logDebug("The parsed CallbackURI contains the following values: $values")
+        Log.d(TAG, "The parsed CallbackURI contains the following parameters: ${values.keys}")
         try {
             assertNoError(values[KEY_ERROR], values[KEY_ERROR_DESCRIPTION])
             assertValidState(parameters[KEY_STATE]!!, values[KEY_STATE])
@@ -161,7 +161,6 @@ internal class OAuthManager(
                     options.clock = Date(currentTimeInMillis)
                     try {
                         IdTokenVerifier().verify(decodedIdToken, options)
-                        logDebug("Authenticated using web flow")
                         validationCallback.onSuccess(null)
                     } catch (exc: TokenValidationException) {
                         validationCallback.onFailure(exc)
@@ -212,7 +211,7 @@ internal class OAuthManager(
             builder.appendQueryParameter(key, value)
         }
         val uri = builder.build()
-        logDebug("Using the following Authorize URI: $uri")
+        Log.d(TAG, "Using the following Authorize URI: $uri")
         return uri
     }
 
@@ -257,12 +256,6 @@ internal class OAuthManager(
     private fun createPKCE(redirectUri: String, headers: Map<String, String>) {
         if (pkce == null) {
             pkce = PKCE(apiClient, redirectUri, headers)
-        }
-    }
-
-    private fun logDebug(message: String) {
-        if (account.isLoggingEnabled) {
-            Log.d(TAG, message)
         }
     }
 

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -52,44 +52,6 @@ public class Auth0Test {
     }
 
     @Test
-    public void shouldHaveLoggingEnabled() {
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.setLoggingEnabled(true);
-
-        assertThat(auth0.isLoggingEnabled(), is(true));
-    }
-
-    @Test
-    public void shouldNotHaveLoggingEnabled() {
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.setLoggingEnabled(false);
-
-        assertThat(auth0.isLoggingEnabled(), is(false));
-    }
-
-    @Test
-    public void shouldHaveConnectTimeout() {
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.setConnectTimeoutInSeconds(5);
-
-        assertThat(auth0.getConnectTimeoutInSeconds(), is(5));
-    }
-
-    @Test
-    public void shouldReadHaveTimeout() {
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        auth0.setReadTimeoutInSeconds(15);
-
-        assertThat(auth0.getReadTimeoutInSeconds(), is(15));
-    }
-
-    @Test
-    public void shouldNotHaveLoggingEnabledByDefault() {
-        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
-        assertThat(auth0.isLoggingEnabled(), is(false));
-    }
-
-    @Test
     public void shouldBuildFromResources() {
         Resources resources = Mockito.mock(Resources.class);
         when(context.getResources()).thenReturn(resources);

--- a/sample/src/main/res/layout/fragment_database_login.xml
+++ b/sample/src/main/res/layout/fragment_database_login.xml
@@ -43,19 +43,54 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="24dp"
         android:layout_marginEnd="16dp"
-        android:text="Log in using your email and password."
+        android:text="Log in using your email and password"
         android:textSize="20sp"
         app:layout_constraintBottom_toTopOf="@+id/textEmail"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="Log in using Auth0's Universal Login "
+        android:textSize="20sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView2" />
+
     <Button
         android:id="@+id/buttonLogin"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:text="Log in"
+        android:text="Log in with Username &amp; Password"
         app:layout_constraintEnd_toEndOf="@+id/textPassword"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="@+id/textPassword"
         app:layout_constraintTop_toBottomOf="@+id/textPassword" />
+
+    <Button
+        android:id="@+id/buttonWebAuth"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Log in with Browser"
+        app:layout_constraintEnd_toEndOf="@+id/textView3"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="@+id/textView3"
+        app:layout_constraintTop_toBottomOf="@+id/textView3" />
+
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="or"
+        android:textSize="18sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/buttonLogin" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### Changes

This class is shared across the 3 clients (both APIs & WebAuth). It is a good place to share setup options, common across the entire library. Previously it supported being set read/connect timeouts and enabling the HTTP logger. Since that logic is too coupled with the `DefaultClient` implementation, this PR removes these properties from the Auth0 class in favor of keeping them in the client implementation instead.


The summary of removed methods:
- setter/getter for `isLoggingEnabled`
- setter/getter for `connectTimeoutInSeconds `
- setter/getter for `readTimeoutInSeconds `
