### PR TITLE
Migrate to newer OSS Plugin with support for Sonatype

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -24,7 +24,7 @@
 
 plugins {
     id 'kotlin-android'
-    id "com.auth0.gradle.oss-library.android" version "0.13.0"
+    id "com.auth0.gradle.oss-library.android" version "0.15.1"
     id "org.jetbrains.dokka" version "1.4.20"
 }
 
@@ -109,7 +109,7 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"
     implementation 'com.google.code.gson:gson:2.8.6'
 
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
     testImplementation "org.powermock:powermock-module-junit4:$powermockVersion"
     testImplementation "org.powermock:powermock-module-junit4-rule:$powermockVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,19 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.20"
+    ext.kotlin_version = "1.4.21"
     repositories {
-        jcenter()
         google()
+        mavenCentral()
+        jcenter() {
+            content {
+                // https://youtrack.jetbrains.com/issue/KT-44730
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     }
 }
 
@@ -16,7 +21,7 @@ allprojects {
     group = 'com.auth0.android'
 
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,5 +23,11 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        jcenter() {
+            content {
+                // https://youtrack.jetbrains.com/issue/KT-44730
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -49,11 +49,11 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.2'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.2'
-    testImplementation 'junit:junit:4.13.1'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.4'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.3.4'
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }


### PR DESCRIPTION
### Changes

Bintray is sunsetting this 31st of March. The new version of the plugin will allow us to upload packages to Maven Central directly.
