### PR TITLE
Update Configuration URL (CDN URL) [SDK-2710]

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.kt
+++ b/auth0/src/main/java/com/auth0/android/Auth0.kt
@@ -1,12 +1,10 @@
 package com.auth0.android
 
 import android.content.Context
-import androidx.annotation.VisibleForTesting
 import com.auth0.android.request.DefaultClient
 import com.auth0.android.request.NetworkingClient
 import com.auth0.android.util.Auth0UserAgent
 import okhttp3.HttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.util.*
 
@@ -93,30 +91,11 @@ public open class Auth0 @JvmOverloads constructor(
             .build()
             .toString()
 
-
-    private fun resolveConfiguration(configurationDomain: String?, domainUrl: HttpUrl): HttpUrl {
-        var url = ensureValidUrl(configurationDomain)
-        if (url == null) {
-            val host = domainUrl.host
-            url = if (host.endsWith(DOT_AUTH0_DOT_COM)) {
-                val parts = host.split(".").toTypedArray()
-                if (parts.size > 3) {
-                    ("https://cdn." + parts[parts.size - 3] + DOT_AUTH0_DOT_COM).toHttpUrl()
-                } else {
-                    AUTH0_US_CDN_URL.toHttpUrl()
-                }
-            } else {
-                domainUrl
-            }
-        }
-        return url
-    }
-
     private fun ensureValidUrl(url: String?): HttpUrl? {
         if (url == null) {
             return null
         }
-        val normalizedUrl = url.toLowerCase(Locale.ROOT)
+        val normalizedUrl = url.lowercase(Locale.ROOT)
         require(!normalizedUrl.startsWith("http://")) { "Invalid domain url: '$url'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used." }
         val safeUrl =
             if (normalizedUrl.startsWith("https://")) normalizedUrl else "https://$normalizedUrl"
@@ -124,8 +103,6 @@ public open class Auth0 @JvmOverloads constructor(
     }
 
     private companion object {
-        private const val AUTH0_US_CDN_URL = "https://cdn.auth0.com"
-        private const val DOT_AUTH0_DOT_COM = ".auth0.com"
         private fun getResourceFromContext(context: Context, resName: String): String {
             val stringRes = context.resources.getIdentifier(resName, "string", context.packageName)
             require(stringRes != 0) {
@@ -141,7 +118,7 @@ public open class Auth0 @JvmOverloads constructor(
     init {
         domainUrl = ensureValidUrl(domain)
         requireNotNull(domainUrl) { String.format("Invalid domain url: '%s'", domain) }
-        configurationUrl = resolveConfiguration(configurationDomain, domainUrl)
+        configurationUrl = ensureValidUrl(configurationDomain) ?: domainUrl
         auth0UserAgent = Auth0UserAgent()
     }
 }

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -63,7 +63,7 @@ public class Auth0Test {
         assertThat(auth0, notNullValue());
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
         assertThat(auth0.getDomainUrl(), equalTo("https://samples.auth0.com/"));
-        assertThat(auth0.getConfigurationUrl(), equalTo("https://cdn.auth0.com/"));
+        assertThat(auth0.getConfigurationUrl(), equalTo("https://samples.auth0.com/"));
     }
 
     @Test
@@ -95,7 +95,7 @@ public class Auth0Test {
         Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN);
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
         assertThat(HttpUrl.parse(auth0.getDomainUrl()), equalTo(HttpUrl.parse("https://samples.auth0.com")));
-        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://cdn.auth0.com")));
+        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://samples.auth0.com")));
     }
 
     @Test
@@ -111,7 +111,7 @@ public class Auth0Test {
         Auth0 auth0 = new Auth0(CLIENT_ID, EU_DOMAIN);
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
         assertThat(HttpUrl.parse(auth0.getDomainUrl()), equalTo(HttpUrl.parse("https://samples.eu.auth0.com")));
-        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://cdn.eu.auth0.com")));
+        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://samples.eu.auth0.com")));
     }
 
     @Test
@@ -119,7 +119,7 @@ public class Auth0Test {
         Auth0 auth0 = new Auth0(CLIENT_ID, AU_DOMAIN);
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
         assertThat(HttpUrl.parse(auth0.getDomainUrl()), equalTo(HttpUrl.parse("https://samples.au.auth0.com")));
-        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://cdn.au.auth0.com")));
+        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://samples.au.auth0.com")));
     }
 
     @Test
@@ -127,7 +127,7 @@ public class Auth0Test {
         Auth0 auth0 = new Auth0(CLIENT_ID, OTHER_DOMAIN);
         assertThat(auth0.getClientId(), equalTo(CLIENT_ID));
         assertThat(HttpUrl.parse(auth0.getDomainUrl()), equalTo(HttpUrl.parse("https://samples-test.other-subdomain.other.auth0.com")));
-        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://cdn.other.auth0.com")));
+        assertThat(HttpUrl.parse(auth0.getConfigurationUrl()), equalTo(HttpUrl.parse("https://samples-test.other-subdomain.other.auth0.com")));
     }
 
     @Test


### PR DESCRIPTION
### Changes

This change updates the default CDN URL. **This is NOT a breaking change.** 

Previously was `https://cdn.[locality.]auth0.com`, now is `https://{tenant}.[locality.]auth0.com`. 
Developers passing a "configuration URL" explicitly will still make use of that given value.


### References

See SDK-2710