### PR TITLE
Update invitation with app links documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ WebAuthProvider.login(account)
 
 #### Accept user invitations
 
-Users can be invited to your organization via a link. Tapping on the invitation link should open your app. Since invitations links are `https` only, is recommended that your app supports [Android App Links](https://developer.android.com/training/app-links). In this [article](https://auth0.com/docs/applications/enable-android-app-links-support) you will find how to make the Auth0 server publish the Digital Asset Links file required by your application.
+Users can be invited to your organization via a link. Tapping on the invitation link should open your app. Since invitations links are `https` only, is recommended that your app supports [Android App Links](https://developer.android.com/training/app-links). In [Enable Android App Links Support](https://auth0.com/docs/applications/enable-android-app-links-support), you will find how to make the Auth0 server publish the Digital Asset Links file required by your application.
 
 When your app gets opened by an invitation link, grab the invitation URL from the received Intent (e.g. in `onCreate` or `onNewIntent`) and pass it to `.withInvitationUrl()`:
 

--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ WebAuthProvider.login(account)
 
 #### Accept user invitations
 
-To accept organization invitations your app needs to support [Android App Links](https://developer.android.com/training/app-links). Tapping on the invitation link should open your app (invitations links are `https` only).
+Users can be invited to your organization via a link. Tapping on the invitation link should open your app. Since invitations links are `https` only, is recommended that your app supports [Android App Links](https://developer.android.com/training/app-links). In this [article](https://auth0.com/docs/applications/enable-android-app-links-support) you will find how to make the Auth0 server publish the Digital Asset Links file required by your application.
 
 When your app gets opened by an invitation link, grab the invitation URL from the received Intent (e.g. in `onCreate` or `onNewIntent`) and pass it to `.withInvitationUrl()`:
 


### PR DESCRIPTION
### Changes

Update the readme to include a link to the App Links configuration of the Auth0 dashboard. Also, rephrase to indicate that the use of App Links is recommended but not required.