### PR TITLE
Update the SLA to 6mo from now

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Android Java toolkit for Auth0 API
 
 **Version 2.0.0 of this SDK is available!**
 
-Check out the [Quickstart article](https://auth0.com/docs/quickstart/native/android) or the [source code](https://github.com/auth0/Auth0.Android). Version 1 will continue to receive Bug & Security fixes until 11th May 2021. After that date, only version 2 will be supported.
+Check out the [Quickstart article](https://auth0.com/docs/quickstart/native/android) or the [source code](https://github.com/auth0/Auth0.Android). Version 1 will continue to receive Bug & Security fixes until 5th November 2021. After that date, only version 2 will be supported.
 
 ---
 


### PR DESCRIPTION
### Changes
Update the SLA for v1 to match the one from Lock.Android v2.