### PR TITLE
Fix MFA Challenge authentication and prevent sending the scope again

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -244,7 +244,8 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         challengeType: String? = null,
         authenticatorId: String? = null
     ): Request<Challenge, AuthenticationException> {
-        val parameters = ParameterBuilder.newAuthenticationBuilder()
+        val parameters = ParameterBuilder.newBuilder()
+            .setClientId(clientId)
             .set(MFA_TOKEN_KEY, mfaToken)
             .set(CHALLENGE_TYPE_KEY, challengeType)
             .set(AUTHENTICATOR_ID_KEY, authenticatorId)

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -119,7 +119,6 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     /**
      * Log in a user using the One Time Password code after they have received the 'mfa_required' error.
      * The MFA token tells the server the username or email, password, and realm values sent on the first request.
-     * The default scope used is 'openid profile email'.
      *
      * Requires your client to have the **MFA OTP** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
      *
@@ -139,7 +138,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @return a request to configure and start that will yield [Credentials]
      */
     public fun loginWithOTP(mfaToken: String, otp: String): AuthenticationRequest {
-        val parameters = ParameterBuilder.newAuthenticationBuilder()
+        val parameters = ParameterBuilder.newBuilder()
             .setGrantType(ParameterBuilder.GRANT_TYPE_MFA_OTP)
             .set(MFA_TOKEN_KEY, mfaToken)
             .set(ONE_TIME_PASSWORD_KEY, otp)
@@ -150,7 +149,6 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     /**
      * Log in a user using an Out Of Band authentication code after they have received the 'mfa_required' error.
      * The MFA token tells the server the username or email, password, and realm values sent on the first request.
-     * The default scope used is 'openid profile email'.
      *
      * Requires your client to have the **MFA OOB** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
      *
@@ -175,7 +173,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         oobCode: String,
         bindingCode: String? = null
     ): AuthenticationRequest {
-        val parameters = ParameterBuilder.newAuthenticationBuilder()
+        val parameters = ParameterBuilder.newBuilder()
             .setGrantType(ParameterBuilder.GRANT_TYPE_MFA_OOB)
             .set(MFA_TOKEN_KEY, mfaToken)
             .set(OUT_OF_BAND_CODE_KEY, oobCode)
@@ -187,7 +185,6 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     /**
      * Log in a user using a multi-factor authentication Recovery Code after they have received the 'mfa_required' error.
      * The MFA token tells the server the username or email, password, and realm values sent on the first request.
-     * The default scope used is 'openid profile email'.
      *
      * Requires your client to have the **MFA** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
      *
@@ -210,7 +207,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         mfaToken: String,
         recoveryCode: String
     ): AuthenticationRequest {
-        val parameters = ParameterBuilder.newAuthenticationBuilder()
+        val parameters = ParameterBuilder.newBuilder()
             .setGrantType(ParameterBuilder.GRANT_TYPE_MFA_RECOVERY_CODE)
             .set(MFA_TOKEN_KEY, mfaToken)
             .set(RECOVERY_CODE_KEY, recoveryCode)

--- a/auth0/src/main/java/com/auth0/android/request/ServerResponse.kt
+++ b/auth0/src/main/java/com/auth0/android/request/ServerResponse.kt
@@ -24,8 +24,11 @@ public data class ServerResponse(
      * Checks if the Content-Type headers declare the received media type as 'application/json'.
      * @return whether this response contains a JSON body or not.
      */
-    public fun isJson(): Boolean =
+    public fun isJson(): Boolean {
         headers.mapKeys { it.key.lowercase(Locale.getDefault()) }["content-type"]
-            ?.contains("application/json")
-            ?: false
+            ?.forEach {
+                if (it.contains("application/json", ignoreCase = true)) return true
+            }
+        return false
+    }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -287,6 +287,7 @@ public class AuthenticationAPIClientTest {
         assertThat(request.path, Matchers.equalTo("/mfa/challenge"))
         val body = bodyFromRequest<Any>(request)
         assertThat(body, Matchers.hasEntry("mfa_token", "ey30.the-mfa-token.value"))
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
         assertThat(body, Matchers.not(Matchers.hasKey("challenge_type")))
         assertThat(body, Matchers.not(Matchers.hasKey("authenticator_id")))
         assertThat(

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -166,7 +166,7 @@ public class AuthenticationAPIClientTest {
         )
         assertThat(body, Matchers.hasEntry("mfa_token", "ey30.the-mfa-token.value"))
         assertThat(body, Matchers.hasEntry("otp", "123456"))
-        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
+        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
         assertThat(body, Matchers.not(Matchers.hasKey("username")))
         assertThat(body, Matchers.not(Matchers.hasKey("password")))
         assertThat(body, Matchers.not(Matchers.hasKey("connection")))
@@ -202,7 +202,7 @@ public class AuthenticationAPIClientTest {
         )
         assertThat(body, Matchers.hasEntry("mfa_token", "ey30.the-mfa-token.value"))
         assertThat(body, Matchers.hasEntry("recovery_code", "123456"))
-        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
+        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
     }
 
     @Test
@@ -234,7 +234,7 @@ public class AuthenticationAPIClientTest {
         )
         assertThat(body, Matchers.hasEntry("mfa_token", "ey30.the-mfa-token.value"))
         assertThat(body, Matchers.hasEntry("oob_code", "123456"))
-        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
+        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
         assertThat(body, Matchers.not(Matchers.hasKey("binding_code")))
     }
 
@@ -267,8 +267,8 @@ public class AuthenticationAPIClientTest {
         )
         assertThat(body, Matchers.hasEntry("mfa_token", "ey30.the-mfa-token.value"))
         assertThat(body, Matchers.hasEntry("oob_code", "123456"))
-        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(body, Matchers.hasEntry("binding_code", "abcdefg"))
+        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
     }
 
     @Test
@@ -290,6 +290,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
         assertThat(body, Matchers.not(Matchers.hasKey("challenge_type")))
         assertThat(body, Matchers.not(Matchers.hasKey("authenticator_id")))
+        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
         assertThat(
             callback, AuthenticationCallbackMatcher.hasPayloadOfType(
                 Challenge::class.java
@@ -313,8 +314,10 @@ public class AuthenticationAPIClientTest {
         assertThat(request.path, Matchers.equalTo("/mfa/challenge"))
         val body = bodyFromRequest<Any>(request)
         assertThat(body, Matchers.hasEntry("mfa_token", "ey30.the-mfa-token.value"))
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
         assertThat(body, Matchers.hasEntry("challenge_type", "oob"))
         assertThat(body, Matchers.hasEntry("authenticator_id", "sms|dev_NU1Ofuw3Cw0XCt5x"))
+        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
         assertThat(
             callback, AuthenticationCallbackMatcher.hasPayloadOfType(
                 Challenge::class.java

--- a/auth0/src/test/java/com/auth0/android/request/ServerResponseTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/ServerResponseTest.kt
@@ -67,11 +67,17 @@ public class ServerResponseTest {
             mock(InputStream::class.java),
             mapOf("CONTENT-TYPE" to listOf("text/html"))
         )
+        val responseEmpty = ServerResponse(
+            200,
+            mock(InputStream::class.java),
+            mapOf()
+        )
 
         assertTrue(responseMixed.isJson())
         assertTrue(responseMixedCombined.isJson())
         assertTrue(responseLower.isJson())
         assertTrue(responseUpper.isJson())
         assertFalse(responseNotJSON.isJson())
+        assertFalse(responseEmpty.isJson())
     }
 }

--- a/auth0/src/test/java/com/auth0/android/request/ServerResponseTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/ServerResponseTest.kt
@@ -47,6 +47,11 @@ public class ServerResponseTest {
             mock(InputStream::class.java),
             mapOf("Content-Type" to listOf("application/json"))
         )
+        val responseMixedCombined = ServerResponse(
+            200,
+            mock(InputStream::class.java),
+            mapOf("Content-Type" to listOf("application/json; charset=UTF-8"))
+        )
         val responseLower = ServerResponse(
             200,
             mock(InputStream::class.java),
@@ -57,9 +62,16 @@ public class ServerResponseTest {
             mock(InputStream::class.java),
             mapOf("CONTENT-TYPE" to listOf("application/json"))
         )
+        val responseNotJSON = ServerResponse(
+            200,
+            mock(InputStream::class.java),
+            mapOf("CONTENT-TYPE" to listOf("text/html"))
+        )
 
         assertTrue(responseMixed.isJson())
+        assertTrue(responseMixedCombined.isJson())
         assertTrue(responseLower.isJson())
         assertTrue(responseUpper.isJson())
+        assertFalse(responseNotJSON.isJson())
     }
 }


### PR DESCRIPTION
### Changes

The "MFA verify" endpoints where sending the `scope` key, when the transaction is already registering it from the previous "login" attempt into the `mfa_token` value. These properties have been removed, as endpoints such as `/mfa/challenge` explicitly reject requests that contain it.

A bug is also fixed where the `/mfa/challenge` was not being authenticated with the `client_id` value. 

Finally, a few additional test cases for the previous content-type header PR were added. The implementation for this didn't change.

### References

See #503 and #500 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
