### PR TITLE
Disable share button in Chrome custom tabs

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
@@ -9,6 +9,7 @@ import android.os.Parcelable;
 import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsSession;
 import androidx.core.content.ContextCompat;
@@ -54,10 +55,13 @@ public class CustomTabsOptions implements Parcelable {
     @SuppressLint("ResourceType")
     Intent toIntent(@NonNull Context context, @Nullable CustomTabsSession session) {
         final CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(session)
-                .setShowTitle(showTitle);
+                .setShowTitle(showTitle)
+                .setShareState(CustomTabsIntent.SHARE_STATE_OFF);
         if (toolbarColor > 0) {
             //Resource exists
-            builder.setToolbarColor(ContextCompat.getColor(context, toolbarColor));
+            final CustomTabColorSchemeParams.Builder colorBuilder = new CustomTabColorSchemeParams.Builder()
+                    .setToolbarColor(ContextCompat.getColor(context, toolbarColor));
+            builder.setDefaultColorSchemeParams(colorBuilder.build());
         }
         return builder.build().intent;
     }

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -115,6 +115,7 @@ public class CustomTabsControllerTest {
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(false));
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
         assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.NO_TITLE));
+        assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_SHARE_STATE, CustomTabsIntent.SHARE_STATE_OFF), is(CustomTabsIntent.SHARE_STATE_OFF));
         assertThat(intent.getData(), is(uri));
         assertThat(intent, not(hasFlag(Intent.FLAG_ACTIVITY_NO_HISTORY)));
     }
@@ -160,6 +161,7 @@ public class CustomTabsControllerTest {
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(true));
         assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.SHOW_PAGE_TITLE));
         assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(Color.BLACK));
+        assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_SHARE_STATE, CustomTabsIntent.SHARE_STATE_OFF), is(CustomTabsIntent.SHARE_STATE_OFF));
         assertThat(intent.getData(), is(uri));
         assertThat(intent, not(hasFlag(Intent.FLAG_ACTIVITY_NO_HISTORY)));
     }
@@ -205,6 +207,7 @@ public class CustomTabsControllerTest {
         assertThat(customTabIntent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
         assertThat(customTabIntent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(false));
         assertThat(customTabIntent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.NO_TITLE));
+        assertThat(customTabIntent.getIntExtra(CustomTabsIntent.EXTRA_SHARE_STATE, CustomTabsIntent.SHARE_STATE_OFF), is(CustomTabsIntent.SHARE_STATE_OFF));
     }
 
     //Helper Methods

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
@@ -81,7 +81,7 @@ public class CustomTabsOptionsTest {
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
         assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(0));
         assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.NO_TITLE));
-
+        assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_SHARE_STATE, CustomTabsIntent.SHARE_STATE_OFF), is(CustomTabsIntent.SHARE_STATE_OFF));
 
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
@@ -95,6 +95,7 @@ public class CustomTabsOptionsTest {
         assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
         assertThat(parceledIntent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(0));
         assertThat(parceledIntent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.NO_TITLE));
+        assertThat(parceledIntent.getIntExtra(CustomTabsIntent.EXTRA_SHARE_STATE, CustomTabsIntent.SHARE_STATE_OFF), is(CustomTabsIntent.SHARE_STATE_OFF));
     }
 
     @Test


### PR DESCRIPTION
### Changes

Disabled the share button for Chrome custom tabs. The share button is not relevant to be shown in a login flow.

Also replaced the deprecated setToolbarColor in the CustomTabsIntent Builder.

### References

Fixes https://github.com/auth0/Auth0.Android/issues/487

### Testing

Verify that the share button isn't shown for the browser login scenario using Chrome.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
