### PR TITLE
Let dokka plugin pull dependencies from JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ allprojects {
             content {
                 // https://youtrack.jetbrains.com/issue/KT-44730
                 includeModule("org.jetbrains.trove4j", "trove4j")
+                includeModule("com.soywiz.korlibs.korte", "korte-jvm")
+                includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
             }
         }
     }


### PR DESCRIPTION
## Changes
While Dokka dependencies migrate off of Bintray, we need to ensure we're still able to generate the docs and publish releases.