### PR TITLE
[SDK-3354] Deserialize UserProfile.createdAt as ISO8601

### DIFF
--- a/auth0/src/main/java/com/auth0/android/request/internal/UserProfileDeserializer.java
+++ b/auth0/src/main/java/com/auth0/android/request/internal/UserProfileDeserializer.java
@@ -2,6 +2,7 @@ package com.auth0.android.request.internal;
 
 import com.auth0.android.result.UserIdentity;
 import com.auth0.android.result.UserProfile;
+import com.google.gson.Gson;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -15,6 +16,13 @@ import java.util.List;
 import java.util.Map;
 
 class UserProfileDeserializer implements JsonDeserializer<UserProfile> {
+
+    private final Gson iso8601DateGson;
+
+    public UserProfileDeserializer() {
+        this.iso8601DateGson = new Gson();
+    }
+
     @Override
     public UserProfile deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         if (!json.isJsonObject() || json.isJsonNull() || json.getAsJsonObject().entrySet().isEmpty()) {
@@ -31,7 +39,7 @@ class UserProfileDeserializer implements JsonDeserializer<UserProfile> {
         final String givenName = context.deserialize(object.remove("given_name"), String.class);
         final String familyName = context.deserialize(object.remove("family_name"), String.class);
         final Boolean emailVerified = object.has("email_verified") ? context.<Boolean>deserialize(object.remove("email_verified"), Boolean.class) : false;
-        final Date createdAt = context.deserialize(object.remove("created_at"), Date.class);
+        final Date createdAt = iso8601DateGson.fromJson(object.remove("created_at"), Date.class);
 
         final Type identitiesType = new TypeToken<List<UserIdentity>>() {}.getType();
         final List<UserIdentity> identities = context.deserialize(object.remove("identities"), identitiesType);

--- a/auth0/src/test/java/com/auth0/android/request/internal/UserProfileGsonTest.kt
+++ b/auth0/src/test/java/com/auth0/android/request/internal/UserProfileGsonTest.kt
@@ -235,12 +235,26 @@ public class UserProfileGsonTest : GsonBaseTest() {
         assertThat(
             profile.createdAt,
             equalTo(
-                SimpleDateFormat(
-                    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-                    Locale.US
-                ).parse("2014-07-06T18:33:49.005Z")
+                getUTCDate(2014, 6, 6, 18, 33, 49, 5)
             )
         )
+    }
+
+    @Test
+    @Throws(Exception::class)
+    public fun shouldCreateProfileFromISO8601CreatedAt() {
+        val profileUtc = pojoFrom(
+            StringReader("""{ "created_at": "2022-04-29T07:09:23.000Z" }"""),
+            UserProfile::class.java
+        )
+        val profileLocal = pojoFrom(
+            StringReader("""{ "created_at": "2022-04-29T10:09:23.000+0300" }"""),
+            UserProfile::class.java
+        )
+        val dateUtc = getUTCDate(2022, 3, 29, 7, 9, 23, 0);
+
+        assertThat(profileUtc.createdAt, equalTo(dateUtc))
+        assertThat(profileLocal.createdAt, equalTo(dateUtc))
     }
 
     @Test
@@ -329,6 +343,18 @@ public class UserProfileGsonTest : GsonBaseTest() {
             profile.getAppMetadata(),
             hasEntry("blocked", false as Any)
         )
+    }
+
+    private fun getUTCDate(year: Int, month: Int, day: Int, hr: Int, min: Int, sec: Int, ms: Int): Date {
+        val cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+        cal[Calendar.YEAR] = year
+        cal[Calendar.MONTH] = month
+        cal[Calendar.DAY_OF_MONTH] = day
+        cal[Calendar.HOUR_OF_DAY] = hr
+        cal[Calendar.MINUTE] = min
+        cal[Calendar.SECOND] = sec
+        cal[Calendar.MILLISECOND] = ms
+        return cal.time
     }
 
     private companion object {


### PR DESCRIPTION
### Changes

Fix issue where createdAt from the UserProfile was being interpreted as a local date rather than UTC.

Originally did https://github.com/auth0/Auth0.Android/pull/564 - but needed a lighter touch

### References

fixes https://github.com/auth0/Auth0.Android/issues/553

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
