### PR TITLE
Remove v2 beta indicators from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Auth0.Android (v2 BETA)
-
-> Note: This library is currently in **Beta** and has not had a complete security review. We do not recommend using this library in production yet. As we move towards general availability, please be aware that releases may contain breaking changes.
+# Auth0.Android
 
 [![CircleCI](https://img.shields.io/circleci/project/github/auth0/Auth0.Android.svg?style=flat-square)](https://circleci.com/gh/auth0/Auth0.Android/tree/master)
 [![Coverage Status](https://img.shields.io/codecov/c/github/auth0/Auth0.Android/master.svg?style=flat-square)](https://codecov.io/github/auth0/Auth0.Android)


### PR DESCRIPTION
Removing leftover warning messages from the beta stage. The library has been through a security review and is now considered stable.