### PR TITLE
Rewrite ThreadSwitcher class so that it is not tied to Looper

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,71 @@ Re-declare the activity manually with `tools:node="remove"` in your app's Androi
     tools:node="remove"/>
 ```
 
+### Unit testing with JUnit 4 or JUnit 5
+#### Handling `Method getMainLooper in android.os.Looper not mocked` errors
+Your unit tests might break with `Caused by: java.lang.RuntimeException: Method getMainLooper in android.os.Looper not mocked` due to the Looper being used internally by this library. There are two options to handle this:
+1. Use Robolectric Shadows - see this [test](https://github.com/auth0/Auth0.Android/blob/main/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt#L44-L45) for an example
+2. If your project does not use Robolectric and uses JUnit 4, you can create a `Rule` that you can add to your unit test:
+```kotlin
+import com.auth0.android.request.internal.CommonThreadSwitcher
+import com.auth0.android.request.internal.ThreadSwitcher
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+public class CommonThreadSwitcherRule : TestWatcher() {
+    override fun starting(description: Description) {
+        super.starting(description)
+        CommonThreadSwitcher.getInstance().setDelegate(object : ThreadSwitcher {
+            override fun mainThread(runnable: Runnable) {
+                runnable.run()
+            }
+
+            override fun backgroundThread(runnable: Runnable) {
+                runnable.run()
+            }
+        })
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        CommonThreadSwitcher.getInstance().setDelegate(null)
+    }
+}
+```
+See this [test](https://github.com/auth0/Auth0.Android/blob/main/auth0/src/test/java/com/auth0/android/request/internal/CommonThreadSwitcherDelegateTest.kt) for an example of it being used.
+
+3. If you use JUnit 5 then you can create an `Extension` similar to the previous `Rule` for JUnit 4:
+```kotlin
+import com.auth0.android.request.internal.CommonThreadSwitcher
+import com.auth0.android.request.internal.ThreadSwitcher
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class CommonThreadSwitcherExtension : BeforeEachCallback, AfterEachCallback {
+
+    override fun beforeEach(context: ExtensionContext?) {
+        CommonThreadSwitcher.getInstance().setDelegate(object : ThreadSwitcher {
+            override fun mainThread(runnable: Runnable) {
+                runnable.run()
+            }
+
+            override fun backgroundThread(runnable: Runnable) {
+                runnable.run()
+            }
+        })
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        CommonThreadSwitcher.getInstance().setDelegate(null)
+    }
+
+}
+```
+
+#### Handling SSL errors
+You might encounter errors similar to `PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target`, which means that you need to set up your unit tests in a way that ignores or trusts all SSL certificates. In that case, you may have to implement your own `NetworkingClient` so that you can supply your own `SSLSocketFactory` and `X509TrustManager`, and use that in creating your `Auth0` object. See the [`DefaultClient`](https://github.com/auth0/Auth0.Android/blob/main/auth0/src/main/java/com/auth0/android/request/DefaultClient.kt) class for an idea on how to extend `NetworkingClient`.
+
 ## Proguard
 The rules should be applied automatically if your application is using `minifyEnabled = true`. If you want to include them manually check the [proguard directory](proguard).
 By default you should at least use the following files:

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
@@ -20,7 +20,7 @@ internal open class BaseRequest<T, U : Auth0Exception>(
     private val client: NetworkingClient,
     private val resultAdapter: JsonAdapter<T>,
     private val errorAdapter: ErrorAdapter<U>,
-    private val threadSwitcher: ThreadSwitcher = DefaultThreadSwitcher
+    private val threadSwitcher: ThreadSwitcher = CommonThreadSwitcher.getInstance()
 ) : Request<T, U> {
 
     private val options: RequestOptions = RequestOptions(method)

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
@@ -79,7 +79,14 @@ internal class RequestFactory<U : Auth0Exception> internal constructor(
         errorAdapter: ErrorAdapter<U>
     ): Request<T, U> {
         val request =
-            createRequest(method, url, client, resultAdapter, errorAdapter, DefaultThreadSwitcher)
+            createRequest(
+                method,
+                url,
+                client,
+                resultAdapter,
+                errorAdapter,
+                CommonThreadSwitcher.getInstance()
+            )
         baseHeaders.map { request.addHeader(it.key, it.value) }
         return request
     }

--- a/auth0/src/main/java/com/auth0/android/request/internal/ThreadSwitcher.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/ThreadSwitcher.kt
@@ -2,53 +2,113 @@ package com.auth0.android.request.internal
 
 import android.os.Handler
 import android.os.Looper
+import androidx.annotation.VisibleForTesting
 import androidx.core.os.HandlerCompat
+import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
 /**
- * Thread Switcher that makes use of the Main Looper
- * and a background thread Executor.
+ * The maximum concurrent threads to execute
+ * in the background. Value taken from the Android docs.
+ * @see <a href="https://developer.android.com/guide/background/threading#creating-multiple-threads">Android: creating-multiple-threads</a>
  */
-internal object DefaultThreadSwitcher : ThreadSwitcher(
-    Looper.getMainLooper(),
-    Executors.newFixedThreadPool(MAX_CONCURRENT_THREADS)
-)
+private const val MAX_CONCURRENT_THREADS = 4
 
 /**
- * Exposes methods to execute tasks in the background
- * or post tasks in the Main / UI thread.
- * @param mainLooper The Main / UI thread Looper.
+ * Thread Switcher that makes use of the Main Looper
+ * and a background thread Executor.
  * @param backgroundExecutor The executor that enqueues tasks to be run in the background.
  */
-public open class ThreadSwitcher(
-    private val mainLooper: Looper,
-    private val backgroundExecutor: Executor
-) {
-    private val mainHandler: Handler by lazy {
-        HandlerCompat.createAsync(mainLooper)
+internal class DefaultThreadSwitcher(
+    private val backgroundExecutor: Executor = Executors.newFixedThreadPool(MAX_CONCURRENT_THREADS)
+) : ThreadSwitcher {
+
+    @Volatile
+    private var mainHandler: Handler? = null
+
+    override fun mainThread(runnable: Runnable) {
+        mainHandler ?: synchronized(this) {
+            if (mainHandler == null) {
+                mainHandler = createAsync(Looper.getMainLooper())
+            }
+        }
+        mainHandler?.post(runnable)
     }
 
-    internal companion object {
-        /**
-         * The maximum concurrent threads to execute
-         * in the background. Value taken from the Android docs.
-         * @see <a href="https://developer.android.com/guide/background/threading#creating-multiple-threads">Android: creating-multiple-threads</a>
-         */
-        internal const val MAX_CONCURRENT_THREADS = 4
+    override fun backgroundThread(runnable: Runnable) {
+        backgroundExecutor.execute(runnable)
     }
 
+    private fun createAsync(looper: Looper): Handler {
+        return HandlerCompat.createAsync(looper)
+    }
+}
+
+/**
+ * Common implementation for classes that exposes methods to execute tasks in the background
+ * or post tasks in the Main / UI thread.
+ */
+public interface ThreadSwitcher {
     /**
      * Posts the task in the Main / UI thread.
      */
-    public fun mainThread(runnable: Runnable) {
-        mainHandler.post(runnable)
-    }
+    public fun mainThread(runnable: Runnable)
 
     /**
      * Enqueues the task to be run on a background thread.
      */
-    public fun backgroundThread(runnable: Runnable) {
-        backgroundExecutor.execute(runnable)
+    public fun backgroundThread(runnable: Runnable)
+}
+
+/**
+ *  Implementation of [ThreadSwitcher] that allows users to set their own task executor,
+ *  aside from the Looper-based DefaultThreadSwitcher that it uses as default for task execution.
+ */
+public class CommonThreadSwitcher(
+    private val defaultThreadSwitcher: ThreadSwitcher
+) : ThreadSwitcher {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal var delegateThreadSwitcher: ThreadSwitcher
+
+    /**
+     * Set a delegate thread switcher instead of the DefaultThreadSwitcher,
+     * should you wish to have your own object that handles task execution.
+     * If set to `null`, the default Looper-based [DefaultThreadSwitcher] will be used.
+     * This is useful for unit tests when you don't want to use the actual main looper.
+     */
+    public fun setDelegate(threadSwitcher: ThreadSwitcher?) {
+        delegateThreadSwitcher = threadSwitcher ?: defaultThreadSwitcher
     }
+
+    override fun mainThread(runnable: Runnable) {
+        delegateThreadSwitcher.mainThread(runnable)
+    }
+
+    override fun backgroundThread(runnable: Runnable) {
+        delegateThreadSwitcher.backgroundThread(runnable)
+    }
+
+    public companion object {
+        @Volatile
+        private var INSTANCE: CommonThreadSwitcher? = null
+
+        @JvmStatic
+        public fun getInstance(): CommonThreadSwitcher {
+            if (INSTANCE != null) {
+                return INSTANCE!!
+            }
+            synchronized(this) {
+                if (INSTANCE == null) {
+                    INSTANCE = CommonThreadSwitcher(DefaultThreadSwitcher())
+                }
+            }
+            return INSTANCE!!
+        }
+    }
+
+    init {
+        delegateThreadSwitcher = defaultThreadSwitcher
+    }
+
 }

--- a/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.kt
@@ -1,6 +1,5 @@
 package com.auth0.android.request.internal
 
-import android.os.Looper
 import com.auth0.android.Auth0Exception
 import com.auth0.android.callback.Callback
 import com.auth0.android.request.*
@@ -274,8 +273,10 @@ public class BaseRequestTest {
     @Throws(Exception::class)
     public fun shouldExecuteRequestOnBackgroundThreadAndPostSuccessToMainThread() {
         val pausedExecutorService = PausedExecutorService()
-        val threadSwitcher =
-            Mockito.spy(ThreadSwitcher(Looper.getMainLooper(), pausedExecutorService))
+        val defaultThreadSwitcher =
+            DefaultThreadSwitcher(pausedExecutorService)
+        val threadSwitcher = Mockito.spy(CommonThreadSwitcher(defaultThreadSwitcher))
+
         val baseRequest = BaseRequest(
             HttpMethod.POST,
             BASE_URL,
@@ -320,8 +321,10 @@ public class BaseRequestTest {
     @Throws(Exception::class)
     public fun shouldExecuteRequestOnBackgroundThreadAndPostFailureToMainThread() {
         val pausedExecutorService = PausedExecutorService()
-        val threadSwitcher =
-            Mockito.spy(ThreadSwitcher(Looper.getMainLooper(), pausedExecutorService))
+        val defaultThreadSwitcher =
+            DefaultThreadSwitcher(pausedExecutorService)
+        val threadSwitcher = Mockito.spy(CommonThreadSwitcher(defaultThreadSwitcher))
+
         val baseRequest = BaseRequest(
             HttpMethod.POST,
             BASE_URL,

--- a/auth0/src/test/java/com/auth0/android/request/internal/CommonThreadSwitcherDelegateTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/internal/CommonThreadSwitcherDelegateTest.kt
@@ -1,0 +1,138 @@
+package com.auth0.android.request.internal
+
+import com.auth0.android.Auth0Exception
+import com.auth0.android.callback.Callback
+import com.auth0.android.request.*
+import com.auth0.android.util.CommonThreadSwitcherRule
+import com.google.gson.Gson
+import com.nhaarman.mockitokotlin2.*
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.mockito.ArgumentMatchers
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.util.*
+
+public class CommonThreadSwitcherDelegateTest {
+
+    @get:Rule
+    public val commonThreadSwitcherRule: TestWatcher = CommonThreadSwitcherRule()
+
+    private lateinit var baseRequest: BaseRequest<SimplePojo, Auth0Exception>
+    private lateinit var resultAdapter: JsonAdapter<SimplePojo>
+
+    @Mock
+    private lateinit var client: NetworkingClient
+
+    @Mock
+    private lateinit var errorAdapter: ErrorAdapter<Auth0Exception>
+
+    @Mock
+    private lateinit var auth0Exception: Auth0Exception
+
+    @Before
+    public fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        resultAdapter = Mockito.spy(GsonAdapter(SimplePojo::class.java, Gson()))
+        baseRequest = createRequest()
+    }
+
+    private fun createRequest(): BaseRequest<SimplePojo, Auth0Exception> =
+        BaseRequest(
+            HttpMethod.POST,
+            BASE_URL,
+            client,
+            resultAdapter,
+            errorAdapter
+        )
+
+    @Test
+    @Throws(Exception::class)
+    public fun shouldExecuteSuccessfulRequestSynchronously() {
+        val baseRequest = BaseRequest(
+            HttpMethod.POST,
+            BASE_URL,
+            client,
+            resultAdapter,
+            errorAdapter
+        )
+        mockSuccessfulServerResponse()
+        val callback: Callback<SimplePojo, Auth0Exception> = mock()
+
+        baseRequest.start(callback)
+        val pojoCaptor = argumentCaptor<SimplePojo>()
+        verify(callback).onSuccess(pojoCaptor.capture())
+        MatcherAssert.assertThat(pojoCaptor.firstValue, Matchers.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(pojoCaptor.firstValue.prop, Matchers.`is`("test-value"))
+        verify(callback, Mockito.never()).onFailure(
+            any()
+        )
+    }
+
+    @Test
+    @Throws(Exception::class)
+    public fun shouldReturnFailureSynchronously() {
+        val baseRequest = BaseRequest(
+            HttpMethod.POST,
+            BASE_URL,
+            client,
+            resultAdapter,
+            errorAdapter
+        )
+        mockFailedRawServerResponse()
+        val callback: Callback<SimplePojo, Auth0Exception> = mock()
+
+        baseRequest.start(callback)
+        verify(callback).onFailure(
+            any()
+        )
+        verify(callback, Mockito.never()).onSuccess(
+            any()
+        )
+    }
+
+    @Throws(Exception::class)
+    private fun mockSuccessfulServerResponse() {
+        val headers = Collections.singletonMap("Content-Type", listOf("application/json"))
+        val jsonResponse = "{\"prop\":\"test-value\"}"
+        val inputStream: InputStream = ByteArrayInputStream(jsonResponse.toByteArray())
+        val response = ServerResponse(200, inputStream, headers)
+        Mockito.`when`(
+            client.load(
+                eq(BASE_URL), any()
+            )
+        ).thenReturn(response)
+    }
+
+    @Throws(Exception::class)
+    private fun mockFailedRawServerResponse() {
+        val headers = Collections.singletonMap("Content-Type", listOf("text/plain"))
+        val textResponse = "Failure"
+        val inputStream: InputStream = ByteArrayInputStream(textResponse.toByteArray())
+        Mockito.`when`(
+            errorAdapter.fromRawResponse(
+                eq(500),
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyMap()
+            )
+        ).thenReturn(auth0Exception)
+        val response = ServerResponse(500, inputStream, headers)
+        Mockito.`when`(
+            client.load(
+                eq(BASE_URL), any()
+            )
+        ).thenReturn(response)
+    }
+
+    private class SimplePojo(val prop: String)
+    private companion object {
+        private const val BASE_URL = "https://auth0.com"
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/request/internal/ThreadSwitcherShadow.java
+++ b/auth0/src/test/java/com/auth0/android/request/internal/ThreadSwitcherShadow.java
@@ -7,12 +7,12 @@ import org.robolectric.annotation.Implements;
 /**
  * Shadow that makes use of the {@link InlineExecutorService} to run background threads
  * as soon as they are posted (synchronously). Used only when classes or methods
- * are annotated with @Config(shadows = ThreadSwitcherShadow.class)
+ * are annotated with @Config(shadows = CommonThreadSwitcher.class)
  *
  * @see <a href="https://github.com/robolectric/robolectric/issues/5645#issuecomment-627512678">https://github.com/robolectric/robolectric/issues/5645#issuecomment-627512678</a>
  * @see <a href="http://robolectric.org/javadoc/4.3/org/robolectric/android/util/concurrent/RoboExecutorService.html">http://robolectric.org/javadoc/4.3/org/robolectric/android/util/concurrent/RoboExecutorService.html</a>
  */
-@Implements(ThreadSwitcher.class)
+@Implements(CommonThreadSwitcher.class)
 @SuppressWarnings({"unused", "RedundantSuppression"})
 public class ThreadSwitcherShadow {
 

--- a/auth0/src/test/java/com/auth0/android/util/CommonThreadSwitcherRule.kt
+++ b/auth0/src/test/java/com/auth0/android/util/CommonThreadSwitcherRule.kt
@@ -1,0 +1,31 @@
+package com.auth0.android.util
+
+import com.auth0.android.request.internal.CommonThreadSwitcher
+import com.auth0.android.request.internal.ThreadSwitcher
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * A JUnit4 Rule that replaces the default executor used by [CommonThreadSwitcher] with a
+ * different one which executes each task synchronously. Can be used in unit tests instead of
+ * Robolectric's Shadows so that `Method getMainLooper in android.os.Looper not mocked` errors are not encountered.
+ */
+public class CommonThreadSwitcherRule : TestWatcher() {
+    override fun starting(description: Description) {
+        super.starting(description)
+        CommonThreadSwitcher.getInstance().setDelegate(object : ThreadSwitcher {
+            override fun mainThread(runnable: Runnable) {
+                runnable.run()
+            }
+
+            override fun backgroundThread(runnable: Runnable) {
+                runnable.run()
+            }
+        })
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        CommonThreadSwitcher.getInstance().setDelegate(null)
+    }
+}


### PR DESCRIPTION
### Changes

This PR addresses the feature request made in #463, which is a request to allow users to set their own implementation of `ThreadSwitcher` to be used in unit tests. This is useful for unit testing, so that `java.lang.RuntimeException:
Method getMainLooper in android.os.Looper not mocked.` errors can be avoided without having to use Robolectric.

### References

Ticket for this can be found here: #463 

### Testing

I've tested this PR by generating an AAR and adding it to our project, checking that our unit tests pass using the JUnit 5 `Extension` and seeing that login/logout works normally in our app.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
