### PR TITLE
Implement Thread Safe Credential Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,9 +601,7 @@ authentication
             manager.saveCredentials(credentials)
         }
     })
-```
-
-**Note:** This method is not thread-safe. Attempting to save credentials multiple times in a short period or from different threads can cause issues like invalidating valid stored tokens.  
+``` 
 
 3. **Check credentials existence:**
 There are cases were you just want to check if a user session is still valid (i.e. to know if you should present the login screen or the main screen). For convenience, we include a `hasValidCredentials` method that can let you know in advance if a non-expired token is available without making an additional network call. The same rules of the `getCredentials` method apply:
@@ -625,9 +623,7 @@ manager.getCredentials(object : Callback<Credentials, CredentialsManagerExceptio
        // Use the credentials
    }
 })
-```
-
-**Note:** This method is not thread-safe. In the scenario where the stored credentials have expired and a `refresh_token` is available, the newly obtained tokens are automatically saved for you by the Credentials Manager. If you're using _Refresh Token Rotation_ you should avoid calling this method concurrently as it might result in more than one renew request being fired, and only the first one succeeding. 
+``` 
 
 
 5. **Clear credentials:**

--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ authentication
         }
     })
 ``` 
+**Note:** This method has been made thread-safe after version 2.7.0.
 
 3. **Check credentials existence:**
 There are cases were you just want to check if a user session is still valid (i.e. to know if you should present the login screen or the main screen). For convenience, we include a `hasValidCredentials` method that can let you know in advance if a non-expired token is available without making an additional network call. The same rules of the `getCredentials` method apply:
@@ -624,7 +625,7 @@ manager.getCredentials(object : Callback<Credentials, CredentialsManagerExceptio
    }
 })
 ``` 
-
+**Note:** In the scenario where the stored credentials have expired and a `refresh_token` is available, the newly obtained tokens are automatically saved for you by the Credentials Manager. This method has been made thread-safe after version 2.7.0.
 
 5. **Clear credentials:**
 When you want to log the user out:

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -6,16 +6,21 @@ import com.auth0.android.callback.Callback
 import com.auth0.android.result.Credentials
 import com.auth0.android.util.Clock
 import java.util.*
+import java.util.concurrent.Executor
 import kotlin.math.min
 
 /**
  * Base class meant to abstract common logic across Credentials Manager implementations.
  * The scope of this class is package-private, as it's not meant to be exposed
+ * @param serialExecutor - [Executor] used to ensure the requests made for [CredentialsManager] and
+ * [SecureCredentialsManager] are executed synchronously to avoid racing conditions. Current usage
+ * is only around the [getCredentials] method but it can be used in future for others.
  */
 public abstract class BaseCredentialsManager internal constructor(
     protected val authenticationClient: AuthenticationAPIClient,
     protected val storage: Storage,
-    private val jwtDecoder: JWTDecoder
+    private val jwtDecoder: JWTDecoder,
+    protected val serialExecutor: Executor
 ) {
     private var _clock: Clock = ClockImpl()
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -21,8 +21,6 @@ public abstract class BaseCredentialsManager internal constructor(
 ) {
     private var _clock: Clock = ClockImpl()
 
-    protected var serialExecutor: Executor = Executors.newSingleThreadExecutor()
-
     /**
      * Updates the clock instance used for expiration verification purposes.
      * The use of this method can help on situations where the clock comes from an external synced source.
@@ -30,15 +28,6 @@ public abstract class BaseCredentialsManager internal constructor(
      */
     public fun setClock(clock: Clock) {
         this._clock = clock
-    }
-
-    /**
-     * @param executor - [Executor] used to ensure the requests made for [CredentialsManager] and
-     * [SecureCredentialsManager] are executed synchronously to avoid racing conditions. Current usage
-     * is only around the [getCredentials] method but it can be used in future for others.
-     */
-    public fun setExecutor(executor: Executor) {
-        this.serialExecutor = executor
     }
 
     @Throws(CredentialsManagerException::class)

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -7,22 +7,21 @@ import com.auth0.android.result.Credentials
 import com.auth0.android.util.Clock
 import java.util.*
 import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 import kotlin.math.min
 
 /**
  * Base class meant to abstract common logic across Credentials Manager implementations.
  * The scope of this class is package-private, as it's not meant to be exposed
- * @param serialExecutor - [Executor] used to ensure the requests made for [CredentialsManager] and
- * [SecureCredentialsManager] are executed synchronously to avoid racing conditions. Current usage
- * is only around the [getCredentials] method but it can be used in future for others.
  */
 public abstract class BaseCredentialsManager internal constructor(
     protected val authenticationClient: AuthenticationAPIClient,
     protected val storage: Storage,
-    private val jwtDecoder: JWTDecoder,
-    protected val serialExecutor: Executor
+    private val jwtDecoder: JWTDecoder
 ) {
     private var _clock: Clock = ClockImpl()
+
+    protected var serialExecutor: Executor = Executors.newSingleThreadExecutor()
 
     /**
      * Updates the clock instance used for expiration verification purposes.
@@ -31,6 +30,15 @@ public abstract class BaseCredentialsManager internal constructor(
      */
     public fun setClock(clock: Clock) {
         this._clock = clock
+    }
+
+    /**
+     * @param executor - [Executor] used to ensure the requests made for [CredentialsManager] and
+     * [SecureCredentialsManager] are executed synchronously to avoid racing conditions. Current usage
+     * is only around the [getCredentials] method but it can be used in future for others.
+     */
+    public fun setExecutor(executor: Executor) {
+        this.serialExecutor = executor
     }
 
     @Throws(CredentialsManagerException::class)

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -16,9 +16,8 @@ import java.util.concurrent.Executors
 public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) internal constructor(
     authenticationClient: AuthenticationAPIClient,
     storage: Storage,
-    jwtDecoder: JWTDecoder,
-    serialExecutor: Executor
-) : BaseCredentialsManager(authenticationClient, storage, jwtDecoder, serialExecutor) {
+    jwtDecoder: JWTDecoder
+) : BaseCredentialsManager(authenticationClient, storage, jwtDecoder) {
     /**
      * Creates a new instance of the manager that will store the credentials in the given Storage.
      *
@@ -28,8 +27,7 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
     public constructor(authenticationClient: AuthenticationAPIClient, storage: Storage) : this(
         authenticationClient,
         storage,
-        JWTDecoder(),
-        Executors.newSingleThreadExecutor()
+        JWTDecoder()
     )
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -16,7 +16,8 @@ import java.util.concurrent.Executors
 public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) internal constructor(
     authenticationClient: AuthenticationAPIClient,
     storage: Storage,
-    jwtDecoder: JWTDecoder
+    jwtDecoder: JWTDecoder,
+    private val serialExecutor: Executor
 ) : BaseCredentialsManager(authenticationClient, storage, jwtDecoder) {
     /**
      * Creates a new instance of the manager that will store the credentials in the given Storage.
@@ -27,7 +28,8 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
     public constructor(authenticationClient: AuthenticationAPIClient, storage: Storage) : this(
         authenticationClient,
         storage,
-        JWTDecoder()
+        JWTDecoder(),
+        Executors.newSingleThreadExecutor()
     )
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -35,8 +35,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     storage: Storage,
     private val crypto: CryptoUtil,
     jwtDecoder: JWTDecoder,
-    serialExecutor: Executor
-) : BaseCredentialsManager(apiClient, storage, jwtDecoder, serialExecutor) {
+) : BaseCredentialsManager(apiClient, storage, jwtDecoder) {
     private val gson: Gson = GsonProvider.gson
 
     //Changeable by the user
@@ -66,8 +65,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         apiClient,
         storage,
         CryptoUtil(context, storage, KEY_ALIAS),
-        JWTDecoder(),
-        Executors.newSingleThreadExecutor()
+        JWTDecoder()
     )
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -35,6 +35,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     storage: Storage,
     private val crypto: CryptoUtil,
     jwtDecoder: JWTDecoder,
+    private val serialExecutor: Executor
 ) : BaseCredentialsManager(apiClient, storage, jwtDecoder) {
     private val gson: Gson = GsonProvider.gson
 
@@ -65,7 +66,8 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         apiClient,
         storage,
         CryptoUtil(context, storage, KEY_ALIAS),
-        JWTDecoder()
+        JWTDecoder(),
+        Executors.newSingleThreadExecutor()
     )
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -346,7 +346,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                 callback.onFailure(
                     CredentialsManagerException(
                         "A change on the Lock Screen security settings have deemed the encryption keys invalid and have been recreated. " +
-                                "Any previously stored content is now lost. Please, try saving the credentials again.",
+                                "Any previously stored content is now lost. Please try saving the credentials again.",
                         e
                     )
                 )

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -190,7 +190,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
              */
             clearCredentials()
             throw CredentialsManagerException(
-                "A change on the Lock Screen security settings have deemed the encryption keys invalid and have been recreated. Please, try saving the credentials again.",
+                "A change on the Lock Screen security settings have deemed the encryption keys invalid and have been recreated. Please try saving the credentials again.",
                 e
             )
         }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -23,6 +23,8 @@ import com.auth0.android.result.Credentials
 import com.auth0.android.result.OptionalCredentials
 import com.google.gson.Gson
 import java.util.*
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 
 /**
  * A safer alternative to the [CredentialsManager] class. A combination of RSA and AES keys is used to keep the values secure.
@@ -32,8 +34,9 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     apiClient: AuthenticationAPIClient,
     storage: Storage,
     private val crypto: CryptoUtil,
-    jwtDecoder: JWTDecoder
-) : BaseCredentialsManager(apiClient, storage, jwtDecoder) {
+    jwtDecoder: JWTDecoder,
+    serialExecutor: Executor
+) : BaseCredentialsManager(apiClient, storage, jwtDecoder, serialExecutor) {
     private val gson: Gson = GsonProvider.gson
 
     //Changeable by the user
@@ -63,7 +66,8 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         apiClient,
         storage,
         CryptoUtil(context, storage, KEY_ALIAS),
-        JWTDecoder()
+        JWTDecoder(),
+        Executors.newSingleThreadExecutor()
     )
 
     /**
@@ -153,6 +157,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
      * implementation and will have [CredentialsManagerException.isDeviceIncompatible] return true.
      */
     @Throws(CredentialsManagerException::class)
+    @Synchronized
     override fun saveCredentials(credentials: Credentials) {
         if (TextUtils.isEmpty(credentials.accessToken) && TextUtils.isEmpty(credentials.idToken)) {
             throw CredentialsManagerException("Credentials must have a valid date of expiration and a valid access_token or id_token value.")
@@ -318,82 +323,83 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         parameters: Map<String, String>,
         callback: Callback<Credentials, CredentialsManagerException>
     ) {
-        val encryptedEncoded = storage.retrieveString(KEY_CREDENTIALS)
-        val encrypted = Base64.decode(encryptedEncoded, Base64.DEFAULT)
-        val json: String
-        try {
-            json = String(crypto.decrypt(encrypted))
-        } catch (e: IncompatibleDeviceException) {
-            callback.onFailure(
-                CredentialsManagerException(
-                    String.format(
-                        "This device is not compatible with the %s class.",
-                        SecureCredentialsManager::class.java.simpleName
-                    ), e
+        serialExecutor.execute {
+            val encryptedEncoded = storage.retrieveString(KEY_CREDENTIALS)
+            val encrypted = Base64.decode(encryptedEncoded, Base64.DEFAULT)
+            val json: String
+            try {
+                json = String(crypto.decrypt(encrypted))
+            } catch (e: IncompatibleDeviceException) {
+                callback.onFailure(
+                    CredentialsManagerException(
+                        String.format(
+                            "This device is not compatible with the %s class.",
+                            SecureCredentialsManager::class.java.simpleName
+                        ), e
+                    )
                 )
-            )
-            decryptCallback = null
-            return
-        } catch (e: CryptoException) {
-            //If keys were invalidated, existing credentials will not be recoverable.
-            clearCredentials()
-            callback.onFailure(
-                CredentialsManagerException(
-                    "A change on the Lock Screen security settings have deemed the encryption keys invalid and have been recreated. " +
-                            "Any previously stored content is now lost. Please, try saving the credentials again.",
-                    e
+                decryptCallback = null
+                return@execute
+            } catch (e: CryptoException) {
+                //If keys were invalidated, existing credentials will not be recoverable.
+                clearCredentials()
+                callback.onFailure(
+                    CredentialsManagerException(
+                        "A change on the Lock Screen security settings have deemed the encryption keys invalid and have been recreated. " +
+                                "Any previously stored content is now lost. Please, try saving the credentials again.",
+                        e
+                    )
                 )
+                decryptCallback = null
+                return@execute
+            }
+            val bridgeCredentials = gson.fromJson(json, OptionalCredentials::class.java)
+            /* OPTIONAL CREDENTIALS
+             * This bridge is required to prevent users from being logged out when
+             * migrating from Credentials with optional Access Token and ID token
+             */
+            val credentials = Credentials(
+                bridgeCredentials.idToken.orEmpty(),
+                bridgeCredentials.accessToken.orEmpty(),
+                bridgeCredentials.type.orEmpty(),
+                bridgeCredentials.refreshToken,
+                bridgeCredentials.expiresAt ?: Date(),
+                bridgeCredentials.scope
             )
-            decryptCallback = null
-            return
-        }
-        val bridgeCredentials = gson.fromJson(json, OptionalCredentials::class.java)
-        /* OPTIONAL CREDENTIALS
-         * This bridge is required to prevent users from being logged out when
-         * migrating from Credentials with optional Access Token and ID token
-         */
-        val credentials = Credentials(
-            bridgeCredentials.idToken.orEmpty(),
-            bridgeCredentials.accessToken.orEmpty(),
-            bridgeCredentials.type.orEmpty(),
-            bridgeCredentials.refreshToken,
-            bridgeCredentials.expiresAt ?: Date(),
-            bridgeCredentials.scope
-        )
-        val cacheExpiresAt = storage.retrieveLong(KEY_CACHE_EXPIRES_AT)
-        val expiresAt = credentials.expiresAt.time
-        val hasEmptyCredentials =
-            TextUtils.isEmpty(credentials.accessToken) && TextUtils.isEmpty(credentials.idToken) || cacheExpiresAt == null
-        if (hasEmptyCredentials) {
-            callback.onFailure(CredentialsManagerException("No Credentials were previously set."))
-            decryptCallback = null
-            return
-        }
-        val hasEitherExpired = hasExpired(cacheExpiresAt!!)
-        val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
-        val scopeChanged = hasScopeChanged(credentials.scope, scope)
-        if (!hasEitherExpired && !willAccessTokenExpire && !scopeChanged) {
-            callback.onSuccess(credentials)
-            decryptCallback = null
-            return
-        }
-        if (credentials.refreshToken == null) {
-            callback.onFailure(CredentialsManagerException("No Credentials were previously set."))
-            decryptCallback = null
-            return
-        }
-        Log.d(TAG, "Credentials have expired. Renewing them now...")
-        val request = authenticationClient.renewAuth(
-            credentials.refreshToken
-        )
+            val cacheExpiresAt = storage.retrieveLong(KEY_CACHE_EXPIRES_AT)
+            val expiresAt = credentials.expiresAt.time
+            val hasEmptyCredentials =
+                TextUtils.isEmpty(credentials.accessToken) && TextUtils.isEmpty(credentials.idToken) || cacheExpiresAt == null
+            if (hasEmptyCredentials) {
+                callback.onFailure(CredentialsManagerException("No Credentials were previously set."))
+                decryptCallback = null
+                return@execute
+            }
+            val hasEitherExpired = hasExpired(cacheExpiresAt!!)
+            val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
+            val scopeChanged = hasScopeChanged(credentials.scope, scope)
+            if (!hasEitherExpired && !willAccessTokenExpire && !scopeChanged) {
+                callback.onSuccess(credentials)
+                decryptCallback = null
+                return@execute
+            }
+            if (credentials.refreshToken == null) {
+                callback.onFailure(CredentialsManagerException("No Credentials were previously set."))
+                decryptCallback = null
+                return@execute
+            }
+            Log.d(TAG, "Credentials have expired. Renewing them now...")
+            val request = authenticationClient.renewAuth(
+                credentials.refreshToken
+            )
 
-        request.addParameters(parameters)
-        if (scope != null) {
-            request.addParameter("scope", scope)
-        }
+            request.addParameters(parameters)
+            if (scope != null) {
+                request.addParameter("scope", scope)
+            }
 
-        request.start(object : AuthenticationCallback<Credentials> {
-            override fun onSuccess(fresh: Credentials) {
+            try {
+                val fresh = request.execute()
                 val expiresAt = fresh.expiresAt.time
                 val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
                 if (willAccessTokenExpire) {
@@ -408,7 +414,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                     )
                     callback.onFailure(wrongTtlException)
                     decryptCallback = null
-                    return
+                    return@execute
                 }
 
                 //non-empty refresh token for refresh token rotation scenarios
@@ -425,9 +431,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                 saveCredentials(refreshed)
                 callback.onSuccess(refreshed)
                 decryptCallback = null
-            }
-
-            override fun onFailure(error: AuthenticationException) {
+            } catch (error: AuthenticationException) {
                 callback.onFailure(
                     CredentialsManagerException(
                         "An error occurred while trying to use the Refresh Token to renew the Credentials.",
@@ -436,7 +440,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                 )
                 decryptCallback = null
             }
-        })
+        }
     }
 
     internal companion object {

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -58,8 +58,7 @@ public class CredentialsManagerTest {
     @Before
     public fun setUp() {
         MockitoAnnotations.openMocks(this)
-        val credentialsManager = CredentialsManager(client, storage, jwtDecoder)
-        credentialsManager.setExecutor(serialExecutor)
+        val credentialsManager = CredentialsManager(client, storage, jwtDecoder, serialExecutor)
         manager = Mockito.spy(credentialsManager)
         //Needed to test expiration verification
         Mockito.doReturn(CredentialsMock.CURRENT_TIME_MS).`when`(manager).currentTimeInMillis
@@ -894,8 +893,7 @@ public class CredentialsManagerTest {
 
     @Test(expected = IllegalArgumentException::class)
     public fun shouldUseCustomExecutorForGetCredentials() {
-        val manager = CredentialsManager(client, storage)
-        manager.setExecutor {
+        val manager = CredentialsManager(client, storage, jwtDecoder) {
             throw IllegalArgumentException("Proper Executor Set")
         }
         manager.getCredentials(object : Callback<Credentials, CredentialsManagerException> {

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -23,6 +23,8 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
+import java.lang.Exception
+import java.lang.IllegalArgumentException
 import java.util.*
 import java.util.concurrent.Executor
 
@@ -56,7 +58,8 @@ public class CredentialsManagerTest {
     @Before
     public fun setUp() {
         MockitoAnnotations.openMocks(this)
-        val credentialsManager = CredentialsManager(client, storage, jwtDecoder, serialExecutor)
+        val credentialsManager = CredentialsManager(client, storage, jwtDecoder)
+        credentialsManager.setExecutor(serialExecutor)
         manager = Mockito.spy(credentialsManager)
         //Needed to test expiration verification
         Mockito.doReturn(CredentialsMock.CURRENT_TIME_MS).`when`(manager).currentTimeInMillis
@@ -887,6 +890,18 @@ public class CredentialsManagerTest {
             }
         })
         MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(true))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    public fun shouldUseCustomExecutorForGetCredentials() {
+        val manager = CredentialsManager(client, storage)
+        manager.setExecutor {
+            throw IllegalArgumentException("Proper Executor Set")
+        }
+        manager.getCredentials(object : Callback<Credentials, CredentialsManagerException> {
+            override fun onSuccess(result: Credentials) { }
+            override fun onFailure(error: CredentialsManagerException) { }
+        })
     }
 
 

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -1560,7 +1560,7 @@ public class SecureCredentialsManagerTest {
     @Test(expected = java.lang.IllegalArgumentException::class)
     public fun shouldUseCustomExecutorForGetCredentials() {
         val manager = SecureCredentialsManager(client, storage, crypto, jwtDecoder)
-        val expirationTime = CredentialsMock.CURRENT_TIME_MS + 10000
+        val expirationTime = CredentialsMock.ONE_HOUR_AHEAD_MS
         Mockito.`when`(storage.retrieveLong("com.auth0.credentials_expires_at"))
             .thenReturn(expirationTime)
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -1569,12 +1569,8 @@ public class SecureCredentialsManagerTest {
             throw java.lang.IllegalArgumentException("Proper Executor Set")
         }
         manager.getCredentials(object : Callback<Credentials, CredentialsManagerException> {
-            override fun onSuccess(result: Credentials) {
-                println("Hi")
-            }
-            override fun onFailure(error: CredentialsManagerException) {
-                println("Hello")
-            }
+            override fun onSuccess(result: Credentials) { }
+            override fun onFailure(error: CredentialsManagerException) { }
         })
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -277,7 +277,7 @@ public class SecureCredentialsManagerTest {
         MatcherAssert.assertThat(exception!!.isDeviceIncompatible, Is.`is`(false))
         MatcherAssert.assertThat(
             exception.message,
-            Is.`is`("A change on the Lock Screen security settings have deemed the encryption keys invalid and have been recreated. Please, try saving the credentials again.")
+            Is.`is`("A change on the Lock Screen security settings have deemed the encryption keys invalid and have been recreated. Please try saving the credentials again.")
         )
         verify(storage).remove("com.auth0.credentials")
         verify(storage).remove("com.auth0.credentials_expires_at")
@@ -370,7 +370,7 @@ public class SecureCredentialsManagerTest {
         MatcherAssert.assertThat(
             exception.message, Is.`is`(
                 "A change on the Lock Screen security settings have deemed the encryption keys invalid and have been recreated. " +
-                        "Any previously stored content is now lost. Please, try saving the credentials again."
+                        "Any previously stored content is now lost. Please try saving the credentials again."
             )
         )
         verify(storage).remove("com.auth0.credentials")

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -46,6 +46,7 @@ import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.util.ReflectionHelpers
+import java.lang.reflect.Modifier
 import java.util.*
 import java.util.concurrent.Executor
 
@@ -1592,6 +1593,13 @@ public class SecureCredentialsManagerTest {
 
         verify(request).addParameters(parameters)
         verify(request).execute()
+    }
+
+    @Test
+    public fun shouldBeMarkedSynchronous(){
+        val method =
+            SecureCredentialsManager::class.java.getMethod("saveCredentials", Credentials::class.java)
+        Modifier.isSynchronized(method.modifiers)
     }
 
     /*


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Added an `Executor` to BaseCredentialsManager
- This executor is provided with a single-threaded `ExecutorService`
- `getCredentials` methods are run over this executor
- `saveCredentials` method in SecureCredentialsManager is made `@Synchronized` to avoid race conditions

### References
#540, #330, #359

### Testing

The existing Unit Tests are provided with proper mocks and fixed to accommodate current changes. Apart from that, manual testing is done where multiple threads try to access the above methods with RTR enabled