### PR TITLE
Add support for OOB multi-factor authentication [SDK-2657]

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -102,8 +102,8 @@ javadocJar {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.browser:browser:1.3.0'
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"
@@ -114,12 +114,12 @@ dependencies {
     testImplementation "org.powermock:powermock-module-junit4:$powermockVersion"
     testImplementation "org.powermock:powermock-module-junit4-rule:$powermockVersion"
     testImplementation "org.powermock:powermock-api-mockito2:$powermockVersion"
-    testImplementation 'org.mockito:mockito-core:3.6.28'
+    testImplementation 'org.mockito:mockito-core:3.7.7'
     // Mockito-Kotlin: See https://github.com/nhaarman/mockito-kotlin/wiki/Parameter-specified-as-non-null-is-null
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"
     testImplementation "com.squareup.okhttp3:okhttp-tls:$okhttpVersion"
     testImplementation 'com.jayway.awaitility:awaitility:1.7.0'
     testImplementation 'org.robolectric:robolectric:4.4'
-    testImplementation 'androidx.test.espresso:espresso-intents:3.3.0'
+    testImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
@@ -152,6 +152,7 @@ public class ParameterBuilder private constructor(parameters: Map<String, String
             "http://auth0.com/oauth/grant-type/password-realm"
         public const val GRANT_TYPE_AUTHORIZATION_CODE: String = "authorization_code"
         public const val GRANT_TYPE_MFA_OTP: String = "http://auth0.com/oauth/grant-type/mfa-otp"
+        public const val GRANT_TYPE_MFA_OOB: String = "http://auth0.com/oauth/grant-type/mfa-oob"
         public const val GRANT_TYPE_PASSWORDLESS_OTP: String =
             "http://auth0.com/oauth/grant-type/passwordless/otp"
         public const val GRANT_TYPE_TOKEN_EXCHANGE: String =

--- a/auth0/src/main/java/com/auth0/android/result/Challenge.kt
+++ b/auth0/src/main/java/com/auth0/android/result/Challenge.kt
@@ -1,0 +1,20 @@
+package com.auth0.android.result
+
+import com.auth0.android.request.internal.JsonRequired
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Multi-factor authentication (MFA) challenge
+ *
+ * @see [com.auth0.android.authentication.AuthenticationAPIClient.multifactorChallenge]
+ */
+public class Challenge(
+    @field:JsonRequired @field:SerializedName("challenge_type")
+    public val challengeType: String,
+
+    @field:SerializedName("oob_code")
+    public val oobCode: String?,
+
+    @field:SerializedName("binding_method")
+    public val bindingMethod: String?
+)

--- a/auth0/src/test/java/com/auth0/android/util/AuthenticationAPIMockServer.kt
+++ b/auth0/src/test/java/com/auth0/android/util/AuthenticationAPIMockServer.kt
@@ -116,15 +116,13 @@ internal class AuthenticationAPIMockServer : APIMockServer() {
         return this
     }
 
-    private fun willReturnApplicationResponseWithBody(
-        body: String?,
-        statusCode: Int
-    ): AuthenticationAPIMockServer {
-        val response = MockResponse()
-            .setResponseCode(statusCode)
-            .addHeader("Content-Type", "application/x-javascript")
-            .setBody(body!!)
-        server.enqueue(response)
+    fun willReturnSuccessfulMFAChallenge(): AuthenticationAPIMockServer {
+        val json = """{
+          "challenge_type":"oob",
+          "binding_method":"prompt",
+          "oob_code": "abcdefg"
+        }"""
+        server.enqueue(responseWithJSON(json, 200))
         return this
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.31"
+    ext.kotlin_version = "1.5.10"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.21"
+    ext.kotlin_version = "1.4.31"
     repositories {
         google()
         mavenCentral()
+        //noinspection JcenterRepositoryObsolete
         jcenter() {
             content {
                 // https://youtrack.jetbrains.com/issue/KT-44730
@@ -12,7 +13,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -23,6 +24,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        //noinspection JcenterRepositoryObsolete
         jcenter() {
             content {
                 // https://youtrack.jetbrains.com/issue/KT-44730

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -47,13 +47,13 @@ android {
 dependencies {
     implementation project(':auth0')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.4'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.4'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }


### PR DESCRIPTION
### Changes

The SDK supports logging in using OTP MFA, without a prior challenge request if the OTP factor is known to be available. 

This PR:
- adds support for making a challenge request for the server to send the code via a specific authenticator (i.e. SMS, voice, push, etc) and 
- adds support for completing the authentication request using that received OOB code.
- updates the dependencies to the versions suggested by the IDE.

### References

Tracked internally: `SDK-2657`
- MFA challenge: https://auth0.com/docs/api/authentication#challenge-request
- OOB authentication: https://auth0.com/docs/api/authentication#verify-with-out-of-band-oob-

### Testing

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
