### PR TITLE
Proper migration for the new key sets was applied.

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -147,7 +147,6 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
             )
             storage.store(KEY_CACHE_EXPIRES_AT, cacheExpiresAt)
             storage.store(KEY_CAN_REFRESH, canRefresh)
-            storage.store(KEY_CRYPTO_ALIAS, KEY_ALIAS)
         } catch (e: IncompatibleDeviceException) {
             throw CredentialsManagerException(
                 String.format(
@@ -230,7 +229,6 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         storage.remove(KEY_EXPIRES_AT)
         storage.remove(KEY_CACHE_EXPIRES_AT)
         storage.remove(KEY_CAN_REFRESH)
-        storage.remove(KEY_CRYPTO_ALIAS)
         Log.d(TAG, "Credentials were just removed from the storage")
     }
 
@@ -258,14 +256,12 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         }
         val cacheExpiresAt = storage.retrieveLong(KEY_CACHE_EXPIRES_AT)
         val canRefresh = storage.retrieveBoolean(KEY_CAN_REFRESH)
-        val keyAliasUsed = storage.retrieveString(KEY_CRYPTO_ALIAS)
         val emptyCredentials = TextUtils.isEmpty(encryptedEncoded) || cacheExpiresAt == null
-        return KEY_ALIAS == keyAliasUsed &&
-                !(emptyCredentials || (hasExpired(cacheExpiresAt!!) || willExpire(
-                    expiresAt,
-                    minTtl
-                )) &&
-                        (canRefresh == null || !canRefresh))
+        return !(emptyCredentials || (hasExpired(cacheExpiresAt!!) || willExpire(
+            expiresAt,
+            minTtl
+        )) &&
+                (canRefresh == null || !canRefresh))
     }
 
     private fun continueGetCredentials(
@@ -397,7 +393,6 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         private const val KEY_EXPIRES_AT = "com.auth0.credentials_access_token_expires_at"
         private const val KEY_CACHE_EXPIRES_AT = "com.auth0.credentials_expires_at"
         private const val KEY_CAN_REFRESH = "com.auth0.credentials_can_refresh"
-        private const val KEY_CRYPTO_ALIAS = "com.auth0.manager_key_alias"
         private const val KEY_ALIAS = "com.auth0.key"
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -125,7 +125,6 @@ public class SecureCredentialsManagerTest {
         verify(storage)
             .store("com.auth0.credentials_access_token_expires_at", sharedExpirationTime)
         verify(storage).store("com.auth0.credentials_can_refresh", true)
-        verify(storage).store("com.auth0.manager_key_alias", KEY_ALIAS)
         verifyNoMoreInteractions(storage)
         val encodedJson = stringCaptor.firstValue
         MatcherAssert.assertThat(encodedJson, Is.`is`(Matchers.notNullValue()))
@@ -161,7 +160,6 @@ public class SecureCredentialsManagerTest {
         verify(storage)
             .store("com.auth0.credentials_access_token_expires_at", accessTokenExpirationTime)
         verify(storage).store("com.auth0.credentials_can_refresh", true)
-        verify(storage).store("com.auth0.manager_key_alias", KEY_ALIAS)
         verifyNoMoreInteractions(storage)
         val encodedJson = stringCaptor.firstValue
         MatcherAssert.assertThat(encodedJson, Is.`is`(Matchers.notNullValue()))
@@ -201,7 +199,6 @@ public class SecureCredentialsManagerTest {
         verify(storage)
             .store("com.auth0.credentials_access_token_expires_at", accessTokenExpirationTime)
         verify(storage).store("com.auth0.credentials_can_refresh", true)
-        verify(storage).store("com.auth0.manager_key_alias", KEY_ALIAS)
         verifyNoMoreInteractions(storage)
         val encodedJson = stringCaptor.firstValue
         MatcherAssert.assertThat(encodedJson, Is.`is`(Matchers.notNullValue()))
@@ -234,7 +231,6 @@ public class SecureCredentialsManagerTest {
         verify(storage)
             .store("com.auth0.credentials_access_token_expires_at", expirationTime)
         verify(storage).store("com.auth0.credentials_can_refresh", false)
-        verify(storage).store("com.auth0.manager_key_alias", KEY_ALIAS)
         verifyNoMoreInteractions(storage)
         val encodedJson = stringCaptor.firstValue
         MatcherAssert.assertThat(encodedJson, Is.`is`(Matchers.notNullValue()))
@@ -994,7 +990,6 @@ public class SecureCredentialsManagerTest {
         verify(storage).remove("com.auth0.credentials_expires_at")
         verify(storage).remove("com.auth0.credentials_access_token_expires_at")
         verify(storage).remove("com.auth0.credentials_can_refresh")
-        verify(storage).remove("com.auth0.manager_key_alias")
         verifyNoMoreInteractions(storage)
     }
 
@@ -1012,7 +1007,6 @@ public class SecureCredentialsManagerTest {
             .thenReturn(false)
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"id_token\":\"idToken\"}")
-        Mockito.`when`(storage.retrieveString("com.auth0.manager_key_alias")).thenReturn(KEY_ALIAS)
         MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(true))
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"access_token\":\"accessToken\"}")
@@ -1028,7 +1022,6 @@ public class SecureCredentialsManagerTest {
             .thenReturn(false)
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"id_token\":\"idToken\"}")
-        Mockito.`when`(storage.retrieveString("com.auth0.manager_key_alias")).thenReturn(KEY_ALIAS)
         MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(true))
         MatcherAssert.assertThat(manager.hasValidCredentials(ONE_HOUR_SECONDS - 1), Is.`is`(true))
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
@@ -1046,7 +1039,6 @@ public class SecureCredentialsManagerTest {
             .thenReturn(false)
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"id_token\":\"idToken\"}")
-        Mockito.`when`(storage.retrieveString("com.auth0.manager_key_alias")).thenReturn(KEY_ALIAS)
         MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(false))
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"access_token\":\"accessToken\"}")
@@ -1062,7 +1054,6 @@ public class SecureCredentialsManagerTest {
             .thenReturn(true)
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"id_token\":\"idToken\", \"refresh_token\":\"refreshToken\"}")
-        Mockito.`when`(storage.retrieveString("com.auth0.manager_key_alias")).thenReturn(KEY_ALIAS)
         MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(true))
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"access_token\":\"accessToken\", \"refresh_token\":\"refreshToken\"}")
@@ -1073,12 +1064,11 @@ public class SecureCredentialsManagerTest {
     public fun shouldNotHaveCredentialsWhenAccessTokenAndIdTokenAreMissing() {
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"token_type\":\"type\", \"refresh_token\":\"refreshToken\"}")
-        Mockito.`when`(storage.retrieveString("com.auth0.manager_key_alias")).thenReturn(KEY_ALIAS)
         Assert.assertFalse(manager.hasValidCredentials())
     }
 
     @Test
-    public fun shouldNotHaveCredentialsWhenTheAliasUsedHasNotBeenMigratedYet() {
+    public fun shouldHaveCredentialsWhenTheAliasUsedHasNotBeenMigratedYet() {
         val expirationTime = CredentialsMock.ONE_HOUR_AHEAD_MS
         Mockito.`when`(storage.retrieveLong("com.auth0.credentials_expires_at"))
             .thenReturn(expirationTime)
@@ -1086,16 +1076,14 @@ public class SecureCredentialsManagerTest {
             .thenReturn(false)
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"id_token\":\"idToken\"}")
-        Mockito.`when`(storage.retrieveString("com.auth0.manager_key_alias"))
-            .thenReturn("old_alias")
-        MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(false))
+        MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(true))
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"access_token\":\"accessToken\"}")
-        MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(false))
+        MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(true))
     }
 
     @Test
-    public fun shouldNotHaveCredentialsWhenTheAliasUsedHasNotBeenSetYet() {
+    public fun shouldHaveCredentialsWhenTheAliasUsedHasNotBeenSetYet() {
         val expirationTime = CredentialsMock.ONE_HOUR_AHEAD_MS
         Mockito.`when`(storage.retrieveLong("com.auth0.credentials_expires_at"))
             .thenReturn(expirationTime)
@@ -1103,11 +1091,10 @@ public class SecureCredentialsManagerTest {
             .thenReturn(false)
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"id_token\":\"idToken\"}")
-        Mockito.`when`(storage.retrieveString("com.auth0.manager_key_alias")).thenReturn(null)
-        MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(false))
+        MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(true))
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"access_token\":\"accessToken\"}")
-        MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(false))
+        MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(true))
     }
 
     /*
@@ -1381,7 +1368,6 @@ public class SecureCredentialsManagerTest {
             .thenReturn(false)
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"access_token\":\"accessToken\"}")
-        Mockito.`when`(storage.retrieveString("com.auth0.manager_key_alias")).thenReturn(KEY_ALIAS)
         MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(false))
 
         //now, update the clock and retry
@@ -1423,7 +1409,6 @@ public class SecureCredentialsManagerTest {
         )
         Mockito.`when`(storage.retrieveBoolean("com.auth0.credentials_can_refresh"))
             .thenReturn(hasRefreshToken)
-        Mockito.`when`(storage.retrieveString("com.auth0.manager_key_alias")).thenReturn(KEY_ALIAS)
         return storedJson
     }
 


### PR DESCRIPTION
### Changes

Proper migration from to version 1.24+ was applied. This [commit](https://github.com/auth0/Auth0.Android/commit/0a259f11397aa2b4a3fa17e27802598f47642ecc) contains "fix" that makes user force logout without any reason. So I applied proper fix to keep existing users being logged in after the upgrade for any version before 1.24. 

### References

This PR will actually fix the problem described here: https://github.com/auth0/Auth0.Android/issues/324 while https://github.com/auth0/Auth0.Android/pull/325 actually do nothing valuable to avoid the logout problem.

### Testing

1. Install 1.23.0 app.
2. Log in.
3. Install app from current branch.
4. See that user is still logged in.

I didn't add unit tests yet since I don't know if library maintainers would be glad to see my contribute. So let me know if I should add some to complete the PR.

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
