### PR TITLE
[SDK-3144] Add user property to Credentials

### DIFF
--- a/auth0/src/main/java/com/auth0/android/request/internal/Jwt.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/Jwt.kt
@@ -31,8 +31,8 @@ internal class Jwt(rawToken: String) {
 
     init {
         parts = splitToken(rawToken)
-        val jsonHeader = parts[0].decodeBase64()
-        val jsonPayload = parts[1].decodeBase64()
+        val jsonHeader = decodeBase64(parts[0])
+        val jsonPayload = decodeBase64(parts[1])
         val mapAdapter = GsonProvider.gson.getAdapter(object : TypeToken<Map<String, Any>>() {})
         decodedHeader = mapAdapter.fromJson(jsonHeader)
         decodedPayload = mapAdapter.fromJson(jsonPayload)
@@ -58,27 +58,29 @@ internal class Jwt(rawToken: String) {
         }
     }
 
-    private fun splitToken(token: String): Array<String> {
-        var parts = token.split(".").toTypedArray()
-        if (parts.size == 2 && token.endsWith(".")) {
-            // Tokens with alg='none' have empty String as Signature.
-            parts = arrayOf(parts[0], parts[1], "")
-        }
-        if (parts.size != 3) {
-            throw IllegalArgumentException(
-                String.format(
-                    "The token was expected to have 3 parts, but got %s.",
-                    parts.size
+    companion object {
+        fun splitToken(token: String): Array<String> {
+            var parts = token.split(".").toTypedArray()
+            if (parts.size == 2 && token.endsWith(".")) {
+                // Tokens with alg='none' have empty String as Signature.
+                parts = arrayOf(parts[0], parts[1], "")
+            }
+            if (parts.size != 3) {
+                throw IllegalArgumentException(
+                    String.format(
+                        "The token was expected to have 3 parts, but got %s.",
+                        parts.size
+                    )
                 )
-            )
+            }
+            return parts
         }
-        return parts
-    }
 
-    private fun String.decodeBase64(): String {
-        val bytes: ByteArray =
-            Base64.decode(this, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
-        return String(bytes, Charsets.UTF_8)
+        fun decodeBase64(encoded: String): String {
+            val bytes: ByteArray =
+                Base64.decode(encoded, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+            return String(bytes, Charsets.UTF_8)
+        }
     }
 
 }

--- a/auth0/src/main/java/com/auth0/android/result/Credentials.kt
+++ b/auth0/src/main/java/com/auth0/android/result/Credentials.kt
@@ -1,7 +1,10 @@
 package com.auth0.android.result
 
 import androidx.annotation.VisibleForTesting
+import com.auth0.android.request.internal.GsonProvider
+import com.auth0.android.request.internal.Jwt
 import com.google.gson.annotations.SerializedName
+
 import java.util.*
 
 /**
@@ -71,4 +74,11 @@ public open class Credentials(
     @field:SerializedName("recovery_code")
     public var recoveryCode: String? = null
         internal set
+
+    public val user: UserProfile get() {
+        val (_, payload) = Jwt.splitToken(idToken)
+        val gson = GsonProvider.gson
+        return gson.fromJson(Jwt.decodeBase64(payload), UserProfile::class.java)
+    }
+
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.Resources
 import com.auth0.android.Auth0
 import com.auth0.android.authentication.ParameterBuilder.Companion.newBuilder
+import com.auth0.android.provider.JwtTestUtils
 import com.auth0.android.request.HttpMethod
 import com.auth0.android.request.NetworkingClient
 import com.auth0.android.request.RequestOptions
@@ -329,11 +330,13 @@ public class AuthenticationAPIClientTest {
 
     @Test
     public fun shouldLoginWithUserAndPasswordSync() {
-        mockAPI.willReturnSuccessfulLogin()
+        val jwt = JwtTestUtils.createTestJWT("HS256", mapOf("sub" to "auth0|123456"))
+        mockAPI.willReturnSuccessfulLogin(jwt)
         val credentials = client
             .login(SUPPORT_AUTH0_COM, "voidpassword", MY_CONNECTION)
             .execute()
         assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
+        assertThat(credentials.user.getId(), Matchers.`is`("auth0|123456"))
         val request = mockAPI.takeRequest()
         assertThat(
             request.getHeader("Accept-Language"), Matchers.`is`(

--- a/auth0/src/test/java/com/auth0/android/provider/JwtTestUtils.java
+++ b/auth0/src/test/java/com/auth0/android/provider/JwtTestUtils.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-class JwtTestUtils {
+public class JwtTestUtils {
 
     static final long FIXED_CLOCK_CURRENT_TIME_MS = 1567314000000L;
     static final String EXPECTED_BASE_DOMAIN = "test.domain.com";
@@ -33,7 +33,7 @@ class JwtTestUtils {
     private static final String RSA_PRIVATE_KEY = "src/test/resources/rsa_private.pem";
     private static final String RSA_PUBLIC_KEY = "src/test/resources/rsa_public.pem";
 
-    static String createTestJWT(@NonNull String algorithm, @NonNull Map<String, Object> bodyClaims) throws Exception {
+    public static String createTestJWT(@NonNull String algorithm, @NonNull Map<String, Object> bodyClaims) throws Exception {
         String header = "{" +
                 "\"alg\":\"" + algorithm + "\"," +
                 "\"typ\":\"JWT\"," +

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsTest.kt
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsTest.kt
@@ -1,10 +1,16 @@
 package com.auth0.android.result
 
+import com.auth0.android.request.internal.GsonProvider.credentialsGson
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import java.util.*
 
+private val idToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vbXktZG9tYWluLmF1dGgwLmNvbSIsInN1YiI6ImF1dGgwfDEyMzQ1NiIsImF1ZCI6Im15X2NsaWVudF9pZCIsImV4cCI6MTMxMTI4MTk3MCwiaWF0IjoxMzExMjgwOTcwLCJuYW1lIjoiSmFuZSBEb2UiLCJnaXZlbl9uYW1lIjoiSmFuZSIsImZhbWlseV9uYW1lIjoiRG9lIiwiZ2VuZGVyIjoiZmVtYWxlIiwiYmlydGhkYXRlIjoiMDAwMC0xMC0zMSIsImVtYWlsIjoiamFuZWRvZUBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJodHRwOi8vZXhhbXBsZS5jb20vamFuZWRvZS9tZS5qcGcifQ.FKw0UVWANEqibD9VTC9WLzstlyc_IRnyPSpUMDP3hKc"
+
+@RunWith(RobolectricTestRunner::class)
 public class CredentialsTest {
     @Test
     public fun shouldCreate() {
@@ -34,5 +40,23 @@ public class CredentialsTest {
             CredentialsMock("idToken", "accessToken", "type", "refreshToken", date, "scope")
         credentials.recoveryCode = "recoveryCode"
         MatcherAssert.assertThat(credentials.recoveryCode, Matchers.`is`("recoveryCode"))
+    }
+
+    @Test
+    public fun shouldGetUser() {
+        val date = Date()
+        val credentials: Credentials =
+            CredentialsMock(idToken, "accessToken", "type", "refreshToken", date, "scope")
+        MatcherAssert.assertThat(credentials.user.getId(), Matchers.`is`("auth0|123456"))
+    }
+
+    @Test
+    public fun shouldNotSerializeUser() {
+        val date = Date()
+        val credentials: Credentials =
+            CredentialsMock(idToken, "accessToken", "type", "refreshToken", date, "scope")
+        MatcherAssert.assertThat(credentials.user.getId(), Matchers.`is`("auth0|123456"))
+        val json = credentialsGson.toJson(credentials, Credentials::class.java)
+        MatcherAssert.assertThat(json, Matchers.not(Matchers.containsString("auth0|123456")))
     }
 }

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsTest.kt
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsTest.kt
@@ -1,6 +1,6 @@
 package com.auth0.android.result
 
-import com.auth0.android.request.internal.GsonProvider.credentialsGson
+import com.auth0.android.request.internal.GsonProvider.gson
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.Test
@@ -56,7 +56,9 @@ public class CredentialsTest {
         val credentials: Credentials =
             CredentialsMock(idToken, "accessToken", "type", "refreshToken", date, "scope")
         MatcherAssert.assertThat(credentials.user.getId(), Matchers.`is`("auth0|123456"))
-        val json = credentialsGson.toJson(credentials, Credentials::class.java)
+        val json = gson.toJson(credentials, Credentials::class.java)
         MatcherAssert.assertThat(json, Matchers.not(Matchers.containsString("auth0|123456")))
+        val obj = gson.fromJson(json, Credentials::class.java)
+        MatcherAssert.assertThat(obj.user.getId(), Matchers.`is`("auth0|123456"))
     }
 }

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsTest.kt
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsTest.kt
@@ -48,6 +48,11 @@ public class CredentialsTest {
         val credentials: Credentials =
             CredentialsMock(idToken, "accessToken", "type", "refreshToken", date, "scope")
         MatcherAssert.assertThat(credentials.user.getId(), Matchers.`is`("auth0|123456"))
+        MatcherAssert.assertThat(credentials.user.name, Matchers.`is`("Jane Doe"))
+        MatcherAssert.assertThat(credentials.user.givenName, Matchers.`is`("Jane"))
+        MatcherAssert.assertThat(credentials.user.familyName, Matchers.`is`("Doe"))
+        MatcherAssert.assertThat(credentials.user.pictureURL, Matchers.`is`("http://example.com/janedoe/me.jpg"))
+        MatcherAssert.assertThat(credentials.user.email, Matchers.`is`("janedoe@example.com"))
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/util/AuthenticationAPIMockServer.kt
+++ b/auth0/src/test/java/com/auth0/android/util/AuthenticationAPIMockServer.kt
@@ -35,10 +35,10 @@ internal class AuthenticationAPIMockServer : APIMockServer() {
         return this
     }
 
-    fun willReturnSuccessfulLogin(): AuthenticationAPIMockServer {
+    fun willReturnSuccessfulLogin(idToken: String = ID_TOKEN): AuthenticationAPIMockServer {
         val json = """{
           "refresh_token": "$REFRESH_TOKEN",
-          "id_token": "$ID_TOKEN",
+          "id_token": "$idToken",
           "access_token": "$ACCESS_TOKEN",
           "token_type": "$BEARER",
           "expires_in": 86000

--- a/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
+++ b/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
@@ -66,7 +66,7 @@ class DatabaseLoginFragment : Fragment() {
                 override fun onSuccess(result: Credentials) {
                     Snackbar.make(
                         requireView(),
-                        "Success: ${result.accessToken}",
+                        "Hello ${result.user.name}",
                         Snackbar.LENGTH_LONG
                     ).show()
                 }
@@ -80,7 +80,7 @@ class DatabaseLoginFragment : Fragment() {
                 override fun onSuccess(result: Credentials) {
                     Snackbar.make(
                         requireView(),
-                        "Success: ${result.accessToken}",
+                        "Hello ${result.user.name}",
                         Snackbar.LENGTH_LONG
                     ).show()
                 }


### PR DESCRIPTION
### Changes

Added the `user` property to `Credentials` 
Exposed a couple of methods on the `Jwt` helper to support this

#### Usage

```kotlin
authentication
    .login("info@auth0.com", "a secret password", "my-database-connection")
    .start(object: Callback<Credentials, AuthenticationException> {
        override fun onSuccess(credentials: Credentials) {
            println(credentials.user.name)
        }
    })
```

I didn't make it a Delegated Property because I couldn't get Gson to deserialize it (see https://stackoverflow.com/a/57604781)

### Testing

Login to the sample app, note the new "Hello YOUR_NAME" greeting.

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
