### PR TITLE
[SDK-3352] Expire credentials based on access token alone

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -90,24 +90,4 @@ public abstract class BaseCredentialsManager internal constructor(
     protected fun hasExpired(expiresAt: Long): Boolean {
         return expiresAt <= currentTimeInMillis
     }
-
-    /**
-     * Takes a credentials object and returns the lowest expiration time, considering
-     * both the access token and the ID token expiration time.
-     *
-     * @param credentials the credentials object to check.
-     * @return the lowest expiration time between the access token and the ID token.
-     */
-    protected fun calculateCacheExpiresAt(credentials: Credentials): Long {
-        var expiresAt = credentials.expiresAt.time
-        if (credentials.idToken.isNotEmpty()) {
-            val idToken = jwtDecoder.decode(credentials.idToken)
-            val idTokenExpiresAtDate = idToken.expiresAt
-            if (idTokenExpiresAtDate != null) {
-                expiresAt = min(idTokenExpiresAtDate.time, expiresAt)
-            }
-        }
-        return expiresAt
-    }
-
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -298,6 +298,8 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
         private const val KEY_TOKEN_TYPE = "com.auth0.token_type"
         private const val KEY_EXPIRES_AT = "com.auth0.expires_at"
         private const val KEY_SCOPE = "com.auth0.scope"
+        // This is no longer used as we get the credentials expiry from the access token only,
+        // but we still store it so users can rollback to versions where it is required.
         private const val LEGACY_KEY_CACHE_EXPIRES_AT = "com.auth0.cache_expires_at"
     }
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -519,6 +519,8 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         private val TAG = SecureCredentialsManager::class.java.simpleName
         private const val KEY_CREDENTIALS = "com.auth0.credentials"
         private const val KEY_EXPIRES_AT = "com.auth0.credentials_access_token_expires_at"
+        // This is no longer used as we get the credentials expiry from the access token only,
+        // but we still store it so users can rollback to versions where it is required.
         private const val LEGACY_KEY_CACHE_EXPIRES_AT = "com.auth0.credentials_expires_at"
         private const val KEY_CAN_REFRESH = "com.auth0.credentials_can_refresh"
         private const val KEY_ALIAS = "com.auth0.key"

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -131,7 +131,7 @@ public class CredentialsManagerTest {
     }
 
     @Test
-    public fun shouldSaveRefreshableCredentialsUsingIdTokenExpForCacheExpirationInStorage() {
+    public fun shouldSaveRefreshableCredentialsIgnoringIdTokenExpForCacheExpirationInStorage() {
         val accessTokenExpirationTime = CredentialsMock.CURRENT_TIME_MS + 5000 * 1000
         val idTokenExpirationTime = CredentialsMock.CURRENT_TIME_MS + 2000 * 1000
         val credentials: Credentials = CredentialsMock(
@@ -150,7 +150,7 @@ public class CredentialsManagerTest {
         verify(storage).store("com.auth0.token_type", "type")
         verify(storage).store("com.auth0.expires_at", accessTokenExpirationTime)
         verify(storage).store("com.auth0.scope", "scope")
-        verify(storage).store("com.auth0.cache_expires_at", idTokenExpirationTime)
+        verify(storage).store("com.auth0.cache_expires_at", accessTokenExpirationTime)
         verifyNoMoreInteractions(storage)
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -1053,7 +1053,7 @@ public class SecureCredentialsManagerTest {
     @Test
     public fun shouldNotHaveCredentialsWhenTokenHasExpiredAndNoRefreshTokenIsAvailable() {
         val expirationTime = CredentialsMock.CURRENT_TIME_MS //Same as current time --> expired
-        Mockito.`when`(storage.retrieveLong("com.auth0.credentials_expires_at"))
+        Mockito.`when`(storage.retrieveLong("com.auth0.credentials_access_token_expires_at"))
             .thenReturn(expirationTime)
         Mockito.`when`(storage.retrieveBoolean("com.auth0.credentials_can_refresh"))
             .thenReturn(false)
@@ -1068,7 +1068,7 @@ public class SecureCredentialsManagerTest {
     @Test
     public fun shouldHaveCredentialsWhenTokenHasExpiredButRefreshTokenIsAvailable() {
         val expirationTime = CredentialsMock.CURRENT_TIME_MS //Same as current time --> expired
-        Mockito.`when`(storage.retrieveLong("com.auth0.credentials_expires_at"))
+        Mockito.`when`(storage.retrieveLong("com.auth0.credentials_access_token_expires_at"))
             .thenReturn(expirationTime)
         Mockito.`when`(storage.retrieveBoolean("com.auth0.credentials_can_refresh"))
             .thenReturn(true)
@@ -1078,13 +1078,6 @@ public class SecureCredentialsManagerTest {
         Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
             .thenReturn("{\"access_token\":\"accessToken\", \"refresh_token\":\"refreshToken\"}")
         MatcherAssert.assertThat(manager.hasValidCredentials(), Is.`is`(true))
-    }
-
-    @Test
-    public fun shouldNotHaveCredentialsWhenAccessTokenAndIdTokenAreMissing() {
-        Mockito.`when`(storage.retrieveString("com.auth0.credentials"))
-            .thenReturn("{\"token_type\":\"type\", \"refresh_token\":\"refreshToken\"}")
-        Assert.assertFalse(manager.hasValidCredentials())
     }
 
     @Test
@@ -1458,7 +1451,7 @@ public class SecureCredentialsManagerTest {
         val credentialsExpiresAt = Date(CredentialsMock.ONE_HOUR_AHEAD_MS)
         val storedExpiresAt = Date(CredentialsMock.CURRENT_TIME_MS - ONE_HOUR_SECONDS * 1000)
         insertTestCredentials(true, true, false, credentialsExpiresAt, "scope")
-        Mockito.`when`(storage.retrieveLong("com.auth0.credentials_expires_at"))
+        Mockito.`when`(storage.retrieveLong("com.auth0.credentials_access_token_expires_at"))
             .thenReturn(storedExpiresAt.time)
 
         // Activity is "created"
@@ -1573,7 +1566,7 @@ public class SecureCredentialsManagerTest {
     public fun shouldUseCustomClock() {
         val manager = SecureCredentialsManager(client, storage, crypto, jwtDecoder) { }
         val expirationTime = CredentialsMock.CURRENT_TIME_MS //Same as current time --> expired
-        Mockito.`when`(storage.retrieveLong("com.auth0.credentials_expires_at"))
+        Mockito.`when`(storage.retrieveLong("com.auth0.credentials_access_token_expires_at"))
             .thenReturn(expirationTime)
         Mockito.`when`(storage.retrieveBoolean("com.auth0.credentials_can_refresh"))
             .thenReturn(false)

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -190,7 +190,7 @@ public class SecureCredentialsManagerTest {
     }
 
     @Test
-    public fun shouldSaveRefreshableCredentialsUsingIdTokenExpForCacheExpirationInStorage() {
+    public fun shouldSaveRefreshableCredentialsIgnoringIdTokenExpForCacheExpirationInStorage() {
         val accessTokenExpirationTime = CredentialsMock.ONE_HOUR_AHEAD_MS
         val idTokenExpirationTime = CredentialsMock.CURRENT_TIME_MS + 2000 * 1000
         val credentials: Credentials = CredentialsMock(
@@ -207,7 +207,7 @@ public class SecureCredentialsManagerTest {
         manager.saveCredentials(credentials)
         verify(storage)
             .store(eq("com.auth0.credentials"), stringCaptor.capture())
-        verify(storage).store("com.auth0.credentials_expires_at", idTokenExpirationTime)
+        verify(storage).store("com.auth0.credentials_expires_at", accessTokenExpirationTime)
         verify(storage)
             .store("com.auth0.credentials_access_token_expires_at", accessTokenExpirationTime)
         verify(storage).store("com.auth0.credentials_can_refresh", true)


### PR DESCRIPTION
### Changes

The `exp` claim on the ID token is for validating the token claims when the ID token is processed, not for setting the duration of the session.

### References

https://openid.net/specs/openid-connect-core-1_0.html#IDToken:~:text=exp-,REQUIRED.%20Expiration%20time%20on%20or%20after%20which%20the%20ID%20Token%20MUST,iat,-REQUIRED.%20Time%20at

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
