### PR TITLE
Added isRefreshTokenDeleted to AuthenticationException

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
@@ -174,6 +174,12 @@ public class AuthenticationException : Auth0Exception {
     /// When authenticating with web-based authentication using prompt=none and the auth0 session had expired
     public val isLoginRequired: Boolean
         get() = "login_required" == code
+    
+    /// User is deleted
+    public val isRefreshTokenDeleted: Boolean
+        get() = "invalid_grant" == code
+                && 403 == statusCode
+                && "The refresh_token was generated for a user who doesn't exist anymore." == description
 
     internal companion object {
         internal const val ERROR_VALUE_AUTHENTICATION_CANCELED = "a0.authentication_canceled"

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
@@ -453,6 +453,15 @@ public class AuthenticationExceptionTest {
         MatcherAssert.assertThat(ex.isPKCENotAvailable, CoreMatchers.`is`(true))
     }
 
+    @Test
+    public fun shouldHaveRefreshTokenDeleted() {
+        values[ERROR_KEY] = "invalid_grant"
+        values[ERROR_DESCRIPTION_KEY] =
+            "The refresh_token was generated for a user who doesn't exist anymore."
+        val ex = AuthenticationException(values, 403)
+        MatcherAssert.assertThat(ex.isRefreshTokenDeleted, CoreMatchers.`is`(true))
+    }
+
     private companion object {
         private const val PASSWORD_STRENGTH_ERROR_RESPONSE =
             "src/test/resources/password_strength_error.json"


### PR DESCRIPTION
### Changes

Added boolean for when user is deleted via dashboard. This makes it easier for apps using the SDK to handle this scenario.

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
