### PR TITLE
Add support for Organizations [SDK-2396]

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,43 @@ users
 
 > In all the cases, the `user ID` parameter is the unique identifier of the auth0 account instance. i.e. in `google-oauth2|123456789` it would be the part after the '|' pipe: `123456789`.
 
+### Organizations (Closed Beta)
 
+Organizations is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications. 
+
+Using Organizations, you can:
+
+- Represent teams, business customers, partner companies, or any logical grouping of users that should have different ways of accessing your applications, as organizations.
+- Manage their membership in a variety of ways, including user invitation.
+- Configure branded, federated login flows for each organization.
+- Implement role-based access control, such that users can have different roles when authenticating in the context of different organizations.
+- Build administration capabilities into your products, using Organizations APIs, so that those businesses can manage their own organizations.
+
+Note that Organizations is currently only available to customers on our Enterprise and Startup subscription plans.
+
+#### Log in to an organization
+
+```kotlin
+WebAuthProvider.login(account)
+    .withOrganization(organizationId)
+    .start(this, callback)
+```
+
+#### Accept user invitations
+
+To accept organization invitations your app needs to support [Android App Links](https://developer.android.com/training/app-links). Tapping on the invitation link should open your app (invitations links are `https` only).
+
+When your app gets opened by an invitation link, grab the invitation URL from the received Intent (e.g. in `onCreate` or `onNewIntent`) and pass it to `.withInvitationUrl()`:
+
+```kotlin
+getIntent()?.data?.let {
+    WebAuthProvider.login(account)
+        .withInvitationUrl(invitationUrl)
+        .start(this, callback)
+}
+```
+
+If the URL doesn't contain the expected values, an error will be raised through the provided callback.
 
 ## Credentials Manager
 

--- a/auth0/src/main/java/com/auth0/android/provider/IdTokenVerificationOptions.java
+++ b/auth0/src/main/java/com/auth0/android/provider/IdTokenVerificationOptions.java
@@ -9,6 +9,7 @@ class IdTokenVerificationOptions {
     private final String issuer;
     private final String audience;
     private final SignatureVerifier verifier;
+    private String organization;
     private String nonce;
     private Integer maxAge;
     private Integer clockSkew;
@@ -34,6 +35,10 @@ class IdTokenVerificationOptions {
 
     void setClock(@Nullable Date now) {
         this.clock = now;
+    }
+
+    void setOrganization(@Nullable String organization) {
+        this.organization = organization;
     }
 
     @NonNull
@@ -69,5 +74,10 @@ class IdTokenVerificationOptions {
     @Nullable
     Date getClock() {
         return clock;
+    }
+
+    @Nullable
+    String getOrganization() {
+        return organization;
     }
 }

--- a/auth0/src/main/java/com/auth0/android/provider/IdTokenVerifier.java
+++ b/auth0/src/main/java/com/auth0/android/provider/IdTokenVerifier.java
@@ -73,6 +73,16 @@ class IdTokenVerifier {
             }
         }
 
+        if (verifyOptions.getOrganization() != null) {
+            String orgClaim = token.getOrganizationId();
+            if (isEmpty(orgClaim)) {
+                throw new TokenValidationException("Organization Id (org_id) claim must be a string present in the ID token");
+            }
+            if (!verifyOptions.getOrganization().equals(orgClaim)) {
+                throw new TokenValidationException(String.format("Organization Id (org_id) claim mismatch in the ID token; expected \"%s\", found \"%s\"", verifyOptions.getOrganization(), orgClaim));
+            }
+        }
+
         if (audience.size() > 1) {
             String azpClaim = token.getAuthorizedParty();
             if (isEmpty(azpClaim)) {

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -166,9 +166,11 @@ internal class OAuthManager(
                     if (!TextUtils.isEmpty(maxAge)) {
                         options.maxAge = Integer.valueOf(maxAge!!)
                     }
+
                     options.clockSkew = idTokenVerificationLeeway
                     options.nonce = parameters[KEY_NONCE]
                     options.clock = Date(currentTimeInMillis)
+                    options.organization = parameters[KEY_ORGANIZATION]
                     try {
                         IdTokenVerifier().verify(decodedIdToken, options)
                         validationCallback.onSuccess(null)
@@ -263,6 +265,8 @@ internal class OAuthManager(
         const val KEY_NONCE = "nonce"
         const val KEY_MAX_AGE = "max_age"
         const val KEY_CONNECTION = "connection"
+        const val KEY_ORGANIZATION = "organization"
+        const val KEY_INVITATION = "invitation"
         const val KEY_SCOPE = "scope"
         const val RESPONSE_TYPE_CODE = "code"
         private const val DEFAULT_SCOPE = "openid profile email"

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -2,6 +2,7 @@ package com.auth0.android.provider
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.auth0.android.Auth0
@@ -166,6 +167,7 @@ public object WebAuthProvider {
         private var issuer: String? = null
         private var scheme: String = "https"
         private var redirectUri: String? = null
+        private var invitationUrl: String? = null
         private var ctOptions: CustomTabsOptions = CustomTabsOptions.newBuilder().build()
         private var leeway: Int? = null
 
@@ -273,6 +275,32 @@ public object WebAuthProvider {
         }
 
         /**
+         * Specify an invitation URL to join an organization.
+         * When called in combination with WebAuthProvider#withOrganization, the invitation URL
+         * will take precedence.
+         *
+         * @param invitationUrl the organization invitation URL
+         * @return the current builder instance
+         * @see withOrganization
+         */
+        public fun withInvitationUrl(invitationUrl: String): Builder {
+            this.invitationUrl = invitationUrl
+            return this
+        }
+
+        /**
+         * Specify an organization id to join to.
+         *
+         * @param organization the id of the organization to join
+         * @return the current builder instance
+         * @see withInvitationUrl
+         */
+        public fun withOrganization(organization: String): Builder {
+            values[OAuthManager.KEY_ORGANIZATION] = organization
+            return this
+        }
+
+        /**
          * Give a scope for this request. The default scope used is "openid profile email".
          * Regardless of the scopes passed, the "openid" scope is always enforced.
          *
@@ -375,6 +403,21 @@ public object WebAuthProvider {
                 )
                 callback.onFailure(ex)
                 return
+            }
+            invitationUrl?.let {
+                val url = Uri.parse(it)
+                val organizationId = url.getQueryParameter(OAuthManager.KEY_ORGANIZATION)
+                val invitationId = url.getQueryParameter(OAuthManager.KEY_INVITATION)
+                if (organizationId.isNullOrBlank() || invitationId.isNullOrBlank()) {
+                    val ex = AuthenticationException(
+                        "a0.invalid_invitation_url",
+                        "The invitation URL provided doesn't contain the 'organization' or 'invitation' values."
+                    )
+                    callback.onFailure(ex)
+                    return
+                }
+                values[OAuthManager.KEY_ORGANIZATION] = organizationId
+                values[OAuthManager.KEY_INVITATION] = invitationId
             }
             val manager = OAuthManager(account, callback, values, ctOptions)
             manager.setHeaders(headers)

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -289,9 +289,9 @@ public object WebAuthProvider {
         }
 
         /**
-         * Specify an organization id to join to.
+         * Specify the ID of an organization to join.
          *
-         * @param organization the id of the organization to join
+         * @param organization the ID of the organization to join
          * @return the current builder instance
          * @see withInvitationUrl
          */

--- a/auth0/src/main/java/com/auth0/android/request/internal/Jwt.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/Jwt.kt
@@ -22,6 +22,7 @@ internal class Jwt(rawToken: String) {
     val subject: String?
     val issuer: String?
     val nonce: String?
+    val organizationId: String?
     val issuedAt: Date?
     val expiresAt: Date?
     val authorizedParty: String?
@@ -44,6 +45,7 @@ internal class Jwt(rawToken: String) {
         subject = decodedPayload["sub"] as String?
         issuer = decodedPayload["iss"] as String?
         nonce = decodedPayload["nonce"] as String?
+        organizationId = decodedPayload["org_id"] as String?
         issuedAt = (decodedPayload["iat"] as? Double)?.let { Date(it.toLong() * 1000) }
         expiresAt = (decodedPayload["exp"] as? Double)?.let { Date(it.toLong() * 1000) }
         authorizedParty = decodedPayload["azp"] as String?

--- a/auth0/src/test/java/com/auth0/android/provider/JwtTestUtils.java
+++ b/auth0/src/test/java/com/auth0/android/provider/JwtTestUtils.java
@@ -27,6 +27,7 @@ class JwtTestUtils {
     static final String[] EXPECTED_AUDIENCE_ARRAY = new String[]{"__test_client_id__", "__test_other_client_id__"};
     static final String EXPECTED_AUDIENCE = "__test_client_id__";
     static final String EXPECTED_NONCE = "__test_nonce__";
+    static final String EXPECTED_ORGANIZATION = "__test_org_id__";
     static final Object EXPECTED_SUBJECT = "__test_subject__";
 
     private static final String RSA_PRIVATE_KEY = "src/test/resources/rsa_private.pem";

--- a/auth0/src/test/java/com/auth0/android/request/internal/JwtTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/internal/JwtTest.kt
@@ -76,6 +76,22 @@ public class JwtTest {
     // Public Claims
 
     @Test
+    public fun shouldGetOrganizationId() {
+        val jwt =
+            Jwt("eyJhbGciOiJIUzI1NiJ9.eyJvcmdfaWQiOiJ0cmF2ZWwwIn0.DRySUBRC0vqlRzsziKGmZgSIlLTY3MpxuTy83_zygos")
+        assertThat(jwt, `is`(notNullValue()))
+        assertThat(jwt.organizationId, `is`("travel0"))
+    }
+
+    @Test
+    public fun shouldGetNullOrganizationIdIfMissing() {
+        val jwt = Jwt("eyJhbGciOiJIUzI1NiJ9.e30.something")
+        assertThat(jwt, `is`(notNullValue()))
+
+        assertThat(jwt.organizationId, `is`(nullValue()))
+    }
+
+    @Test
     public fun shouldGetIssuer() {
         val jwt =
             Jwt("eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJKb2huIERvZSJ9.SgXosfRR_IwCgHq5lF3tlM-JHtpucWCRSaVuoHTbWbQ")


### PR DESCRIPTION
### Changes

This PR adds support for organizations. It consists of two new setters added to the Web Auth module.

#### Accept an invitation to join an organization

Use the `.withInvitationURL()` method in the `WebAuthProvider` builder to allow the user to accept an invitation. The given URL will be parsed and the required values extracted and used when the browser is launched.

#### Log in to an organization

If the organization ID is known, use the `.withOrganization()` method in the `WebAuthProvider` builder to allow the user to log in to an organization.


> When logging in into an organization, the received ID token will contain an `org_id` claim that will be automatically verified against the organization name requested when the authentication was started.


### References
See `SDK-2396`

### Testing

#### Passing the organization ID

```kotlin
WebAuthProvider.login(account)
            .withOrganization("org_x6OiLNbQXV8wssnO")
            .start(requireContext(), object : Callback<Credentials, AuthenticationException> {}
```

![org-login](https://user-images.githubusercontent.com/3900123/111700930-604be780-883a-11eb-83e2-ab6292d20f4c.gif)

#### Passing the invitation URL

```kotlin
WebAuthProvider.login(account)
            .withInvitationUrl("https://lbalmaceda.auth0.com/android/com.auth0.sample/callback?invitation=DTUBbkFhtgdw8EqEXNvmnJXiv3r2uqzV&organization=org_x6OiLNbQXV8wssnO&organization_name=hornero")
            .start(requireContext(), object : Callback<Credentials, AuthenticationException> {}
```

![invitation-login](https://user-images.githubusercontent.com/3900123/111701078-94270d00-883a-11eb-8752-e18748d48704.gif)


- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not
