### PR TITLE
Prevent NPE when parsing email_verified boolean

### DIFF
--- a/auth0/src/main/java/com/auth0/android/request/internal/UserProfileDeserializer.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/UserProfileDeserializer.java
@@ -30,7 +30,7 @@ class UserProfileDeserializer implements JsonDeserializer<UserProfile> {
         final String email = context.deserialize(object.remove("email"), String.class);
         final String givenName = context.deserialize(object.remove("given_name"), String.class);
         final String familyName = context.deserialize(object.remove("family_name"), String.class);
-        final boolean emailVerified = object.has("email_verified") ? context.<Boolean>deserialize(object.remove("email_verified"), Boolean.class) : false;
+        final Boolean emailVerified = object.has("email_verified") ? context.<Boolean>deserialize(object.remove("email_verified"), Boolean.class) : false;
         final Date createdAt = context.deserialize(object.remove("created_at"), Date.class);
 
         final Type identitiesType = new TypeToken<List<UserIdentity>>() {}.getType();

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
@@ -304,8 +304,8 @@ public class AuthenticationExceptionTest {
     @Throws(Exception::class)
     public fun shouldHaveNotStrongPasswordWithDetailedDescription() {
         val fr = FileReader(PASSWORD_STRENGTH_ERROR_RESPONSE)
-        val mapType = object : TypeToken<Map<String?, Any?>?>() {}.type
-        val mapPayload = GsonProvider.gson.fromJson<Map<String, Any>>(fr, mapType)
+        val mapType = object : TypeToken<Map<String, Any>>() {}
+        val mapPayload: Map<String, Any> = GsonProvider.gson.getAdapter(mapType).fromJson(fr)
         val ex = AuthenticationException(mapPayload)
         MatcherAssert.assertThat(ex.isPasswordNotStrongEnough, CoreMatchers.`is`(true))
         val expectedDescription =

--- a/auth0/src/test/java/com/auth0/android/request/internal/UserProfileGsonTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/internal/UserProfileGsonTest.kt
@@ -40,6 +40,17 @@ public class UserProfileGsonTest : GsonBaseTest() {
 
     @Test
     @Throws(Exception::class)
+    public fun shouldHandleNullBooleans() {
+        val userProfile = pojoFrom(
+            StringReader(
+                """{"email_verified": null}"""
+            ), UserProfile::class.java
+        )
+        assertThat(userProfile, `is`(notNullValue()))
+    }
+
+    @Test
+    @Throws(Exception::class)
     public fun shouldNotRequireUserId() {
         val userProfile = pojoFrom(
             StringReader(


### PR DESCRIPTION
### Changes

Small change preventing an NPE to be raised when the key is present in the user profile JSON but its value is explicitly null. 

Also, replaced the usage of `fromJson(type, input)` in a test case with the preferred adapter access. Non-customized adapters can handle null/empty string inputs and fail appropriately.

### References
Resolves https://github.com/auth0/Auth0.Android/issues/509