### PR TITLE
[SDK-3082] Avoid config change to handle authentication

### DIFF
--- a/auth0/src/main/AndroidManifest.xml
+++ b/auth0/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <application>
         <activity
             android:name="com.auth0.android.provider.AuthenticationActivity"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|keyboard|keyboardHidden"
             android:exported="false"
             android:launchMode="singleTask"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />


### PR DESCRIPTION
### Changes
We have avoided config changes by locking it in the Manifest. 
We have done a discovery on why this would be the right solution which is marked in the Jira ticket.

Using Contexts or other Activity resources can cause a crash if the Activity is recreated. Hence use of ViewModel is suggested

### References
https://github.com/auth0/Auth0.Android/issues/530
https://github.com/auth0/Auth0.Android/issues/535
