### PR TITLE
Improve authenticated flow of the Credentials Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ val manager = SecureCredentialsManager(this, authentication, storage)
 
 You can require the user authentication to obtain credentials. This will make the manager prompt the user with the device's configured Lock Screen, which they must pass correctly in order to obtain the credentials. **This feature is only available on devices where the user has setup a secured Lock Screen** (PIN, Pattern, Password or Fingerprint).
 
-To enable authentication you must call the `requireAuthentication` method passing a valid _Activity_ context, a request code that represents the authentication call, and the title and description to display in the Lock Screen. As seen in the snippet below, you can leave these last two parameters with `null` to use the system default resources.
+To enable authentication you must call the `requireAuthentication` method passing a valid _Activity_ context, a request code that represents the authentication call, and the title and description to display in the Lock Screen. As seen in the snippet below, you can leave these last two parameters with `null` to use the system's default title and description. It's only safe to call this method before the Activity is started. 
 
 ```kotlin
 //You might want to define a constant with the Request Code
@@ -667,7 +667,7 @@ companion object {
 manager.requireAuthentication(this, AUTH_REQ_CODE, null, null)
 ```
 
-When the above conditions are met and the manager requires the user authentication, it will use the activity context to launch a new activity and wait for its result in the `onActivityResult` method. Your activity must override this method and pass the request code and result code to the manager's `checkAuthenticationResult` method to verify if this request was successful or not.
+When the above conditions are met and the manager requires the user authentication, it will use the activity context to launch the Lock Screen activity and wait for its result. If your activity is a subclass of `ComponentActivity`, this will be handled automatically for you internally. Otherwise, your activity must override the `onActivityResult` method and pass the request code and result code to the manager's `checkAuthenticationResult` method to verify if this request was successful or not.
 
 ```kotlin
  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -120,6 +120,6 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"
     testImplementation "com.squareup.okhttp3:okhttp-tls:$okhttpVersion"
     testImplementation 'com.jayway.awaitility:awaitility:1.7.0'
-    testImplementation 'org.robolectric:robolectric:4.4'
+    testImplementation 'org.robolectric:robolectric:4.6.1'
     testImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -90,26 +90,23 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     ): Boolean {
         require(!(requestCode < 1 || requestCode > 255)) { "Request code must be a value between 1 and 255." }
         val kManager = activity.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
-        authIntent =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) kManager.createConfirmDeviceCredentialIntent(
-                title,
-                description
-            ) else null
+        authIntent = kManager.createConfirmDeviceCredentialIntent(title, description)
         authenticateBeforeDecrypt =
-            ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && kManager.isDeviceSecure
-                    || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && kManager.isKeyguardSecure)
+            ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && kManager.isDeviceSecure || kManager.isKeyguardSecure)
                     && authIntent != null)
         if (authenticateBeforeDecrypt) {
             authenticationRequestCode = requestCode
 
             /*
+             *  https://developer.android.com/training/basics/intents/result#register
              *  Docs say it's safe to call "registerForActivityResult" BEFORE the activity is created. In practice,
              *  when that's not the case, a RuntimeException is thrown. The lifecycle state check below is meant to
              *  prevent that exception while still falling back to the old "startActivityForResult" flow. That's in
              *  case devs are invoking this method in places other than the Activity's "OnCreate" method.
              */
-            if (activity is ComponentActivity &&
-                !activity.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+            if (activity is ComponentActivity && !activity.lifecycle.currentState.isAtLeast(
+                    Lifecycle.State.STARTED
+                )
             ) {
                 activityResultContract =
                     activity.registerForActivityResult(


### PR DESCRIPTION
### Changes
The `requireAuthentication` method takes an `Activity` instance to use as context to launch the "lock screen" intent. When this is a subclass of `ComponentActivity`, we can make use of the new [Activity Results API](https://developer.android.com/training/basics/intents/result) to launch that intent instead. This is the recommended way now that `startActivityForResult` has been deprecated.

When that's the case, the launch and result handling happen internally without the developer having to invoke the `checkAuthenticationResult` method to "complete" the flow.

This PR does NOT include breaking changes.

### References

See https://github.com/auth0/Auth0.Android/issues/513

### Testing

Added unit tests and manually tested the new flow.

Existing implementations would still receive a call to their activities' `onActivityResult` method, but with a request code value different than the one requested by our SDK, passed by the dev in the `requireAuthentication` call. Developers should ignore it because the request code is not a match. Yet, we were already handling this case internally and checking for the request code [in these lines](https://github.com/auth0/Auth0.Android/blob/main/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt#L113-L115) anyway, so distracted developers are covered. 

I did notice that if the `requireAuthentication` method was called after the activity is resumed/started, then the following runtime exception is raised:

```
Caused by: java.lang.IllegalStateException: LifecycleOwner com.auth0.androidsample.LoginActivity@494936b is attempting to register while current state is STARTED. LifecycleOwners must call register before they are STARTED.
```

So I added a check (and tests) to prevent using this use case with Activity Results if the activity passed as context is already started.
