### PR TITLE
Add Java's R8 Proguard rules for Gson

### DIFF
--- a/proguard/proguard-gson.pro
+++ b/proguard/proguard-gson.pro
@@ -4,3 +4,11 @@
 -keepattributes *Annotation*
 
 -dontwarn com.google.gson.internal.UnsafeAllocator
+
+#R8
+# - See https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md
+# - See https://medium.com/@harryaung/mysterious-null-crash-with-gson-serializedname-fields-when-r8-proguard-is-on-f8a4bd036e34
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+-keep,allowobfuscation @interface com.google.gson.annotations.SerializedName

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -23,8 +23,9 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig debug.signingConfig
         }
     }
     testOptions {


### PR DESCRIPTION
Adds the Proguard rules required for Gson to deserialize credentials from the Credential Manager classes.

I was able to reproduce this issue with a snippet like the following:

```kotlin
val scm = SecureCredentialsManager(
    requireContext(),
    apiClient,
    SharedPreferencesStorage(requireContext())
)
scm.saveCredentials(result)
scm.getCredentials(object: Callback<Credentials, CredentialsManagerException> {
    override fun onSuccess(result: Credentials) {
        Log.e("TAG", "success")
    }

    override fun onFailure(error: CredentialsManagerException) {
        Log.e("TAG", "failure", error)
    }

})
```
The observed behavior before this change is that "failure" is logged. When the new rules are set, the snippet logs "success". 

The changes include defining the debug signing configuration for easily testing the sample app with a release configuration.

### Reference
https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md
Closes https://github.com/auth0/Auth0.Android/issues/462