### PR TITLE
Make requests that return Void have an optional type

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ val callback = object : Callback<Credentials, AuthenticationException> {
         // Failure! Check the exception for details
     }
 
-    override fun onSuccess(credentials: Credentials?) {
+    override fun onSuccess(credentials: Credentials) {
         // Success! Access token and ID token are presents
     }
 }
@@ -258,7 +258,7 @@ WebAuthProvider.logout(account)
     .start(this, logoutCallback)
 
 //Declare the callback that will receive the result
-val logoutCallback = object: Callback<Void, AuthenticationException> {
+val logoutCallback = object: Callback<Void?, AuthenticationException> {
     override fun onFailure(exception: AuthenticationException) {
         // Failure! Check the exception for details
     }
@@ -326,7 +326,7 @@ authentication
     .start(object: Callback<Credentials, AuthenticationException> {
         override fun onFailure(exception: AuthenticationException) { }
 
-        override fun onSuccess(credentials: Credentials?) { }
+        override fun onSuccess(credentials: Credentials) { }
     })
 ```
 
@@ -345,7 +345,7 @@ authentication
     .start(object: Callback<Credentials, AuthenticationException> {
         override fun onFailure(exception: AuthenticationException) { }
 
-        override fun onSuccess(credentials: Credentials?) { }
+        override fun onSuccess(credentials: Credentials) { }
     })
 ```
 
@@ -379,7 +379,7 @@ authentication
     .start(object: Callback<Credentials, AuthenticationException> {
        override fun onFailure(exception: AuthenticationException) { }
 
-       override fun onSuccess(credentials: Credentials?) { }
+       override fun onSuccess(credentials: Credentials) { }
    })
 ```
 
@@ -392,7 +392,7 @@ authentication
     .start(object: Callback<Credentials, AuthenticationException> {
         override fun onFailure(exception: AuthenticationException) { }
 
-        override fun onSuccess(credentials: Credentials?) { }
+        override fun onSuccess(credentials: Credentials) { }
     })
 ```
 
@@ -405,7 +405,7 @@ authentication
    .start(object: Callback<UserProfile, AuthenticationException> {
        override fun onFailure(exception: AuthenticationException) { }
 
-       override fun onSuccess(profile: UserProfile?) { }
+       override fun onSuccess(profile: UserProfile) { }
    })
 ```
 
@@ -434,7 +434,7 @@ authentication.login(email, password, realm)
                             // Handle error
                         }
 
-                        override fun onSuccess(credentials: Credentials?) {
+                        override fun onSuccess(credentials: Credentials) {
                             // Handle WebAuth success
                         }
                     })
@@ -442,7 +442,7 @@ authentication.login(email, password, realm)
             // Handle other errors
         }
 
-        override fun onSuccess(credentials: Credentials?) {
+        override fun onSuccess(credentials: Credentials) {
             // Handle API success
         }
     })
@@ -478,7 +478,7 @@ users
     
         override fun onFailure(exception: ManagementException) { }
     
-        override fun onSuccess(identities: List<UserIdentity>?) { }
+        override fun onSuccess(identities: List<UserIdentity>) { }
     })
 ```
 
@@ -491,7 +491,7 @@ users
     
         override fun onFailure(exception: ManagementException) { }
     
-        override fun onSuccess(identities: List<UserIdentity>?) { }
+        override fun onSuccess(identities: List<UserIdentity>) { }
     })
 ```
 
@@ -504,7 +504,7 @@ users
     
         override fun onFailure(exception: ManagementException) { }
     
-        override fun onSuccess(identities: UserProfile?) { }
+        override fun onSuccess(identities: UserProfile) { }
     })
 ```
 
@@ -522,7 +522,7 @@ users
     
         override fun onFailure(exception: ManagementException) { }
     
-        override fun onSuccess(identities: UserProfile?) { }
+        override fun onSuccess(identities: UserProfile) { }
     })
 ```
 
@@ -560,7 +560,7 @@ authentication
             // Error
         }
     
-        override fun onSuccess(credentials: Credentials?) {
+        override fun onSuccess(credentials: Credentials) {
             //Save the credentials
             manager.saveCredentials(credentials)
         }
@@ -585,7 +585,7 @@ manager.getCredentials(object : Callback<Credentials, CredentialsManagerExceptio
        // Error
    }
 
-   override fun onSuccess(credentials: Credentials?) {
+   override fun onSuccess(credentials: Credentials) {
        // Use the credentials
    }
 })
@@ -632,7 +632,7 @@ manager.requireAuthentication(this, AUTH_REQ_CODE, null, null)
 When the above conditions are met and the manager requires the user authentication, it will use the activity context to launch a new activity and wait for its result in the `onActivityResult` method. Your activity must override this method and pass the request code and result code to the manager's `checkAuthenticationResult` method to verify if this request was successful or not.
 
 ```kotlin
-public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+ override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     if (manager.checkAuthenticationResult(requestCode, resultCode)) {
         return
     }
@@ -700,7 +700,7 @@ For more advanced configuration of the networking client, you can provide a cust
 class CustomNetClient : NetworkingClient {
     override fun load(url: String, options: RequestOptions): ServerResponse {
         // Create and execute the request to the specified URL with the given options
-        val response = ...  
+        val response = // ...
             
         // Return a ServerResponse from the received response data
         return ServerResponse(responseCode, responseBody, responseHeaders)        

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ val logoutCallback = object: Callback<Void?, AuthenticationException> {
         // Failure! Check the exception for details
     }
 
-    override fun onSuccess(payload: Void?) {
+    override fun onSuccess(result: Void?) {
         // Success! The browser session was cleared
     }
 }
@@ -365,7 +365,7 @@ authentication
     .start(object: Callback<Void, AuthenticationException> {
         override fun onFailure(exception: AuthenticationException) { }
 
-        override fun onSuccess(payload: Void?) { }
+        override fun onSuccess(result: Void?) { }
     })
 ```
 

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -62,7 +62,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * client
      *     .login("{username or email}", "{password}", "{database connection name}")
      *     .start(object : Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials?) { }
+     *         override fun onSuccess(payload: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      *```
@@ -93,7 +93,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.login("{username or email}", "{password}")
      *     .start(object:  Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials?) { }
+     *         override fun onSuccess(payload: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      *```
@@ -119,7 +119,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * client.loginWithOTP("{mfa token}", "{one time password}")
      *     .start(object : Callback<Credentials, AuthenticationException> {
      *         override fun onFailure(error: AuthenticationException) { }
-     *         override fun onSuccess(payload: Credentials?) { }
+     *         override fun onSuccess(payload: Credentials) { }
      * })
      *```
      *
@@ -145,7 +145,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.loginWithNativeSocialToken("{subject token}", "{subject token type}")
      *     .start(object: Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials?) { }
+     *         override fun onSuccess(payload: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      * ```
@@ -183,7 +183,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.loginWithPhoneNumber("{phone number}", "{code}", "{passwordless connection name}")
      *     .start(object: Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials?) { }
+     *         override fun onSuccess(payload: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      * ```
@@ -219,7 +219,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.loginWithEmail("{email}", "{code}", "{passwordless connection name}")
      *     .start(object: Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials?) { }
+     *         override fun onSuccess(payload: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      *```
@@ -252,7 +252,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.userInfo("{access_token}")
      *     .start(object: Callback<UserProfile, AuthenticationException> {
-     *         override fun onSuccess(payload: UserProfile?) { }
+     *         override fun onSuccess(payload: UserProfile) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      *```
@@ -271,7 +271,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.createUser("{email}", "{password}", "{username}", "{database connection name}")
      *     .start(object: Callback<DatabaseUser, AuthenticationException> {
-     *         override fun onSuccess(payload: DatabaseUser?) { }
+     *         override fun onSuccess(payload: DatabaseUser) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      * ```
@@ -314,7 +314,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.signUp("{email}", "{password}", "{username}", "{database connection name}")
      *     .start(object: Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials?) { }
+     *         override fun onSuccess(payload: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      *```
@@ -342,7 +342,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * Example usage:
      * ```
      * client.resetPassword("{email}", "{database connection name}")
-     *     .start(object: Callback<Void, AuthenticationException> {
+     *     .start(object: Callback<Void?, AuthenticationException> {
      *         override fun onSuccess(payload: Void?) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
@@ -355,7 +355,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     public fun resetPassword(
         email: String,
         connection: String
-    ): Request<Void, AuthenticationException> {
+    ): Request<Void?, AuthenticationException> {
         val url = auth0.getDomainUrl().toHttpUrl().newBuilder()
             .addPathSegment(DB_CONNECTIONS_PATH)
             .addPathSegment(CHANGE_PASSWORD_PATH)
@@ -375,7 +375,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * Example usage:
      * ```
      * client.revokeToken("{refresh_token}")
-     *     .start(object: Callback<Void, AuthenticationException> {
+     *     .start(object: Callback<Void?, AuthenticationException> {
      *         override fun onSuccess(payload: Void?) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
@@ -384,7 +384,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @param refreshToken the token to revoke
      * @return a request to start
      */
-    public fun revokeToken(refreshToken: String): Request<Void, AuthenticationException> {
+    public fun revokeToken(refreshToken: String): Request<Void?, AuthenticationException> {
         val parameters = ParameterBuilder.newBuilder()
             .setClientId(clientId)
             .set(TOKEN_KEY, refreshToken)
@@ -408,7 +408,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * client.renewAuth("{refresh_token}")
      *     .addParameter("scope", "openid profile email")
      *     .start(object: Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials?) { }
+     *         override fun onSuccess(payload: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      * ```
@@ -439,7 +439,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * Example usage:
      * ```
      * client.passwordlessWithEmail("{email}", PasswordlessType.CODE, "{passwordless connection name}")
-     *     .start(object: Callback<Void, AuthenticationException> {
+     *     .start(object: Callback<Void?, AuthenticationException> {
      *         override onSuccess(payload: Void?) { }
      *         override onFailure(error: AuthenticationException) { }
      * })
@@ -455,7 +455,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         email: String,
         passwordlessType: PasswordlessType,
         connection: String = EMAIL_CONNECTION
-    ): Request<Void, AuthenticationException> {
+    ): Request<Void?, AuthenticationException> {
         val parameters = ParameterBuilder.newBuilder()
             .set(EMAIL_KEY, email)
             .setSend(passwordlessType)
@@ -471,7 +471,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * Example usage:
      * ```
      * client.passwordlessWithSms("{phone number}", PasswordlessType.CODE, "{passwordless connection name}")
-     *     .start(object: Callback<Void, AuthenticationException> {
+     *     .start(object: Callback<Void?, AuthenticationException> {
      *         override fun onSuccess(payload: Void?) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
@@ -487,7 +487,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         phoneNumber: String,
         passwordlessType: PasswordlessType,
         connection: String = SMS_CONNECTION
-    ): Request<Void, AuthenticationException> {
+    ): Request<Void?, AuthenticationException> {
         val parameters = ParameterBuilder.newBuilder()
             .set(PHONE_NUMBER_KEY, phoneNumber)
             .setSend(passwordlessType)
@@ -502,7 +502,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      *
      * @return a request to configure and start
      */
-    private fun passwordless(): Request<Void, AuthenticationException> {
+    private fun passwordless(): Request<Void?, AuthenticationException> {
         val url = auth0.getDomainUrl().toHttpUrl().newBuilder()
             .addPathSegment(PASSWORDLESS_PATH)
             .addPathSegment(START_PATH)

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -62,7 +62,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * client
      *     .login("{username or email}", "{password}", "{database connection name}")
      *     .start(object : Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials) { }
+     *         override fun onSuccess(result: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      *```
@@ -93,7 +93,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.login("{username or email}", "{password}")
      *     .start(object:  Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials) { }
+     *         override fun onSuccess(result: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      *```
@@ -119,7 +119,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * client.loginWithOTP("{mfa token}", "{one time password}")
      *     .start(object : Callback<Credentials, AuthenticationException> {
      *         override fun onFailure(error: AuthenticationException) { }
-     *         override fun onSuccess(payload: Credentials) { }
+     *         override fun onSuccess(result: Credentials) { }
      * })
      *```
      *
@@ -145,7 +145,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.loginWithNativeSocialToken("{subject token}", "{subject token type}")
      *     .start(object: Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials) { }
+     *         override fun onSuccess(result: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      * ```
@@ -183,7 +183,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.loginWithPhoneNumber("{phone number}", "{code}", "{passwordless connection name}")
      *     .start(object: Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials) { }
+     *         override fun onSuccess(result: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      * ```
@@ -219,7 +219,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.loginWithEmail("{email}", "{code}", "{passwordless connection name}")
      *     .start(object: Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials) { }
+     *         override fun onSuccess(result: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      *```
@@ -252,7 +252,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.userInfo("{access_token}")
      *     .start(object: Callback<UserProfile, AuthenticationException> {
-     *         override fun onSuccess(payload: UserProfile) { }
+     *         override fun onSuccess(result: UserProfile) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      *```
@@ -271,7 +271,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.createUser("{email}", "{password}", "{username}", "{database connection name}")
      *     .start(object: Callback<DatabaseUser, AuthenticationException> {
-     *         override fun onSuccess(payload: DatabaseUser) { }
+     *         override fun onSuccess(result: DatabaseUser) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      * ```
@@ -314,7 +314,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.signUp("{email}", "{password}", "{username}", "{database connection name}")
      *     .start(object: Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials) { }
+     *         override fun onSuccess(result: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      *```
@@ -343,7 +343,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.resetPassword("{email}", "{database connection name}")
      *     .start(object: Callback<Void?, AuthenticationException> {
-     *         override fun onSuccess(payload: Void?) { }
+     *         override fun onSuccess(result: Void?) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      * ```
@@ -376,7 +376,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.revokeToken("{refresh_token}")
      *     .start(object: Callback<Void?, AuthenticationException> {
-     *         override fun onSuccess(payload: Void?) { }
+     *         override fun onSuccess(result: Void?) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      * ```
@@ -408,7 +408,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * client.renewAuth("{refresh_token}")
      *     .addParameter("scope", "openid profile email")
      *     .start(object: Callback<Credentials, AuthenticationException> {
-     *         override fun onSuccess(payload: Credentials) { }
+     *         override fun onSuccess(result: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      * ```
@@ -440,7 +440,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.passwordlessWithEmail("{email}", PasswordlessType.CODE, "{passwordless connection name}")
      *     .start(object: Callback<Void?, AuthenticationException> {
-     *         override onSuccess(payload: Void?) { }
+     *         override onSuccess(result: Void?) { }
      *         override onFailure(error: AuthenticationException) { }
      * })
      * ```
@@ -472,7 +472,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.passwordlessWithSms("{phone number}", PasswordlessType.CODE, "{passwordless connection name}")
      *     .start(object: Callback<Void?, AuthenticationException> {
-     *         override fun onSuccess(payload: Void?) { }
+     *         override fun onSuccess(result: Void?) { }
      *         override fun onFailure(error: AuthenticationException) { }
      * })
      * ```

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -43,7 +43,7 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
         storage.store(KEY_REFRESH_TOKEN, credentials.refreshToken)
         storage.store(KEY_ID_TOKEN, credentials.idToken)
         storage.store(KEY_TOKEN_TYPE, credentials.type)
-        storage.store(KEY_EXPIRES_AT, credentials.expiresAt!!.time)
+        storage.store(KEY_EXPIRES_AT, credentials.expiresAt.time)
         storage.store(KEY_SCOPE, credentials.scope)
         storage.store(KEY_CACHE_EXPIRES_AT, cacheExpiresAt)
     }
@@ -112,7 +112,7 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
         }
         request.start(object : AuthenticationCallback<Credentials> {
             override fun onSuccess(fresh: Credentials) {
-                val expiresAt = fresh!!.expiresAt!!.time
+                val expiresAt = fresh.expiresAt!!.time
                 val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
                 if (willAccessTokenExpire) {
                     val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -111,7 +111,7 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
             request.addParameter("scope", scope)
         }
         request.start(object : AuthenticationCallback<Credentials> {
-            override fun onSuccess(fresh: Credentials?) {
+            override fun onSuccess(fresh: Credentials) {
                 val expiresAt = fresh!!.expiresAt!!.time
                 val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
                 if (willAccessTokenExpire) {

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -334,7 +334,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
             request.addParameter("scope", scope)
         }
         request.start(object : AuthenticationCallback<Credentials> {
-            override fun onSuccess(fresh: Credentials?) {
+            override fun onSuccess(fresh: Credentials) {
                 val expiresAt = fresh!!.expiresAt!!.time
                 val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
                 if (willAccessTokenExpire) {

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -143,7 +143,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
             val encryptedEncoded = Base64.encodeToString(encrypted, Base64.DEFAULT)
             storage.store(KEY_CREDENTIALS, encryptedEncoded)
             storage.store(
-                KEY_EXPIRES_AT, credentials.expiresAt!!
+                KEY_EXPIRES_AT, credentials.expiresAt
                     .time
             )
             storage.store(KEY_CACHE_EXPIRES_AT, cacheExpiresAt)
@@ -335,7 +335,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         }
         request.start(object : AuthenticationCallback<Credentials> {
             override fun onSuccess(fresh: Credentials) {
-                val expiresAt = fresh!!.expiresAt!!.time
+                val expiresAt = fresh.expiresAt!!.time
                 val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
                 if (willAccessTokenExpire) {
                     val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000

--- a/auth0/src/main/java/com/auth0/android/callback/Callback.kt
+++ b/auth0/src/main/java/com/auth0/android/callback/Callback.kt
@@ -12,7 +12,7 @@ public interface Callback<T, U : Auth0Exception> {
      *
      * @param payload Request payload or null
      */
-    public fun onSuccess(payload: T?)
+    public fun onSuccess(payload: T)
 
     /**
      * Method called on Auth0 API request failure

--- a/auth0/src/main/java/com/auth0/android/callback/Callback.kt
+++ b/auth0/src/main/java/com/auth0/android/callback/Callback.kt
@@ -8,11 +8,11 @@ import com.auth0.android.Auth0Exception
 public interface Callback<T, U : Auth0Exception> {
 
     /**
-     * Method called on success with the payload or null.
+     * Method called on success with the result.
      *
-     * @param payload Request payload
+     * @param result Request result
      */
-    public fun onSuccess(payload: T)
+    public fun onSuccess(result: T)
 
     /**
      * Method called on Auth0 API request failure

--- a/auth0/src/main/java/com/auth0/android/callback/Callback.kt
+++ b/auth0/src/main/java/com/auth0/android/callback/Callback.kt
@@ -10,7 +10,7 @@ public interface Callback<T, U : Auth0Exception> {
     /**
      * Method called on success with the payload or null.
      *
-     * @param payload Request payload or null
+     * @param payload Request payload
      */
     public fun onSuccess(payload: T)
 

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
@@ -61,7 +61,7 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
      * ```
      * client.link("{auth0 primary user id}", "{user secondary token}")
      *     .start(object: Callback<List<UserIdentity>, ManagementException> {
-     *         override fun onSuccess(payload: List<UserIdentity>?) { }
+     *         override fun onSuccess(result: List<UserIdentity>) { }
      *         override fun onFailure(error: ManagementException) { }
      * })
      * ```
@@ -97,7 +97,7 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
      * ```
      * client.unlink("{auth0 primary user id}", {auth0 secondary user id}, "{secondary provider}")
      *     .start(object: Callback<List<UserIdentity>, ManagementException> {
-     *         override fun onSuccess(payload: List<UserIdentity>?) { }
+     *         override fun onSuccess(result: List<UserIdentity>) { }
      *         override fun onFailure(error: ManagementException) {}
      * })
      * ```
@@ -133,7 +133,7 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
      * ```
      * client.updateMetadata("{user id}", "{user metadata}")
      *     .start(object: Callback<UserProfile, ManagementException> {
-     *         override fun onSuccess(payload: UserProfile?) { }
+     *         override fun onSuccess(result: UserProfile) { }
      *         override fun onFailure(error: ManagementException) { }
      * })
      * ```
@@ -169,7 +169,7 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
      * ```
      * client.getProfile("{user id}")
      *     .start(object: Callback<UserProfile, ManagementException> {
-     *         override fun onSuccess(payload: UserProfile?) { }
+     *         override fun onSuccess(result: UserProfile) { }
      *         override fun onFailure(error: ManagementException) { }
      * })
      * ```

--- a/auth0/src/main/java/com/auth0/android/provider/IdTokenVerifier.java
+++ b/auth0/src/main/java/com/auth0/android/provider/IdTokenVerifier.java
@@ -27,7 +27,6 @@ class IdTokenVerifier {
         if (isEmpty(token.getIssuer())) {
             throw new TokenValidationException("Issuer (iss) claim must be a string present in the ID token");
         }
-        //noinspection ConstantConditions
         if (!token.getIssuer().equals(verifyOptions.getIssuer())) {
             throw new TokenValidationException(String.format("Issuer (iss) claim mismatch in the ID token, expected \"%s\", found \"%s\"", verifyOptions.getIssuer(), token.getIssuer()));
         }

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
@@ -10,7 +10,7 @@ import java.util.*
 
 internal class LogoutManager(
     private val account: Auth0,
-    private val callback: Callback<Void, AuthenticationException>,
+    private val callback: Callback<Void?, AuthenticationException>,
     returnToUrl: String,
     ctOptions: CustomTabsOptions
 ) : ResumableManager() {

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
@@ -16,10 +16,10 @@ internal class LogoutManager(
 ) : ResumableManager() {
     private val parameters: MutableMap<String, String>
     private val ctOptions: CustomTabsOptions
-    fun startLogout(context: Context?) {
+    fun startLogout(context: Context) {
         addClientParameters(parameters)
         val uri = buildLogoutUri()
-        AuthenticationActivity.authenticateUsingBrowser(context!!, uri, ctOptions)
+        AuthenticationActivity.authenticateUsingBrowser(context, uri, ctOptions)
     }
 
     public override fun resume(result: AuthorizeResult): Boolean {

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -100,7 +100,7 @@ internal class OAuthManager(
         pkce!!.getToken(
             values[KEY_CODE],
             object : Callback<Credentials, AuthenticationException> {
-                override fun onSuccess(credentials: Credentials?) {
+                override fun onSuccess(credentials: Credentials) {
                     assertValidIdToken(credentials!!.idToken, object : VoidCallback {
                         override fun onSuccess(payload: Void?) {
                             callback.onSuccess(credentials)
@@ -145,7 +145,7 @@ internal class OAuthManager(
                     validationCallback.onFailure(error)
                 }
 
-                override fun onSuccess(signatureVerifier: SignatureVerifier?) {
+                override fun onSuccess(signatureVerifier: SignatureVerifier) {
                     val options = IdTokenVerificationOptions(
                         idTokenVerificationIssuer!!,
                         apiClient.clientId,

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -104,7 +104,7 @@ internal class OAuthManager(
                     assertValidIdToken(
                         credentials.idToken,
                         object : Callback<Void?, Auth0Exception> {
-                            override fun onSuccess(payload: Void?) {
+                            override fun onSuccess(result: Void?) {
                                 callback.onSuccess(credentials)
                             }
 
@@ -155,11 +155,11 @@ internal class OAuthManager(
                     validationCallback.onFailure(error)
                 }
 
-                override fun onSuccess(signatureVerifier: SignatureVerifier) {
+                override fun onSuccess(result: SignatureVerifier) {
                     val options = IdTokenVerificationOptions(
                         idTokenVerificationIssuer!!,
                         apiClient.clientId,
-                        signatureVerifier
+                        result
                     )
                     val maxAge = parameters[KEY_MAX_AGE]
                     if (!TextUtils.isEmpty(maxAge)) {

--- a/auth0/src/main/java/com/auth0/android/provider/SignatureVerifier.java
+++ b/auth0/src/main/java/com/auth0/android/provider/SignatureVerifier.java
@@ -60,7 +60,6 @@ abstract class SignatureVerifier {
         apiClient.fetchJsonWebKeys().start(new AuthenticationCallback<Map<String, PublicKey>>() {
             @Override
             public void onSuccess(@Nullable Map<String, PublicKey> jwks) {
-                //noinspection ConstantConditions
                 PublicKey publicKey = jwks.get(keyId);
                 try {
                     callback.onSuccess(new AsymmetricSignatureVerifier(publicKey));

--- a/auth0/src/main/java/com/auth0/android/provider/SignatureVerifier.java
+++ b/auth0/src/main/java/com/auth0/android/provider/SignatureVerifier.java
@@ -59,8 +59,8 @@ abstract class SignatureVerifier {
     static void forAsymmetricAlgorithm(@Nullable final String keyId, @NonNull AuthenticationAPIClient apiClient, @NonNull final Callback<SignatureVerifier, TokenValidationException> callback) {
         apiClient.fetchJsonWebKeys().start(new AuthenticationCallback<Map<String, PublicKey>>() {
             @Override
-            public void onSuccess(@Nullable Map<String, PublicKey> jwks) {
-                PublicKey publicKey = jwks.get(keyId);
+            public void onSuccess(@Nullable Map<String, PublicKey> result) {
+                PublicKey publicKey = result.get(keyId);
                 try {
                     callback.onSuccess(new AsymmetricSignatureVerifier(publicKey));
                 } catch (InvalidKeyException e) {

--- a/auth0/src/main/java/com/auth0/android/provider/VoidCallback.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/VoidCallback.kt
@@ -6,4 +6,4 @@ import com.auth0.android.callback.Callback
 /**
  * Generic callback called on success/failure, that receives no payload when succeeds.
  */
-internal interface VoidCallback : Callback<Void, Auth0Exception>
+internal interface VoidCallback : Callback<Void?, Auth0Exception>

--- a/auth0/src/main/java/com/auth0/android/provider/VoidCallback.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/VoidCallback.kt
@@ -1,9 +1,0 @@
-package com.auth0.android.provider
-
-import com.auth0.android.Auth0Exception
-import com.auth0.android.callback.Callback
-
-/**
- * Generic callback called on success/failure, that receives no payload when succeeds.
- */
-internal interface VoidCallback : Callback<Void?, Auth0Exception>

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -136,7 +136,7 @@ public object WebAuthProvider {
          * @see AuthenticationException.isBrowserAppNotAvailable
          * @see AuthenticationException.isAuthenticationCanceled
          */
-        public fun start(context: Context, callback: Callback<Void, AuthenticationException>) {
+        public fun start(context: Context, callback: Callback<Void?, AuthenticationException>) {
             resetManagerInstance()
             if (!ctOptions.hasCompatibleBrowser(context.packageManager)) {
                 val ex = AuthenticationException(

--- a/auth0/src/main/java/com/auth0/android/request/DefaultClient.kt
+++ b/auth0/src/main/java/com/auth0/android/request/DefaultClient.kt
@@ -38,7 +38,6 @@ public class DefaultClient(
     override fun load(url: String, options: RequestOptions): ServerResponse {
         val response = prepareCall(url.toHttpUrl(), options).execute()
 
-        //FIXME: Ensure body is being closed
         return ServerResponse(
             response.code,
             response.body!!.byteStream(),

--- a/auth0/src/main/java/com/auth0/android/request/JsonAdapter.kt
+++ b/auth0/src/main/java/com/auth0/android/request/JsonAdapter.kt
@@ -12,8 +12,9 @@ public interface JsonAdapter<T> {
      * Converts the JSON input given in the Reader to the <T> instance.
      * @param reader the reader that contains the JSON encoded string.
      * @throws IOException could be thrown to signal that the input was invalid.
+     * @return the parsed <T> result
      */
     @Throws(IOException::class)
-    public fun fromJson(reader: Reader): T?
+    public fun fromJson(reader: Reader): T
 
 }

--- a/auth0/src/main/java/com/auth0/android/request/ProfileRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/ProfileRequest.kt
@@ -76,11 +76,11 @@ public class ProfileRequest
      */
     override fun start(callback: Callback<Authentication, AuthenticationException>) {
         authenticationRequest.start(object : Callback<Credentials, AuthenticationException> {
-            override fun onSuccess(credentials: Credentials?) {
+            override fun onSuccess(credentials: Credentials) {
                 userInfoRequest
                     .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials!!.accessToken)
                     .start(object : Callback<UserProfile, AuthenticationException> {
-                        override fun onSuccess(profile: UserProfile?) {
+                        override fun onSuccess(profile: UserProfile) {
                             callback.onSuccess(Authentication(profile!!, credentials))
                         }
 

--- a/auth0/src/main/java/com/auth0/android/request/ProfileRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/ProfileRequest.kt
@@ -78,10 +78,10 @@ public class ProfileRequest
         authenticationRequest.start(object : Callback<Credentials, AuthenticationException> {
             override fun onSuccess(credentials: Credentials) {
                 userInfoRequest
-                    .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials!!.accessToken)
+                    .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials.accessToken)
                     .start(object : Callback<UserProfile, AuthenticationException> {
                         override fun onSuccess(profile: UserProfile) {
-                            callback.onSuccess(Authentication(profile!!, credentials))
+                            callback.onSuccess(Authentication(profile, credentials))
                         }
 
                         override fun onFailure(error: AuthenticationException) {
@@ -104,11 +104,11 @@ public class ProfileRequest
      */
     @Throws(Auth0Exception::class)
     override fun execute(): Authentication {
-        val credentials = authenticationRequest.execute()!!
+        val credentials = authenticationRequest.execute()
         val profile = userInfoRequest
             .addHeader(HEADER_AUTHORIZATION, "Bearer " + credentials.accessToken)
             .execute()
-        return Authentication(profile!!, credentials)
+        return Authentication(profile, credentials)
     }
 
     private companion object {

--- a/auth0/src/main/java/com/auth0/android/request/Request.kt
+++ b/auth0/src/main/java/com/auth0/android/request/Request.kt
@@ -24,7 +24,7 @@ public interface Request<T, U : Auth0Exception> {
      * @throws Auth0Exception on failure
      */
     @Throws(Auth0Exception::class)
-    public fun execute(): T?
+    public fun execute(): T
 
     /**
      * Add parameters to the request as a Map of Object with the keys as String

--- a/auth0/src/main/java/com/auth0/android/request/SignUpRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/SignUpRequest.kt
@@ -128,7 +128,7 @@ public class SignUpRequest
      */
     override fun start(callback: Callback<Credentials, AuthenticationException>) {
         signUpRequest.start(object : Callback<DatabaseUser, AuthenticationException> {
-            override fun onSuccess(user: DatabaseUser?) {
+            override fun onSuccess(user: DatabaseUser) {
                 authenticationRequest.start(callback)
             }
 
@@ -147,6 +147,6 @@ public class SignUpRequest
     @Throws(Auth0Exception::class)
     override fun execute(): Credentials {
         signUpRequest.execute()
-        return authenticationRequest.execute()!!
+        return authenticationRequest.execute()
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.kt
@@ -86,6 +86,6 @@ internal open class BaseAuthenticationRequest(private val request: Request<Crede
 
     @Throws(Auth0Exception::class)
     override fun execute(): Credentials {
-        return request.execute()!!
+        return request.execute()
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
@@ -54,7 +54,7 @@ internal open class BaseRequest<T, U : Auth0Exception>(
     override fun start(callback: Callback<T, U>) {
         threadSwitcher.backgroundThread {
             try {
-                val result: T? = execute()
+                val result: T = execute()
                 threadSwitcher.mainThread {
                     callback.onSuccess(result)
                 }
@@ -73,7 +73,7 @@ internal open class BaseRequest<T, U : Auth0Exception>(
      * The result is parsed into a <T> value or a <U> exception is thrown if something went wrong.
      */
     @kotlin.jvm.Throws(Auth0Exception::class)
-    override fun execute(): T? {
+    override fun execute(): T {
         val response: ServerResponse
         try {
             response = client.load(url, options)
@@ -86,7 +86,7 @@ internal open class BaseRequest<T, U : Auth0Exception>(
         val reader = AwareInputStreamReader(response.body, Charset.defaultCharset())
         if (response.isSuccess()) {
             //2. Successful scenario. Response of type T
-            val result: T? = resultAdapter.fromJson(reader)
+            val result: T = resultAdapter.fromJson(reader)
             reader.close()
             return result
         }

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
@@ -32,8 +32,8 @@ internal class RequestFactory<U : Auth0Exception> internal constructor(
         resultAdapter: JsonAdapter<T>
     ): Request<T, U> = setupRequest(HttpMethod.POST, url, resultAdapter, errorAdapter)
 
-    fun post(url: String): Request<Void, U> =
-        this.post(url, object : JsonAdapter<Void> {
+    fun post(url: String): Request<Void?, U> =
+        this.post(url, object : JsonAdapter<Void?> {
             override fun fromJson(reader: Reader): Void? {
                 return null
             }

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SharedPreferencesStorageTest.java
@@ -69,7 +69,6 @@ public class SharedPreferencesStorageTest {
     public void shouldThrowOnCreateIfCustomPreferencesFileNameIsEmpty() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("The SharedPreferences name is invalid");
-        //noinspection ConstantConditions
         new SharedPreferencesStorage(context, "");
     }
 

--- a/auth0/src/test/java/com/auth0/android/provider/JwtTestUtils.java
+++ b/auth0/src/test/java/com/auth0/android/provider/JwtTestUtils.java
@@ -1,11 +1,13 @@
 package com.auth0.android.provider;
 
-import androidx.annotation.NonNull;
 import android.util.Base64;
+
+import androidx.annotation.NonNull;
 
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -109,8 +111,8 @@ class JwtTestUtils {
             byte[] signatureBytes = s.sign();
             signature = Base64.encodeToString(signatureBytes, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
         }
-        String encodedHeader = new String(encodedHeaderBytes, "UTF-8");
-        String encodedBody = new String(encodedBodyBytes, "UTF-8");
+        String encodedHeader = new String(encodedHeaderBytes, StandardCharsets.UTF_8);
+        String encodedBody = new String(encodedBodyBytes, StandardCharsets.UTF_8);
 
         return String.format("%s.%s.%s", encodedHeader, encodedBody, signature);
     }

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -83,7 +83,7 @@ public class WebAuthProviderTest {
         )
         BrowserPickerTest.setupBrowserContext(
             activity,
-            Arrays.asList("com.auth0.browser"),
+            listOf("com.auth0.browser"),
             null,
             null
         )

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -59,7 +59,7 @@ public class WebAuthProviderTest {
     private lateinit var callback: Callback<Credentials, AuthenticationException>
 
     @Mock
-    private lateinit var voidCallback: Callback<Void, AuthenticationException>
+    private lateinit var voidCallback: Callback<Void?, AuthenticationException>
     private lateinit var activity: Activity
     private lateinit var account: Auth0
 

--- a/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.kt
@@ -14,7 +14,10 @@ import org.hamcrest.core.IsCollectionContaining
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.*
+import org.mockito.ArgumentMatchers
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.android.util.concurrent.PausedExecutorService
 import org.robolectric.shadows.ShadowLooper
@@ -254,12 +257,10 @@ public class BaseRequestTest {
 
         // Release the main thread queue
         ShadowLooper.shadowMainLooper().idle()
-        val pojoCaptor = ArgumentCaptor.forClass(
-            SimplePojo::class.java
-        )
+        val pojoCaptor = argumentCaptor<SimplePojo>()
         verify(callback).onSuccess(pojoCaptor.capture())
-        MatcherAssert.assertThat(pojoCaptor.value, Matchers.`is`(Matchers.notNullValue()))
-        MatcherAssert.assertThat(pojoCaptor.value.prop, Matchers.`is`("test-value"))
+        MatcherAssert.assertThat(pojoCaptor.firstValue, Matchers.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(pojoCaptor.firstValue.prop, Matchers.`is`("test-value"))
         verify(callback, Mockito.never()).onFailure(
             any()
         )

--- a/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/RequestFactoryTest.java
@@ -55,7 +55,7 @@ public class RequestFactoryTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         factory = createRequestFactory();
     }
 

--- a/auth0/src/test/java/com/auth0/android/util/MockAuthenticationCallback.java
+++ b/auth0/src/test/java/com/auth0/android/util/MockAuthenticationCallback.java
@@ -1,7 +1,6 @@
 package com.auth0.android.util;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.AuthenticationCallback;
@@ -19,7 +18,7 @@ public class MockAuthenticationCallback<T> implements AuthenticationCallback<T> 
     }
 
     @Override
-    public void onSuccess(@Nullable T payload) {
+    public void onSuccess(@NonNull T payload) {
         this.payload = payload;
     }
 

--- a/auth0/src/test/java/com/auth0/android/util/MockAuthenticationCallback.java
+++ b/auth0/src/test/java/com/auth0/android/util/MockAuthenticationCallback.java
@@ -18,8 +18,8 @@ public class MockAuthenticationCallback<T> implements AuthenticationCallback<T> 
     }
 
     @Override
-    public void onSuccess(@NonNull T payload) {
-        this.payload = payload;
+    public void onSuccess(@NonNull T result) {
+        this.payload = result;
     }
 
     public Callable<AuthenticationException> error() {

--- a/auth0/src/test/java/com/auth0/android/util/MockCallback.java
+++ b/auth0/src/test/java/com/auth0/android/util/MockCallback.java
@@ -1,7 +1,6 @@
 package com.auth0.android.util;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.auth0.android.Auth0Exception;
 import com.auth0.android.callback.Callback;
@@ -14,7 +13,7 @@ public class MockCallback<T, U extends Auth0Exception> implements Callback<T, U>
     private U error;
 
     @Override
-    public void onSuccess(@Nullable T payload) {
+    public void onSuccess(@NonNull T payload) {
         this.payload = payload;
     }
 

--- a/auth0/src/test/java/com/auth0/android/util/MockCallback.java
+++ b/auth0/src/test/java/com/auth0/android/util/MockCallback.java
@@ -13,8 +13,8 @@ public class MockCallback<T, U extends Auth0Exception> implements Callback<T, U>
     private U error;
 
     @Override
-    public void onSuccess(@NonNull T payload) {
-        this.payload = payload;
+    public void onSuccess(@NonNull T result) {
+        this.payload = result;
     }
 
     @Override

--- a/auth0/src/test/java/com/auth0/android/util/MockManagementCallback.java
+++ b/auth0/src/test/java/com/auth0/android/util/MockManagementCallback.java
@@ -1,7 +1,6 @@
 package com.auth0.android.util;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.auth0.android.callback.ManagementCallback;
 import com.auth0.android.management.ManagementException;
@@ -19,7 +18,7 @@ public class MockManagementCallback<T> implements ManagementCallback<T> {
     }
 
     @Override
-    public void onSuccess(@Nullable T payload) {
+    public void onSuccess(@NonNull T payload) {
         this.payload = payload;
     }
 

--- a/auth0/src/test/java/com/auth0/android/util/MockManagementCallback.java
+++ b/auth0/src/test/java/com/auth0/android/util/MockManagementCallback.java
@@ -18,8 +18,8 @@ public class MockManagementCallback<T> implements ManagementCallback<T> {
     }
 
     @Override
-    public void onSuccess(@NonNull T payload) {
-        this.payload = payload;
+    public void onSuccess(@NonNull T result) {
+        this.payload = result;
     }
 
     public Callable<ManagementException> error() {

--- a/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
+++ b/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
@@ -56,7 +56,7 @@ class DatabaseLoginFragment : Fragment() {
                         .show()
                 }
 
-                override fun onSuccess(payload: Credentials?) {
+                override fun onSuccess(payload: Credentials) {
                     Snackbar.make(
                         requireView(),
                         "Success: ${payload!!.accessToken}",
@@ -69,7 +69,7 @@ class DatabaseLoginFragment : Fragment() {
     private fun webAuth() {
         WebAuthProvider.login(account)
             .start(requireContext(), object : Callback<Credentials, AuthenticationException> {
-                override fun onSuccess(payload: Credentials?) {
+                override fun onSuccess(payload: Credentials) {
                     Snackbar.make(
                         requireView(),
                         "Success: ${payload!!.accessToken}",

--- a/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
+++ b/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
@@ -56,10 +56,10 @@ class DatabaseLoginFragment : Fragment() {
                         .show()
                 }
 
-                override fun onSuccess(payload: Credentials) {
+                override fun onSuccess(result: Credentials) {
                     Snackbar.make(
                         requireView(),
-                        "Success: ${payload!!.accessToken}",
+                        "Success: ${result.accessToken}",
                         Snackbar.LENGTH_LONG
                     ).show()
                 }
@@ -69,10 +69,10 @@ class DatabaseLoginFragment : Fragment() {
     private fun webAuth() {
         WebAuthProvider.login(account)
             .start(requireContext(), object : Callback<Credentials, AuthenticationException> {
-                override fun onSuccess(payload: Credentials) {
+                override fun onSuccess(result: Credentials) {
                     Snackbar.make(
                         requireView(),
-                        "Success: ${payload!!.accessToken}",
+                        "Success: ${result.accessToken}",
                         Snackbar.LENGTH_LONG
                     ).show()
                 }


### PR DESCRIPTION
### Changes
This PR updates the `Callback` interface so that the value passed on `onSuccess` is no longer optional. This should help callers to use the method directly rather than null check it with `?` or `!!` before accessing its properties.

The change was possible by making individual requests that can succeed without any specific result value (`Void`) to have an optional type. 

### Kotlin callers:
The warnings refer to the change of the parameter name.
#### Void callbacks:
![image](https://user-images.githubusercontent.com/3900123/105493353-9432e280-5cb9-11eb-95c7-1a06c6f73c61.png)

#### Non-Void callbacks:
![image](https://user-images.githubusercontent.com/3900123/105493376-9d23b400-5cb9-11eb-98c9-775861b9cacd.png)


The screenshots captured below show what the autocomplete suggest when filling the second parameter (e.g. for java typing "new..." and using the autocomplete).

### Java callers:

#### Void callbacks:
![image](https://user-images.githubusercontent.com/3900123/105493496-c3e1ea80-5cb9-11eb-8b7f-95ae87291782.png)

#### Non-Void callbacks:

The immediate difference with Kotlin is that the `onFailure` function shows a warning about the `error` parameter not being annotated as `NonNull`. I'd expect this to happen also for the `credentials` parameter, given that the `Callback` interface says is not null. This behavior is not seen on Kotlin callers. In the end, the java annotations for nullability are just for helping the compiler emit warnings and are NOT going to make the application fail on runtime.

![image](https://user-images.githubusercontent.com/3900123/105493526-cba18f00-5cb9-11eb-811d-e7dde3065353.png)
