### PR TITLE
Enforce openid scope on the AuthenticationAPIClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ authentication
     })
 ```
 
-> The default scope used is `openid profile email`
+> The default scope used is `openid profile email`. Regardless of the scopes set to the request, the `openid` scope is always enforced.
 
 
 #### Login using MFA with One Time Password code
@@ -349,6 +349,7 @@ authentication
     })
 ```
 
+> The default scope used is `openid profile email`. Regardless of the scopes set to the request, the `openid` scope is always enforced.
 
 
 #### Passwordless Login
@@ -369,7 +370,6 @@ authentication
     })
 ```
 
-> The default scope used is `openid profile email`
 
 Step 2: Input the code
 
@@ -383,6 +383,7 @@ authentication
    })
 ```
 
+> The default scope used is `openid profile email`. Regardless of the scopes set to the request, the `openid` scope is always enforced.
 
 #### Sign Up with database connection
 
@@ -396,6 +397,7 @@ authentication
     })
 ```
 
+> The default scope used is `openid profile email`. Regardless of the scopes set to the request, the `openid` scope is always enforced.
 
 #### Get user information
 

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -77,10 +77,9 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         password: String,
         realmOrConnection: String
     ): AuthenticationRequest {
-        val builder = ParameterBuilder.newBuilder()
+        val parameters = ParameterBuilder.newAuthenticationBuilder()
             .set(USERNAME_KEY, usernameOrEmail)
             .set(PASSWORD_KEY, password)
-        val parameters = builder
             .setGrantType(ParameterBuilder.GRANT_TYPE_PASSWORD_REALM)
             .setRealm(realmOrConnection)
             .asDictionary()
@@ -103,7 +102,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @return a request to configure and start that will yield [Credentials]
      */
     public fun login(usernameOrEmail: String, password: String): AuthenticationRequest {
-        val requestParameters = ParameterBuilder.newBuilder()
+        val requestParameters = ParameterBuilder.newAuthenticationBuilder()
             .set(USERNAME_KEY, usernameOrEmail)
             .set(PASSWORD_KEY, password)
             .setGrantType(ParameterBuilder.GRANT_TYPE_PASSWORD)
@@ -129,7 +128,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @return a request to configure and start that will yield [Credentials]
      */
     public fun loginWithOTP(mfaToken: String, otp: String): AuthenticationRequest {
-        val parameters = ParameterBuilder.newBuilder()
+        val parameters = ParameterBuilder.newAuthenticationBuilder()
             .setGrantType(ParameterBuilder.GRANT_TYPE_MFA_OTP)
             .set(MFA_TOKEN_KEY, mfaToken)
             .set(ONE_TIME_PASSWORD_KEY, otp)
@@ -155,22 +154,13 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @return a request to configure and start that will yield [Credentials]
      */
     public fun loginWithNativeSocialToken(token: String, tokenType: String): AuthenticationRequest {
-        val url = auth0.getDomainUrl().toHttpUrl().newBuilder()
-            .addPathSegment(OAUTH_PATH)
-            .addPathSegment(TOKEN_PATH)
-            .build()
         val parameters = ParameterBuilder.newAuthenticationBuilder()
             .setGrantType(ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
             .setClientId(clientId)
             .set(SUBJECT_TOKEN_KEY, token)
             .set(SUBJECT_TOKEN_TYPE_KEY, tokenType)
             .asDictionary()
-        val credentialsAdapter = GsonAdapter(
-            Credentials::class.java, gson
-        )
-        val request = BaseAuthenticationRequest(factory.post(url.toString(), credentialsAdapter))
-        request.addParameters(parameters)
-        return request
+        return loginWithToken(parameters)
     }
 
     /**
@@ -199,10 +189,9 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         verificationCode: String,
         realmOrConnection: String = SMS_CONNECTION
     ): AuthenticationRequest {
-        val builder = ParameterBuilder.newAuthenticationBuilder()
+        val parameters = ParameterBuilder.newAuthenticationBuilder()
             .setClientId(clientId)
             .set(USERNAME_KEY, phoneNumber)
-        val parameters = builder
             .setGrantType(ParameterBuilder.GRANT_TYPE_PASSWORDLESS_OTP)
             .set(ONE_TIME_PASSWORD_KEY, verificationCode)
             .setRealm(realmOrConnection)
@@ -235,10 +224,9 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         verificationCode: String,
         realmOrConnection: String = EMAIL_CONNECTION
     ): AuthenticationRequest {
-        val builder = ParameterBuilder.newAuthenticationBuilder()
+        val parameters = ParameterBuilder.newAuthenticationBuilder()
             .setClientId(clientId)
             .set(USERNAME_KEY, email)
-        val parameters = builder
             .setGrantType(ParameterBuilder.GRANT_TYPE_PASSWORDLESS_OTP)
             .set(ONE_TIME_PASSWORD_KEY, verificationCode)
             .setRealm(realmOrConnection)

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -37,6 +37,8 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     /**
      * Creates a new API client instance providing Auth0 account info.
      *
+     * Example usage:
+     *
      * ```
      * val auth0 = Auth0("YOUR_CLIENT_ID", "YOUR_DOMAIN")
      * val client = AuthenticationAPIClient(auth0)
@@ -57,7 +59,10 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     /**
      * Log in a user with email/username and password for a connection/realm.
      * It will use the password-realm grant type for the `/oauth/token` endpoint
-     * Example:
+     * The default scope used is 'openid profile email'.
+     *
+     * Example usage:
+     *
      * ```
      * client
      *     .login("{username or email}", "{password}", "{database connection name}")
@@ -88,7 +93,10 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     /**
      * Log in a user with email/username and password using the password grant and the default directory.
+     * The default scope used is 'openid profile email'.
+     *
      * Example usage:
+     *
      * ```
      * client.login("{username or email}", "{password}")
      *     .start(object:  Callback<Credentials, AuthenticationException> {
@@ -113,7 +121,12 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     /**
      * Log in a user using the One Time Password code after they have received the 'mfa_required' error.
      * The MFA token tells the server the username or email, password and realm values sent on the first request.
-     * Requires your client to have the **MFA** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.* Example usage:
+     * The default scope used is 'openid profile email'.
+     *
+     * Requires your client to have the **MFA** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
+     *
+     * Example usage:
+     *
      *```
      * client.loginWithOTP("{mfa token}", "{one time password}")
      *     .start(object : Callback<Credentials, AuthenticationException> {
@@ -138,7 +151,8 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     /**
      * Log in a user using a token obtained from a Native Social Identity Provider, such as Facebook, using ['\oauth\token' endpoint](https://auth0.com/docs/api/authentication#token-exchange-for-native-social)
-     * The default scope used is 'openid'.
+     * The default scope used is 'openid profile email'.
+     *
      * Example usage:
      *
      * ```
@@ -165,7 +179,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     /**
      * Log in a user using a phone number and a verification code received via SMS (Part of passwordless login flow)
-     * The default scope used is 'openid'.
+     * The default scope used is 'openid profile email'.
      *
      * Your Application must have the **Passwordless OTP** Grant Type enabled.
      *
@@ -201,7 +215,8 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     /**
      * Log in a user using an email and a verification code received via Email (Part of passwordless login flow).
-     * The default scope used is 'openid'.
+     * The default scope used is 'openid profile email'.
+     *
      * Your Application must have the **Passwordless OTP** Grant Type enabled.
      *
      * Example usage:
@@ -236,6 +251,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     /**
      * Returns the information of the user associated with the given access_token.
+     *
      * Example usage:
      * ```
      * client.userInfo("{access_token}")
@@ -255,6 +271,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     /**
      * Creates a user in a DB connection using ['/dbconnections/signup' endpoint](https://auth0.com/docs/api/authentication#signup)
+     *
      * Example usage:
      * ```
      * client.createUser("{email}", "{password}", "{username}", "{database connection name}")
@@ -298,7 +315,10 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     /**
      * Creates a user in a DB connection using ['/dbconnections/signup' endpoint](https://auth0.com/docs/api/authentication#signup)
      * and then logs in the user.
+     * The default scope used is 'openid profile email'.
+     *
      * Example usage:
+     *
      * ```
      * client.signUp("{email}", "{password}", "{username}", "{database connection name}")
      *     .start(object: Callback<Credentials, AuthenticationException> {
@@ -327,7 +347,9 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     /**
      * Request a reset password using ['/dbconnections/change_password'](https://auth0.com/docs/api/authentication#change-password)
+     *
      * Example usage:
+     *
      * ```
      * client.resetPassword("{email}", "{database connection name}")
      *     .start(object: Callback<Void?, AuthenticationException> {
@@ -360,7 +382,9 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     /**
      * Request the revoke of a given refresh_token. Once revoked, the refresh_token cannot be used to obtain new tokens.
      * Your Auth0 Application Type should be set to 'Native' and Token Endpoint Authentication Method must be set to 'None'.
+     *
      * Example usage:
+     *
      * ```
      * client.revokeToken("{refresh_token}")
      *     .start(object: Callback<Void?, AuthenticationException> {
@@ -388,9 +412,11 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     /**
      * Requests new Credentials using a valid Refresh Token. The received token will have the same audience and scope as first requested.
      *
-     *
      * This method will use the /oauth/token endpoint with the 'refresh_token' grant, and the response will include an id_token and an access_token if 'openid' scope was requested when the refresh_token was obtained.
      * Additionally, if the application has Refresh Token Rotation configured, a new one-time use refresh token will also be included in the response.
+     *
+     * The scope of the newly received Access Token can be reduced sending the scope parameter with this request.
+     *
      * Example usage:
      * ```
      * client.renewAuth("{refresh_token}")
@@ -423,7 +449,9 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     /**
      * Start a passwordless flow with an [Email](https://auth0.com/docs/api/authentication#get-code-or-link).
+     *
      * Your Application must have the **Passwordless OTP** Grant Type enabled.
+     *
      * Example usage:
      * ```
      * client.passwordlessWithEmail("{email}", PasswordlessType.CODE, "{passwordless connection name}")
@@ -455,7 +483,9 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     /**
      * Start a passwordless flow with a [SMS](https://auth0.com/docs/api/authentication#get-code-or-link)
+     *
      * Your Application requires to have the **Passwordless OTP** Grant Type enabled.
+     *
      * Example usage:
      * ```
      * client.passwordlessWithSms("{phone number}", PasswordlessType.CODE, "{passwordless connection name}")
@@ -507,17 +537,19 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * If the login request fails, the returned request will fail
      *
      * @param authenticationRequest that will authenticate a user with Auth0 and return a [Credentials]
-     * @return a [ProfileRequest] that first logins and the fetches the profile
+     * @return a [ProfileRequest] that first logs in and then fetches the profile
      */
     public fun getProfileAfter(authenticationRequest: AuthenticationRequest): ProfileRequest {
-        val profileRequest = profileRequest()
-        return ProfileRequest(authenticationRequest, profileRequest)
+        return ProfileRequest(authenticationRequest, profileRequest())
     }
 
     /**
      * Fetch the token information from Auth0, using the authorization_code grant type
      * The authorization code received from the Auth0 server and the code verifier used
      * to generate the challenge sent to the /authorize call must be provided.
+     *
+     * Example usage:
+     *
      * ```
      * client
      *     .token("authorization code", "code verifier", "redirect_uri")
@@ -570,6 +602,9 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         return factory.get(url.toString(), jwksAdapter)
     }
 
+    /**
+     * Helper function to make a request to the /oauth/token endpoint.
+     */
     private fun loginWithToken(parameters: Map<String, String>): AuthenticationRequest {
         val url = auth0.getDomainUrl().toHttpUrl().newBuilder()
             .addPathSegment(OAUTH_PATH)

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
@@ -1,5 +1,7 @@
 package com.auth0.android.authentication
 
+import com.auth0.android.request.internal.OidcUtils
+
 /**
  * Builder for Auth0 Authentication API parameters
  * You can build your parameters like this
@@ -64,7 +66,7 @@ public class ParameterBuilder private constructor(parameters: Map<String, String
      * @return itself
      */
     public fun setScope(scope: String): ParameterBuilder {
-        return set(SCOPE_KEY, scope)
+        return set(SCOPE_KEY, OidcUtils.includeRequiredScope(scope))
     }
 
     /**
@@ -166,15 +168,16 @@ public class ParameterBuilder private constructor(parameters: Map<String, String
         public const val AUDIENCE_KEY: String = "audience"
 
         /**
-         * Creates a new instance of the builder using default values for login request, e.g. 'openid' for scope.
+         * Creates a new instance of the builder using default values for login request, e.g. 'openid profile email' for scope.
          *
          * @return a new builder
          */
         @JvmStatic
         public fun newAuthenticationBuilder(): ParameterBuilder {
             return newBuilder()
-                .setScope(SCOPE_OPENID)
+                .setScope(OidcUtils.DEFAULT_SCOPE)
         }
+
         /**
          * Creates a new instance of the builder.
          *

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -12,6 +12,7 @@ import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
 import com.auth0.android.request.internal.Jwt
+import com.auth0.android.request.internal.OidcUtils
 import com.auth0.android.result.Credentials
 import java.security.SecureRandom
 import java.util.*
@@ -55,7 +56,7 @@ internal class OAuthManager(
     }
 
     fun startAuthentication(context: Context, redirectUri: String, requestCode: Int) {
-        addRequiredScope(parameters)
+        OidcUtils.includeDefaultScope(parameters)
         addPKCEParameters(parameters, redirectUri, headers)
         addClientParameters(parameters, redirectUri)
         addValidationParameters(parameters)
@@ -222,19 +223,6 @@ internal class OAuthManager(
         val uri = builder.build()
         Log.d(TAG, "Using the following Authorize URI: $uri")
         return uri
-    }
-
-    private fun addRequiredScope(parameters: MutableMap<String, String>) {
-        if (!parameters.containsKey(KEY_SCOPE)) {
-            parameters[KEY_SCOPE] = DEFAULT_SCOPE
-            return
-        }
-        val existingScopes = parameters[KEY_SCOPE]!!.split(" ")
-            .map { it.toLowerCase(Locale.ROOT) }
-        if (!existingScopes.contains(REQUIRED_SCOPE)) {
-            val requiredScopes = (existingScopes + REQUIRED_SCOPE).joinToString(separator = " ")
-            parameters[KEY_SCOPE] = requiredScopes
-        }
     }
 
     private fun addPKCEParameters(

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
@@ -31,13 +31,23 @@ internal open class BaseRequest<T, U : Auth0Exception>(
     }
 
     override fun addParameters(parameters: Map<String, String>): Request<T, U> {
-        options.parameters.putAll(parameters)
+        val mapCopy = parameters.toMutableMap()
+        if (parameters.containsKey(OidcUtils.KEY_SCOPE)) {
+            val updatedScope =
+                OidcUtils.includeRequiredScope(parameters.getValue(OidcUtils.KEY_SCOPE))
+            mapCopy[OidcUtils.KEY_SCOPE] = updatedScope
+        }
+        options.parameters.putAll(mapCopy)
         return this
     }
 
     override fun addParameter(name: String, value: String): Request<T, U> {
-        options.parameters[name] = value
-        return this
+        val anyValue: Any = if (name == OidcUtils.KEY_SCOPE) {
+            OidcUtils.includeRequiredScope(value)
+        } else {
+            value
+        }
+        return addParameter(name, anyValue)
     }
 
     internal fun addParameter(name: String, value: Any): Request<T, U> {

--- a/auth0/src/main/java/com/auth0/android/request/internal/OidcUtils.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/OidcUtils.kt
@@ -1,0 +1,46 @@
+package com.auth0.android.request.internal
+
+import java.util.*
+
+/**
+ * Small utility class to handle OpenID Connect conformance
+ */
+internal object OidcUtils {
+    internal const val KEY_SCOPE = "scope"
+    internal const val DEFAULT_SCOPE = "openid profile email"
+    private const val REQUIRED_SCOPE = "openid"
+
+    /**
+     * Given a string, it will check if it contains the scope of "openid".
+     * If it does, it will keep it unchanged. Otherwise, it will append "openid".
+     *
+     * @param scope the scope to check if includes "openid"
+     * @return a scope that contains "openid"
+     */
+    fun includeRequiredScope(scope: String): String {
+        val existingScopes = scope.split(" ")
+            .map { it.toLowerCase(Locale.ROOT) }
+        return if (!existingScopes.contains(REQUIRED_SCOPE)) {
+            (existingScopes + REQUIRED_SCOPE).joinToString(separator = " ").trim()
+        } else {
+            scope
+        }
+    }
+
+    /**
+     * Given a map, it will check if it contains a key with the name "scope" in it.
+     * If the "scope" key is not defined, it will add one with the value of "openid profile email".
+     * If the "scope" key is defined and its value contains "openid", it will keep it unchanged.
+     * Otherwise, it will append "openid" to it.
+     *
+     * @param parameters the map to check if includes a scope of "openid""
+     * @return a map with a scope containing "openid" or "openid profile email".
+     */
+    fun includeDefaultScope(parameters: MutableMap<String, String>) {
+        parameters[KEY_SCOPE] = if (parameters.containsKey(KEY_SCOPE)) {
+            includeRequiredScope(parameters.getValue(KEY_SCOPE))
+        } else {
+            DEFAULT_SCOPE
+        }
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -168,6 +168,7 @@ public class AuthenticationAPIClientTest {
         )
         assertThat(body, Matchers.hasEntry("mfa_token", "ey30.the-mfa-token.value"))
         assertThat(body, Matchers.hasEntry("otp", "123456"))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(body, Matchers.not(Matchers.hasKey("username")))
         assertThat(body, Matchers.not(Matchers.hasKey("password")))
         assertThat(body, Matchers.not(Matchers.hasKey("connection")))
@@ -226,8 +227,8 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("username", SUPPORT_AUTH0_COM))
         assertThat(body, Matchers.hasEntry("password", "some-password"))
         assertThat(body, Matchers.hasEntry("realm", MY_CONNECTION))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(body, Matchers.not(Matchers.hasKey("connection")))
-        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
         assertThat(body, Matchers.not(Matchers.hasKey("audience")))
     }
 
@@ -255,9 +256,9 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("grant_type", "password"))
         assertThat(body, Matchers.hasEntry("username", SUPPORT_AUTH0_COM))
         assertThat(body, Matchers.hasEntry("password", "some-password"))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(body, Matchers.not(Matchers.hasKey("realm")))
         assertThat(body, Matchers.not(Matchers.hasKey("connection")))
-        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
         assertThat(body, Matchers.not(Matchers.hasKey("audience")))
     }
 
@@ -280,9 +281,9 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("grant_type", "password"))
         assertThat(body, Matchers.hasEntry("username", SUPPORT_AUTH0_COM))
         assertThat(body, Matchers.hasEntry("password", "some-password"))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(body, Matchers.not(Matchers.hasKey("realm")))
         assertThat(body, Matchers.not(Matchers.hasKey("connection")))
-        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
         assertThat(body, Matchers.not(Matchers.hasKey("audience")))
     }
 
@@ -353,7 +354,7 @@ public class AuthenticationAPIClientTest {
         )
         assertThat(body, Matchers.hasEntry("subject_token", "test-token-value"))
         assertThat(body, Matchers.hasEntry("subject_token_type", "test-token-type"))
-        assertThat(body, Matchers.hasEntry("scope", OPENID))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(
             callback, AuthenticationCallbackMatcher.hasPayloadOfType(
                 Credentials::class.java
@@ -382,7 +383,7 @@ public class AuthenticationAPIClientTest {
         )
         assertThat(body, Matchers.hasEntry("subject_token", "test-token-value"))
         assertThat(body, Matchers.hasEntry("subject_token_type", "test-token-type"))
-        assertThat(body, Matchers.hasEntry("scope", OPENID))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
     }
 
@@ -410,7 +411,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("realm", MY_CONNECTION))
         assertThat(body, Matchers.hasEntry("username", "+10101010101"))
         assertThat(body, Matchers.hasEntry("otp", "1234"))
-        assertThat(body, Matchers.hasEntry("scope", OPENID))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(
             callback, AuthenticationCallbackMatcher.hasPayloadOfType(
                 Credentials::class.java
@@ -442,7 +443,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("realm", "sms"))
         assertThat(body, Matchers.hasEntry("username", "+10101010101"))
         assertThat(body, Matchers.hasEntry("otp", "1234"))
-        assertThat(body, Matchers.hasEntry("scope", OPENID))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(
             callback, AuthenticationCallbackMatcher.hasPayloadOfType(
                 Credentials::class.java
@@ -473,7 +474,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("realm", "sms"))
         assertThat(body, Matchers.hasEntry("username", "+10101010101"))
         assertThat(body, Matchers.hasEntry("otp", "1234"))
-        assertThat(body, Matchers.hasEntry("scope", OPENID))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
     }
 
@@ -501,7 +502,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("realm", MY_CONNECTION))
         assertThat(body, Matchers.hasEntry("username", SUPPORT_AUTH0_COM))
         assertThat(body, Matchers.hasEntry("otp", "1234"))
-        assertThat(body, Matchers.hasEntry("scope", OPENID))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(
             callback, AuthenticationCallbackMatcher.hasPayloadOfType(
                 Credentials::class.java
@@ -533,7 +534,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("realm", "email"))
         assertThat(body, Matchers.hasEntry("username", SUPPORT_AUTH0_COM))
         assertThat(body, Matchers.hasEntry("otp", "1234"))
-        assertThat(body, Matchers.hasEntry("scope", OPENID))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(
             callback, AuthenticationCallbackMatcher.hasPayloadOfType(
                 Credentials::class.java
@@ -565,7 +566,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("realm", "email"))
         assertThat(body, Matchers.hasEntry("username", SUPPORT_AUTH0_COM))
         assertThat(body, Matchers.hasEntry("otp", "1234"))
-        assertThat(body, Matchers.hasEntry("scope", OPENID))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
     }
 
@@ -742,7 +743,7 @@ public class AuthenticationAPIClientTest {
         assertThat(loginBody, Matchers.hasEntry("username", SUPPORT_AUTH0_COM))
         assertThat(loginBody, Matchers.hasEntry("password", PASSWORD))
         assertThat(loginBody, Matchers.hasEntry("realm", MY_CONNECTION))
-        assertThat(loginBody, Matchers.not(Matchers.hasKey("scope")))
+        assertThat(loginBody, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(loginBody, Matchers.not(Matchers.hasKey("connection")))
     }
 
@@ -809,6 +810,7 @@ public class AuthenticationAPIClientTest {
         assertThat(loginBody, Matchers.hasEntry("username", SUPPORT_AUTH0_COM))
         assertThat(loginBody, Matchers.hasEntry("password", PASSWORD))
         assertThat(loginBody, Matchers.hasEntry("realm", MY_CONNECTION))
+        assertThat(loginBody, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(
             loginBody,
             Matchers.hasEntry("grant_type", "http://auth0.com/oauth/grant-type/password-realm")
@@ -847,6 +849,7 @@ public class AuthenticationAPIClientTest {
         assertThat(loginBody, Matchers.hasEntry("username", SUPPORT_AUTH0_COM))
         assertThat(loginBody, Matchers.hasEntry("password", PASSWORD))
         assertThat(loginBody, Matchers.hasEntry("realm", MY_CONNECTION))
+        assertThat(loginBody, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(
             loginBody,
             Matchers.hasEntry("grant_type", "http://auth0.com/oauth/grant-type/password-realm")
@@ -888,7 +891,7 @@ public class AuthenticationAPIClientTest {
         assertThat(loginBody, Matchers.hasEntry("username", SUPPORT_AUTH0_COM))
         assertThat(loginBody, Matchers.hasEntry("password", PASSWORD))
         assertThat(loginBody, Matchers.hasEntry("realm", MY_CONNECTION))
-        assertThat(loginBody, Matchers.not(Matchers.hasKey("scope")))
+        assertThat(loginBody, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(loginBody, Matchers.not(Matchers.hasKey("connection")))
     }
 
@@ -1477,6 +1480,7 @@ public class AuthenticationAPIClientTest {
         )
         assertThat(request.path, Matchers.equalTo("/oauth/token"))
         val body = bodyFromRequest(request)
+        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
         assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
         assertThat(body, Matchers.hasEntry("refresh_token", "refreshToken"))
         assertThat(body, Matchers.hasEntry("grant_type", "refresh_token"))
@@ -1505,6 +1509,30 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
         assertThat(body, Matchers.hasEntry("refresh_token", "refreshToken"))
         assertThat(body, Matchers.hasEntry("grant_type", "refresh_token"))
+        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
+        assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
+    }
+
+    @Test
+    public fun shouldRenewAuthWithOAuthTokenAndCustomScope() {
+        val auth0 = auth0
+        val client = AuthenticationAPIClient(auth0)
+        mockAPI.willReturnSuccessfulLogin()
+        val credentials = client.renewAuth("refreshToken")
+            .addParameter("scope", "read:users")
+            .execute()
+        val request = mockAPI.takeRequest()
+        assertThat(
+            request.getHeader("Accept-Language"), Matchers.`is`(
+                defaultLocale
+            )
+        )
+        assertThat(request.path, Matchers.equalTo("/oauth/token"))
+        val body = bodyFromRequest(request)
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
+        assertThat(body, Matchers.hasEntry("refresh_token", "refreshToken"))
+        assertThat(body, Matchers.hasEntry("grant_type", "refresh_token"))
+        assertThat(body, Matchers.hasEntry("scope", "read:users openid"))
         assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
     }
 
@@ -1603,7 +1631,7 @@ public class AuthenticationAPIClientTest {
     private val defaultLocale: String
         get() {
             val language = Locale.getDefault().toString()
-            return if (!language.isEmpty()) language else DEFAULT_LOCALE_IF_MISSING
+            return if (language.isNotEmpty()) language else DEFAULT_LOCALE_IF_MISSING
         }
     private val auth0: Auth0
         get() {

--- a/auth0/src/test/java/com/auth0/android/authentication/ParameterBuilderTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/ParameterBuilderTest.java
@@ -37,7 +37,7 @@ public class ParameterBuilderTest {
 
     @Test
     public void shouldInstantiateWithDefaultScope() {
-        assertThat(ParameterBuilder.newAuthenticationBuilder().asDictionary(), hasEntry("scope", ParameterBuilder.SCOPE_OPENID));
+        assertThat(ParameterBuilder.newAuthenticationBuilder().asDictionary(), hasEntry("scope", "openid profile email"));
     }
 
     @Test
@@ -51,9 +51,9 @@ public class ParameterBuilderTest {
     }
 
     @Test
-    public void shouldSetScope() {
-        Map<String, String> parameters = builder.setScope(ParameterBuilder.SCOPE_OFFLINE_ACCESS).asDictionary();
-        assertThat(parameters, hasEntry("scope", ParameterBuilder.SCOPE_OFFLINE_ACCESS));
+    public void shouldSetRequiredScope() {
+        Map<String, String> parameters = builder.setScope("name").asDictionary();
+        assertThat(parameters, hasEntry("scope", "name openid"));
     }
 
     @Test


### PR DESCRIPTION
### Changes

The requests affected by this change include all `/oauth/token` calls but the one that is used to renew the credentials with a Refresh Token. 

The logic is as follows:
- Each of these requests will be set an initial default `scope` of "openid profile email" to match the `WebAuthProvider` default scope.
- If a `scope` value is set by the developer, it will be checked that it includes "openid" and it will append "openid" if it's missing.

This change is to ensure the tokens response from the server is compliant with the OpenID Connect spec. 


This is NOT a breaking change
