### PR TITLE
Security: Bump Kotlin Stdlib to 1.6.20 to address CVE-2022-24329

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
 
       - run:
           name: Run checks
-          command: rm -rf .gradle && ./gradlew clean test jacocoTestReport lint --continue --console=plain --max-workers=2 --no-daemon
+          command: ./gradlew clean test jacocoTestReport lint --continue --console=plain --max-workers=2 --no-daemon
 
       - store_artifacts:
           path: auth0/build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,25 +4,14 @@ jobs:
     environment:
       GRADLE_OPTS: -Dkotlin.compiler.execution.strategy=in-process
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:2022.03.1
 
     steps:
       - checkout
 
-      - restore_cache:
-          keys:
-            - v2-dep-{{ checksum "build.gradle" }}-{{ checksum  "auth0/build.gradle" }}
-
       - run:
           name: Run checks
-          command: ./gradlew clean test jacocoTestReport lint --continue --console=plain --max-workers=2 --no-daemon
-
-      - save_cache:
-          key: v2-dep-{{ checksum "build.gradle" }}-{{ checksum  "auth0/build.gradle" }}
-          paths:
-            - ~/.gradle
-            - ~/.android
-            - /usr/local/android-sdk-linux/extras
+          command: rm -rf .gradle && ./gradlew clean test jacocoTestReport lint --continue --console=plain --max-workers=2 --no-daemon
 
       - store_artifacts:
           path: auth0/build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
 
       - run:
           name: Run checks
-          command: ./gradlew clean test jacocoTestReport lint --continue --console=plain --max-workers=2 --no-daemon
+          command: rm -rf .gradle && ./gradlew clean test jacocoTestReport lint --continue --console=plain --parallel --no-daemon
 
       - store_artifacts:
           path: auth0/build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
 
       - run:
           name: Run checks
-          command: rm -rf .gradle && ./gradlew clean test jacocoTestReport lint --continue --console=plain --parallel --no-daemon
+          command: ./gradlew clean test jacocoTestReport lint --continue --console=plain --max-workers=2 --no-daemon
 
       - store_artifacts:
           path: auth0/build/reports

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.10"
+    ext.kotlin_version = "1.5.20"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.6.0"
+    ext.kotlin_version = "1.6.10"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.20"
+    ext.kotlin_version = "1.5.21"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.21"
+    ext.kotlin_version = "1.5.30"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.31"
+    ext.kotlin_version = "1.5.32"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.30"
+    ext.kotlin_version = "1.5.31"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.10"
+    ext.kotlin_version = "1.6.20"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.32"
+    ext.kotlin_version = "1.6.0"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.6.20"
+    ext.kotlin_version = "1.5.32"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.6.10"
+    ext.kotlin_version = "1.6.20"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.32"
+    ext.kotlin_version = "1.5.10"
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
This PR:
- Updates the CircleCI docker image to a supported version
- Simplifies the CircleCI build process by removing unused steps
- Bumps the Kotlin version to 1.6.20 (up from 1.5.10) to address [CVE-2022-24329](https://nvd.nist.gov/vuln/detail/CVE-2022-24329)

Related PRs:
- https://github.com/auth0/Lock.Android/pull/641