### PR TITLE
Add federated option to the Web Auth Logout [SDK-2165]

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
@@ -12,7 +12,8 @@ internal class LogoutManager(
     private val account: Auth0,
     private val callback: Callback<Void?, AuthenticationException>,
     returnToUrl: String,
-    ctOptions: CustomTabsOptions
+    ctOptions: CustomTabsOptions,
+    federated: Boolean = false
 ) : ResumableManager() {
     private val parameters: MutableMap<String, String>
     private val ctOptions: CustomTabsOptions
@@ -56,11 +57,16 @@ internal class LogoutManager(
         private const val KEY_CLIENT_ID = "client_id"
         private const val KEY_USER_AGENT = "auth0Client"
         private const val KEY_RETURN_TO_URL = "returnTo"
+        private const val KEY_FEDERATED = "federated"
     }
 
     init {
         parameters = HashMap()
         parameters[KEY_RETURN_TO_URL] = returnToUrl
+        if (federated) {
+            // null or empty values are not included in the request
+            parameters[KEY_FEDERATED] = "1"
+        }
         this.ctOptions = ctOptions
     }
 }

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -84,6 +84,7 @@ public object WebAuthProvider {
         private var scheme = "https"
         private var returnToUrl: String? = null
         private var ctOptions: CustomTabsOptions = CustomTabsOptions.newBuilder().build()
+        private var federated: Boolean = false
 
         /**
          * When using a Custom Tabs compatible Browser, apply these customization options.
@@ -128,6 +129,20 @@ public object WebAuthProvider {
         }
 
         /**
+         * Although not a common practice, you can force the user to log out of their identity provider.
+         * Think of the user experience before you use this parameter.
+         *
+         * This feature is not supported by every identity provider. Read more about the limitations in
+         * the [Log Users Out of Identity Provider](https://auth0.com/docs/logout/log-users-out-of-idps) article.
+         *
+         * @return the current builder instance
+         */
+        public fun withFederated(): LogoutBuilder {
+            this.federated = true
+            return this
+        }
+
+        /**
          * Request the user session to be cleared. When successful, the callback will get invoked.
          * An error is raised if there are no browser applications installed in the device or if
          * the user closed the browser before completing the logout.
@@ -154,7 +169,7 @@ public object WebAuthProvider {
                     account.getDomainUrl()
                 )
             }
-            val logoutManager = LogoutManager(account, callback, returnToUrl!!, ctOptions)
+            val logoutManager = LogoutManager(account, callback, returnToUrl!!, ctOptions, federated)
             managerInstance = logoutManager
             logoutManager.startLogout(context)
         }

--- a/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/LogoutManagerTest.java
@@ -38,7 +38,7 @@ public class LogoutManagerTest {
 
     @Test
     public void shouldCallOnFailureWhenResumedWithCanceledResult() {
-        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/android/my.app.name/callback", customTabsOptions);
+        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/android/my.app.name/callback", customTabsOptions, false);
         AuthorizeResult result = mock(AuthorizeResult.class);
         when(result.isCanceled()).thenReturn(true);
         manager.resume(result);
@@ -51,7 +51,7 @@ public class LogoutManagerTest {
 
     @Test
     public void shouldCallOnSuccessWhenResumedWithValidResult() {
-        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/android/my.app.name/callback", customTabsOptions);
+        LogoutManager manager = new LogoutManager(account, callback, "https://auth0.com/android/my.app.name/callback", customTabsOptions, false);
         AuthorizeResult result = mock(AuthorizeResult.class);
         when(result.isCanceled()).thenReturn(false);
         manager.resume(result);

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -2362,6 +2362,36 @@ public class WebAuthProviderTest {
         )
     }
 
+    // federated
+    @Test
+    public fun shouldNotUseFederatedByDefaultOnLogout() {
+        logout(account)
+            .start(activity, voidCallback)
+        verify(activity).startActivity(intentCaptor.capture())
+        val uri =
+            intentCaptor.firstValue.getParcelableExtra<Uri>(AuthenticationActivity.EXTRA_AUTHORIZE_URI)
+        assertThat(uri, `is`(notNullValue()))
+        assertThat(
+            uri,
+            not(UriMatchers.hasParamWithName("federated"))
+        )
+    }
+
+    @Test
+    public fun shouldUseFederatedOnLogout() {
+        logout(account)
+            .withFederated()
+            .start(activity, voidCallback)
+        verify(activity).startActivity(intentCaptor.capture())
+        val uri =
+            intentCaptor.firstValue.getParcelableExtra<Uri>(AuthenticationActivity.EXTRA_AUTHORIZE_URI)
+        assertThat(uri, `is`(notNullValue()))
+        assertThat(
+            uri,
+            UriMatchers.hasParamWithValue("federated", "1")
+        )
+    }
+
     // auth0 related
     @Test
     public fun shouldHaveTelemetryInfoOnLogout() {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -13,7 +13,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        manifestPlaceholders = [auth0Domain: "lbalmaceda.auth0.com", auth0Scheme: "https"]
+        manifestPlaceholders = [auth0Domain: "lbalmaceda.auth0.com", auth0Scheme: "demo"]
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
+++ b/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
@@ -21,7 +21,8 @@ import com.google.android.material.snackbar.Snackbar
 class DatabaseLoginFragment : Fragment() {
 
     private val account: Auth0 by lazy {
-        val account = Auth0("esCyeleWIb1iKJUcz6fVR4e29mEHkn0O", "lbalmaceda.auth0.com")
+        // -- REPLACE this credentials with your own Auth0 app credentials!
+        val account = Auth0("PX2vJhpALUNT66NHdCdD30XWqlIR4oEZ", "lbalmaceda.auth0.com")
         // Only enable network traffic logging on production environments!
         account.networkingClient = DefaultClient(enableLogging = true)
         account
@@ -43,6 +44,9 @@ class DatabaseLoginFragment : Fragment() {
         }
         binding.buttonWebAuth.setOnClickListener {
             webAuth()
+        }
+        binding.buttonWebLogout.setOnClickListener {
+            webLogout()
         }
         return binding.root
     }
@@ -68,11 +72,32 @@ class DatabaseLoginFragment : Fragment() {
 
     private fun webAuth() {
         WebAuthProvider.login(account)
+            .withScheme("demo")
             .start(requireContext(), object : Callback<Credentials, AuthenticationException> {
                 override fun onSuccess(result: Credentials) {
                     Snackbar.make(
                         requireView(),
                         "Success: ${result.accessToken}",
+                        Snackbar.LENGTH_LONG
+                    ).show()
+                }
+
+                override fun onFailure(error: AuthenticationException) {
+                    val message =
+                        if (error.isCanceled) "Browser was closed" else error.getDescription()
+                    Snackbar.make(requireView(), message, Snackbar.LENGTH_LONG).show()
+                }
+            })
+    }
+
+    private fun webLogout() {
+        WebAuthProvider.logout(account)
+            .withScheme("demo")
+            .start(requireContext(), object : Callback<Void?, AuthenticationException> {
+                override fun onSuccess(result: Void?) {
+                    Snackbar.make(
+                        requireView(),
+                        "Logged out",
                         Snackbar.LENGTH_LONG
                     ).show()
                 }

--- a/sample/src/main/res/layout/fragment_database_login.xml
+++ b/sample/src/main/res/layout/fragment_database_login.xml
@@ -45,7 +45,7 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="24dp"
         android:layout_marginEnd="16dp"
-        android:text="Log in using your email and password"
+        android:text="Authenticate with email and password"
         android:textSize="20sp"
         app:layout_constraintBottom_toTopOf="@+id/textEmail"
         app:layout_constraintEnd_toEndOf="parent"
@@ -57,7 +57,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="24dp"
-        android:text="Log in using Auth0's Universal Login "
+        android:text="Authenticate with Auth0's Universal Login"
         android:textSize="20sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -84,6 +84,16 @@
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="@+id/textView3"
         app:layout_constraintTop_toBottomOf="@+id/textView3" />
+
+    <Button
+        android:id="@+id/buttonWebLogout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Log out with Browser"
+        app:layout_constraintEnd_toEndOf="@+id/buttonWebAuth"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="@+id/textView3"
+        app:layout_constraintTop_toBottomOf="@+id/buttonWebAuth" />
 
     <TextView
         android:id="@+id/textView2"


### PR DESCRIPTION
### Changes

This is a valid parameter exposed by the Authentication API that was missing in this SDK. Support for this feature is up to the Universal Login page and the external identity providers.

### References

Internally: `SDK-2165`

- Read more https://auth0.com/docs/logout/log-users-out-of-idps


### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

I tested this signing in with my Google account on the device. The Google logout site seems to ignore the return to URL and instead takes you to the account selection screen. It does show that the account has been logged out, though.

https://user-images.githubusercontent.com/3900123/125913085-950d3bdd-5ed4-4d4f-a6e6-4b3d3fc5232c.mp4


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
