### PR TITLE
Add Intent.FLAG_ACTIVITY_NEW_TASK flag for AuthenticationActivity

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.kt
@@ -99,6 +99,7 @@ public open class AuthenticationActivity : Activity() {
             intent.putExtra(EXTRA_AUTHORIZE_URI, authorizeUri)
             intent.putExtra(EXTRA_CT_OPTIONS, options)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             context.startActivity(intent)
         }
     }


### PR DESCRIPTION
### Changes

Add `Intent.FLAG_ACTIVITY_NEW_TASK` flag to intent for opening `AuthenticationActivity`. With this flag it is possible to open the login flow with an application context.
In current solution you can pass a context parameter but it needs to be an activity so maybe it's a bit misleading today. 

Using DI framework this would be really nice to be able to use application context. 

Another potential change would be to expose parameters so intent flags could be added depending on use case.

### References

Info about the flag.
https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_NEW_TASK

### Testing

I have done successful manual testing in our app where we're using the web login flow.

Could not find any Junit test that needed to change or be added.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
