### PR TITLE
Explicitly specify charset, don't rely on default charset

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
@@ -16,6 +16,7 @@ import androidx.annotation.VisibleForTesting;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyPairGenerator;
@@ -367,7 +368,7 @@ class CryptoUtil {
             byte[] aes = keyGen.generateKey().getEncoded();
             //Save encrypted encoded version
             byte[] encryptedAES = RSAEncrypt(aes);
-            String encodedEncryptedAESText = new String(Base64.encode(encryptedAES, Base64.DEFAULT));
+            String encodedEncryptedAESText = new String(Base64.encode(encryptedAES, Base64.DEFAULT), StandardCharsets.UTF_8);
             storage.store(KEY_ALIAS, encodedEncryptedAESText);
             return aes;
         } catch (NoSuchAlgorithmException e) {
@@ -453,7 +454,7 @@ class CryptoUtil {
             byte[] encrypted = cipher.doFinal(decryptedInput);
             byte[] encodedIV = Base64.encode(cipher.getIV(), Base64.DEFAULT);
             //Save IV for Decrypt stage
-            storage.store(KEY_IV_ALIAS, new String(encodedIV));
+            storage.store(KEY_IV_ALIAS, new String(encodedIV, StandardCharsets.UTF_8));
             return encrypted;
         } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException e) {
             /*

--- a/auth0/src/main/java/com/auth0/android/provider/AsymmetricSignatureVerifier.java
+++ b/auth0/src/main/java/com/auth0/android/provider/AsymmetricSignatureVerifier.java
@@ -5,7 +5,7 @@ import android.util.Base64;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -39,7 +39,7 @@ class AsymmetricSignatureVerifier extends SignatureVerifier {
     @Override
     protected void checkSignature(@NonNull String[] tokenParts) throws TokenValidationException {
         String content = tokenParts[0] + "." + tokenParts[1];
-        byte[] contentBytes = content.getBytes(Charset.defaultCharset());
+        byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
         boolean valid = false;
         try {
             byte[] signatureBytes = Base64.decode(tokenParts[2], Base64.URL_SAFE | Base64.NO_WRAP);

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
@@ -4,7 +4,7 @@ import com.auth0.android.Auth0Exception
 import com.auth0.android.callback.Callback
 import com.auth0.android.request.*
 import java.io.IOException
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 /**
  * Base class for every request on this library.
@@ -93,7 +93,7 @@ internal open class BaseRequest<T, U : Auth0Exception>(
             throw error
         }
 
-        val reader = AwareInputStreamReader(response.body, Charset.defaultCharset())
+        val reader = AwareInputStreamReader(response.body, StandardCharsets.UTF_8)
         if (response.isSuccess()) {
             //2. Successful scenario. Response of type T
             val result: T = resultAdapter.fromJson(reader)

--- a/auth0/src/test/java/com/auth0/android/provider/JwtTestUtils.java
+++ b/auth0/src/test/java/com/auth0/android/provider/JwtTestUtils.java
@@ -126,7 +126,7 @@ class JwtTestUtils {
         dis.readFully(keyBytes);
         dis.close();
 
-        String temp = new String(keyBytes);
+        String temp = new String(keyBytes, StandardCharsets.UTF_8);
         String privKeyPEM = temp.replace("-----BEGIN PRIVATE KEY-----\n", "");
         privKeyPEM = privKeyPEM.replace("-----END PRIVATE KEY-----", "");
 
@@ -146,7 +146,7 @@ class JwtTestUtils {
         dis.readFully(keyBytes);
         dis.close();
 
-        String temp = new String(keyBytes);
+        String temp = new String(keyBytes, StandardCharsets.UTF_8);
         String pubKeyPEM = temp.replace("-----BEGIN PUBLIC KEY-----\n", "");
         pubKeyPEM = pubKeyPEM.replace("-----END PUBLIC KEY-----", "");
 


### PR DESCRIPTION
### Changes
Fixes #484, fixes #485

Replaces (implicit) usage of the default charset with explicit usage of [`StandardCharsets.UTF_8`](https://developer.android.com/reference/java/nio/charset/StandardCharsets#UTF_8) (added in API level 19).

Android guarantees that [`Charset.defaultCharset()` is UTF-8](https://developer.android.com/reference/java/nio/charset/Charset#defaultCharset()) (note that this is not true for the JDK, though that might not be important here), however to make the expected behavior clearer this pull request explicitly uses UTF-8 as charset.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
