### PR TITLE
Fix memory leak in CustomTabsService

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -31,7 +31,7 @@ class CustomTabsController extends CustomTabsServiceConnection {
 
     @NonNull
     private final CustomTabsOptions customTabsOptions;
-    private boolean isBound;
+    private boolean didTryToBind;
 
     @VisibleForTesting
     CustomTabsController(@NonNull Context context, @NonNull CustomTabsOptions options) {
@@ -67,11 +67,13 @@ class CustomTabsController extends CustomTabsServiceConnection {
     public void bindService() {
         Log.v(TAG, "Trying to bind the service");
         Context context = this.context.get();
-        isBound = false;
+        didTryToBind = false;
+        boolean wasBound = false;
         if (context != null && preferredPackage != null) {
-            isBound = CustomTabsClient.bindCustomTabsService(context, preferredPackage, this);
+            didTryToBind = true;
+            wasBound = CustomTabsClient.bindCustomTabsService(context, preferredPackage, this);
         }
-        Log.v(TAG, "Bind request result: " + isBound);
+        Log.v(TAG, String.format("Bind request result (%s): %s", preferredPackage, wasBound));
     }
 
     /**
@@ -80,9 +82,9 @@ class CustomTabsController extends CustomTabsServiceConnection {
     public void unbindService() {
         Log.v(TAG, "Trying to unbind the service");
         Context context = this.context.get();
-        if (isBound && context != null) {
+        if (didTryToBind && context != null) {
             context.unbindService(this);
-            isBound = false;
+            didTryToBind = false;
         }
     }
 

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -93,12 +93,12 @@ public class CustomTabsControllerTest {
     }
 
     @Test
-    public void shouldNotUnbindIfNotBound() throws Exception {
+    public void shouldUnbindEvenIfNotBound() throws Exception {
         bindService(controller, false);
         connectBoundService();
 
         controller.unbindService();
-        verify(context, never()).unbindService(any(ServiceConnection.class));
+        verify(context).unbindService(any(ServiceConnection.class));
     }
 
     @Test


### PR DESCRIPTION
### Description
The service was only receiving the call to "unbind" if it was successfully bound in the past. This PR changes that, so that it will now unbind it whenever an attempt to bind it was made previously. 

I'm keeping track of that with a new boolean flag -> `didTryToBind`.

### References
Fixes https://github.com/auth0/Auth0.Android/issues/461

#### Before

As seen in the video, the existing error does not have any impact on the authentication process. This is a memory leak that the OS logs to the logcat.

https://user-images.githubusercontent.com/3900123/135082729-ef0c5e5d-86c5-4b9d-bf9b-b6f127365e43.mp4


#### After

Error is gone.

https://user-images.githubusercontent.com/3900123/135082767-c9eb50ae-6f39-43d4-a90b-c7980567824f.mp4


