### PR TITLE
Catch IOExceptions from response body InputStream

### DIFF
--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
@@ -103,8 +103,9 @@ internal open class BaseRequest<T, U : Auth0Exception>(
                 //3. Network exceptions, timeouts, etc reading response body
                 val error: U = errorAdapter.fromException(exception)
                 throw error
+            } finally {
+                reader.close()
             }
-            reader.close()
             return result
         }
 

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
@@ -99,6 +99,7 @@ internal open class BaseRequest<T, U : Auth0Exception>(
             val result: T = try {
                 resultAdapter.fromJson(reader)
             } catch (exception: Exception) {
+                //multi catch IOException and JsonParseException (including JsonIOException)
                 //3. Network exceptions, timeouts, etc reading response body
                 val error: U = errorAdapter.fromException(exception)
                 throw error

--- a/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.kt
@@ -5,6 +5,7 @@ import com.auth0.android.Auth0Exception
 import com.auth0.android.callback.Callback
 import com.auth0.android.request.*
 import com.google.gson.Gson
+import com.google.gson.JsonIOException
 import com.nhaarman.mockitokotlin2.*
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
@@ -172,6 +173,41 @@ public class BaseRequestTest {
         MatcherAssert.assertThat(exception, Matchers.`is`(auth0Exception))
         MatcherAssert.assertThat(result, Matchers.`is`(Matchers.nullValue()))
         verifyZeroInteractions(resultAdapter)
+        verify(errorAdapter).fromException(eq(networkError))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    public fun shouldBuildErrorFromResponseException() {
+        mockSuccessfulServerResponse()
+        val resultAdapter = Mockito.mock(GsonAdapter::class.java) as JsonAdapter<SimplePojo>
+        val baseRequest = BaseRequest(
+            HttpMethod.POST,
+            BASE_URL,
+            client,
+            resultAdapter,
+            errorAdapter
+        )
+        val networkError = mock<JsonIOException>()
+        Mockito.`when`(
+            resultAdapter.fromJson(
+                any()
+            )
+        ).thenThrow(networkError)
+        Mockito.`when`(
+            errorAdapter.fromException(
+                any()
+            )
+        ).thenReturn(auth0Exception)
+        var exception: Exception? = null
+        var result: SimplePojo? = null
+        try {
+            result = baseRequest.execute()
+        } catch (e: Exception) {
+            exception = e
+        }
+        MatcherAssert.assertThat(exception, Matchers.`is`(auth0Exception))
+        MatcherAssert.assertThat(result, Matchers.`is`(Matchers.nullValue()))
         verify(errorAdapter).fromException(eq(networkError))
     }
 

--- a/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/internal/BaseRequestTest.kt
@@ -178,7 +178,7 @@ public class BaseRequestTest {
 
     @Test
     @Throws(Exception::class)
-    public fun shouldBuildErrorFromResponseException() {
+    public fun shouldBuildErrorFromResponseParseException() {
         mockSuccessfulServerResponse()
         val resultAdapter = Mockito.mock(GsonAdapter::class.java) as JsonAdapter<SimplePojo>
         val baseRequest = BaseRequest(


### PR DESCRIPTION
### Changes

Handle exception from `resultAdapter.fromJson(reader)` call.

### References

Closes https://github.com/auth0/Auth0.Android/issues/483

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors (*that were completing successfully before, 16 failed before and after changes)
