### PR TITLE
Use dokka for docs generation

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -25,6 +25,7 @@
 plugins {
     id 'kotlin-android'
     id "com.auth0.gradle.oss-library.android" version "0.13.0"
+    id "org.jetbrains.dokka" version "1.4.20"
 }
 
 logger.lifecycle("Using version ${version} for ${name}")
@@ -90,6 +91,13 @@ android {
 ext {
     okhttpVersion = '4.9.0'
     powermockVersion = '2.0.9'
+}
+
+// Configure javadoc jar to use dokka output
+// TODO update oss-plugin to use dokka instead of doing it here
+javadocJar {
+    dependsOn "dokkaJavadoc"
+    from "$buildDir/dokka/javadoc"
 }
 
 dependencies {


### PR DESCRIPTION
### Changes

Adds the [dokka gradle plugin](https://github.com/Kotlin/dokka/), and configures the `javadocJar` task to use the files generated by dokka. Longer-term we should update the [OSS publishing plugin](https://github.com/auth0/oss-library-gradle-plugin) to handle this, but this change will enable the generation of the javadoc jar from kotlin sources.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
