### PR TITLE
Bump GSON dependency to 2.8.9

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.3.0'
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.8.9'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'


### PR DESCRIPTION
This change bumps [the GSON dependency to 2.8.9](https://github.com/google/gson/releases/tag/gson-parent-2.8.9) to resolve a potential vulnerability in earlier versions of the library reported: https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327