### PR TITLE
Improve access_denied error handling by using the description

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -197,7 +197,7 @@ internal class OAuthManager(
             ERROR_VALUE_ACCESS_DENIED.equals(errorValue, ignoreCase = true) -> {
                 throw AuthenticationException(
                     ERROR_VALUE_ACCESS_DENIED,
-                    "Permissions were not granted. Try again."
+                    errorDescription ?: "Permissions were not granted. Try again."
                 )
             }
             ERROR_VALUE_UNAUTHORIZED.equals(errorValue, ignoreCase = true) -> {

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -1351,6 +1351,36 @@ public class WebAuthProviderTest {
     }
 
     @Test
+    public fun shouldFailToResumeLoginWithIntentWithAccessDeniedAndDescription() {
+        login(account)
+            .withState("1234567890")
+            .start(activity, callback)
+        val intent = createAuthIntent(
+            createHash(
+                null,
+                "aToken",
+                null,
+                "urlType",
+                1111L,
+                "1234567890",
+                "access_denied",
+                "email is already associated with another account",
+                null
+            )
+        )
+        Assert.assertTrue(resume(intent))
+        verify(callback).onFailure(authExceptionCaptor.capture())
+        assertThat(
+            authExceptionCaptor.firstValue, `is`(notNullValue())
+        )
+        assertThat(authExceptionCaptor.firstValue.getCode(), `is`("access_denied"))
+        assertThat(
+            authExceptionCaptor.firstValue.getDescription(),
+            `is`("email is already associated with another account")
+        )
+    }
+
+    @Test
     public fun shouldFailToResumeLoginWithIntentWithRuleError() {
         login(account)
             .withState("1234567890")


### PR DESCRIPTION
### Changes
When the `access_denied` error is received from the server, the description was hardcoded and the one sent from the server, if available, ignored. This PR changes that.

### References

Closes #493 

### Testing
- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
