### PR TITLE
Explicitly reject "none" signing algorithm

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/SignatureVerifier.java
+++ b/auth0/src/main/java/com/auth0/android/provider/SignatureVerifier.java
@@ -40,7 +40,7 @@ abstract class SignatureVerifier {
     }
 
     private void checkAlgorithm(String tokenAlgorithm) throws TokenValidationException {
-        if (!supportedAlgorithms.contains(tokenAlgorithm)) {
+        if (!supportedAlgorithms.contains(tokenAlgorithm) || "none".equalsIgnoreCase(tokenAlgorithm)) {
             if (supportedAlgorithms.size() == 1) {
                 throw new TokenValidationException(String.format("Signature algorithm of \"%s\" is not supported. Expected the ID token to be signed with %s.", tokenAlgorithm, supportedAlgorithms.get(0)));
             } else {


### PR DESCRIPTION
### Changes

ID tokens signed with "none" algorithm were already being rejected as [this test proves](https://github.com/auth0/Auth0.Android/blob/a419556ec5a7188fa7d34ae9d4166922454fb3c8/auth0/src/test/java/com/auth0/android/provider/AsymmetricSignatureVerifierTest.java#L58).

This PR adds an explicit condition to the IF clause to reject it. No additional tests need to be provided.