### PR TITLE
Fix bug parsing content type headers

### DIFF
--- a/auth0/src/main/java/com/auth0/android/request/ServerResponse.kt
+++ b/auth0/src/main/java/com/auth0/android/request/ServerResponse.kt
@@ -1,6 +1,7 @@
 package com.auth0.android.request
 
 import java.io.InputStream
+import java.util.*
 
 /**
  * Contains the information received from the server after executing a network request.
@@ -23,5 +24,8 @@ public data class ServerResponse(
      * Checks if the Content-Type headers declare the received media type as 'application/json'.
      * @return whether this response contains a JSON body or not.
      */
-    public fun isJson(): Boolean = headers["Content-Type"]?.contains("application/json") ?: false
+    public fun isJson(): Boolean =
+        headers.mapKeys { it.key.lowercase(Locale.getDefault()) }["content-type"]
+            ?.contains("application/json")
+            ?: false
 }

--- a/auth0/src/test/java/com/auth0/android/request/ServerResponseTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/ServerResponseTest.kt
@@ -1,0 +1,65 @@
+package com.auth0.android.request
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.mock
+import java.io.InputStream
+
+public class ServerResponseTest {
+
+    @Test
+    public fun shouldDetectSuccessfulResponse() {
+        val responseSuccess = ServerResponse(
+            200,
+            mock(InputStream::class.java),
+            emptyMap()
+        )
+        val responseNoContent = ServerResponse(
+            204,
+            mock(InputStream::class.java),
+            emptyMap()
+        )
+        assertTrue(responseSuccess.isSuccess())
+        assertTrue(responseNoContent.isSuccess())
+    }
+
+    @Test
+    public fun shouldDetectFailedResponse() {
+        val responseMultipleChoices = ServerResponse(
+            300,
+            mock(InputStream::class.java),
+            emptyMap()
+        )
+        val responseUnauthorized = ServerResponse(
+            401,
+            mock(InputStream::class.java),
+            emptyMap()
+        )
+        assertFalse(responseMultipleChoices.isSuccess())
+        assertFalse(responseUnauthorized.isSuccess())
+    }
+
+    @Test
+    public fun shouldDetectJsonContentHeader() {
+        val responseMixed = ServerResponse(
+            200,
+            mock(InputStream::class.java),
+            mapOf("Content-Type" to listOf("application/json"))
+        )
+        val responseLower = ServerResponse(
+            200,
+            mock(InputStream::class.java),
+            mapOf("content-type" to listOf("application/json"))
+        )
+        val responseUpper = ServerResponse(
+            200,
+            mock(InputStream::class.java),
+            mapOf("CONTENT-TYPE" to listOf("application/json"))
+        )
+
+        assertTrue(responseMixed.isJson())
+        assertTrue(responseLower.isJson())
+        assertTrue(responseUpper.isJson())
+    }
+}


### PR DESCRIPTION
### Changes
The function that was parsing the Content-Type header was not ignoring the case. This caused some endpoints to fail to be processed as JSON content. This PR fixes that by converting the keys to lowercase before making the "contains" assertion.

### References

See RFC, section 4.2: https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
