### PR TITLE
remove setUserAgent methods from API clients

### DIFF
--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -140,7 +140,7 @@ We will not provide support and will change these as required without any previo
 ### Constructors changed
 
 - `AuthenticationAPIClient` can no longer be constructed from a `Context`. Use `AuthenticationAPIClient(auth0: Auth0)` instead. You can create an instance of `Auth0` using a `Context`.
-- `UsersAPIClient` can no longer be constructed from a `Context`. Use UsersAPIClient(auth0: Auth0, token: String)` instead. You can create an instance of `Auth0` using a `Context`.
+- `UsersAPIClient` can no longer be constructed from a `Context`. Use `UsersAPIClient(auth0: Auth0, token: String)` instead. You can create an instance of `Auth0` using a `Context`.
 - `SignupRequest` now requires the second parameter to be an `AuthenticationRequest`.
 - `ProfileRequest` now requires an `AuthenticationRequest` and a `Request<UserProfile, AuthenticationException>`.
 - `Credentials` can no longer be constructed with an "expires in" value. The date of expiration or "expires at" should be given instead. You typically won't be constructing Credentials on your own.
@@ -158,6 +158,8 @@ We will not provide support and will change these as required without any previo
 - `setTLS12Enforced()` and `isTLS12Enforced()` have been removed. The SDK now supports modern TLS by default.
 
 #### `AuthenticationAPIClient` methods removed or changed
+
+- `setUserAgent(String)` has been removed. You can set headers to be sent directly on each Request instance using the `addHeader("{NAME}", "{VALUE}")` method or globally to the networking client instance via `DefaultClient(defaultHeaders = mapOf())` constructor parameter.
 
 Methods and classes specific to calling any [Authentication APIs](https://auth0.com/docs/api/authentication) categorized as Legacy have been removed in v2. The following methods have been removed:
 
@@ -221,6 +223,8 @@ Methods that returned a `TokenRequest` now return a `Request`:
 - `setDevice("{DEVICE}")` has been removed. Use `set("device", "{VALUE}")` instead.
 
 #### `UsersAPIClient` methods changed
+
+- `setUserAgent(String)` has been removed. You can set headers to be sent directly on each Request instance using the `addHeader("{NAME}", "{VALUE}")` method or globally to the networking client instance via `DefaultClient(defaultHeaders = mapOf())` constructor parameter.
 
 Methods that returned a `ParameterizableRequest` now return a `Request`:
 

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -55,15 +55,6 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         get() = auth0.getDomainUrl()
 
     /**
-     * Set the value of 'User-Agent' header for every request to Auth0 Authentication API
-     *
-     * @param userAgent value to send in every request to Auth0
-     */
-    public fun setUserAgent(userAgent: String) {
-        factory.setUserAgent(userAgent)
-    }
-
-    /**
      * Log in a user with email/username and password for a connection/realm.
      * It will use the password-realm grant type for the `/oauth/token` endpoint
      * Example:

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
@@ -56,15 +56,6 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
         get() = auth0.getDomainUrl()
 
     /**
-     * Set the value of 'User-Agent' header for every request to Auth0 Authentication API
-     *
-     * @param userAgent value to send in every request to Auth0
-     */
-    public fun setUserAgent(userAgent: String) {
-        factory.setUserAgent(userAgent)
-    }
-
-    /**
      * Link a user identity calling ['/api/v2/users/:primaryUserId/identities'](https://auth0.com/docs/link-accounts#the-management-api) endpoint
      * Example usage:
      * ```

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
@@ -62,10 +62,6 @@ internal class RequestFactory<U : Auth0Exception> internal constructor(
         baseHeaders[AUTH0_CLIENT_INFO_HEADER] = clientInfo
     }
 
-    fun setUserAgent(userAgent: String) {
-        baseHeaders[USER_AGENT_HEADER] = userAgent
-    }
-
     @VisibleForTesting
     fun <T> createRequest(
         method: HttpMethod,

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.java
@@ -125,16 +125,6 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSetUserAgent() {
-        Auth0 account = new Auth0("client-id", "https://tenant.auth0.com/");
-        //noinspection unchecked
-        RequestFactory<AuthenticationException> factory = mock(RequestFactory.class);
-        AuthenticationAPIClient client = new AuthenticationAPIClient(account, factory, gson);
-        client.setUserAgent("nexus-5x");
-        verify(factory).setUserAgent("nexus-5x");
-    }
-
-    @Test
     public void shouldSetAuth0UserAgentIfPresent() {
         final Auth0UserAgent auth0UserAgent = mock(Auth0UserAgent.class);
         when(auth0UserAgent.getValue()).thenReturn("the-user-agent-data");

--- a/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
+++ b/auth0/src/test/java/com/auth0/android/management/UsersAPIClientTest.java
@@ -124,16 +124,6 @@ public class UsersAPIClientTest {
         assertThat(optionsCaptor.getValue().getHeaders(), is(IsMapContaining.hasKey("Auth0-Client")));
     }
 
-    @Test
-    public void shouldSetUserAgent() {
-        Auth0 account = new Auth0("client-id", "https://tenant.auth0.com/");
-        //noinspection unchecked
-        RequestFactory<ManagementException> factory = mock(RequestFactory.class);
-        final UsersAPIClient client = new UsersAPIClient(account, factory, gson);
-        client.setUserAgent("android-user-agent");
-        verify(factory).setUserAgent("android-user-agent");
-    }
-
     public void shouldSetAuth0UserAgentIfPresent() {
         final Auth0UserAgent auth0UserAgent = mock(Auth0UserAgent.class);
         when(auth0UserAgent.getValue()).thenReturn("the-user-agent-data");

--- a/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.verify;
 public class RequestFactoryTest {
 
     private static final String CLIENT_INFO = "client_info";
-    private static final String USER_AGENT = "user_agent";
     private static final String BASE_URL = "http://domain.auth0.com";
 
     @Mock
@@ -134,24 +133,6 @@ public class RequestFactoryTest {
 
         factory.patch(BASE_URL, resultAdapter);
         verify(patchRequest).addHeader("Auth0-Client", CLIENT_INFO);
-    }
-
-    @Test
-    public void shouldHaveUserAgentHeader() {
-        RequestFactory<Auth0Exception> factory = createRequestFactory();
-        factory.setUserAgent(USER_AGENT);
-
-        factory.get(BASE_URL, resultAdapter);
-        verify(getRequest).addHeader("User-Agent", USER_AGENT);
-
-        factory.post(BASE_URL, resultAdapter);
-        verify(postRequest).addHeader("User-Agent", USER_AGENT);
-
-        factory.delete(BASE_URL, resultAdapter);
-        verify(deleteRequest).addHeader("User-Agent", USER_AGENT);
-
-        factory.patch(BASE_URL, resultAdapter);
-        verify(patchRequest).addHeader("User-Agent", USER_AGENT);
     }
 
     @Test

--- a/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
+++ b/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
@@ -8,7 +8,6 @@ import androidx.fragment.app.Fragment
 import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
-import com.auth0.android.callback.AuthenticationCallback
 import com.auth0.android.callback.Callback
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.request.DefaultClient
@@ -51,7 +50,7 @@ class DatabaseLoginFragment : Fragment() {
     private fun dbLogin(email: String, password: String) {
         apiClient.login(email, password, "Username-Password-Authentication")
             //Additional customization to the request goes here
-            .start(object : AuthenticationCallback<Credentials> {
+            .start(object : Callback<Credentials, AuthenticationException> {
                 override fun onFailure(error: AuthenticationException) {
                     Snackbar.make(requireView(), error.getDescription(), Snackbar.LENGTH_LONG)
                         .show()


### PR DESCRIPTION
### Changes
The setters for a user-agent header previously available on both API clients are now removed. The same can still be achieved either by setting the header to individual requests or via the `DefaultClient` constructor parameters in a global way.