### PR TITLE
Security: Update OkHttp to 4.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
 
       - run:
           name: Run checks
-          command: ./gradlew clean test jacocoTestReport lint --continue --console=plain --max-workers=2 --no-daemon
+          command: ./gradlew clean test jacocoTestReport lint --continue --console=plain --max-workers=1 --no-daemon
 
       - store_artifacts:
           path: auth0/build/reports

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -89,7 +89,7 @@ android {
 }
 
 ext {
-    okhttpVersion = '4.9.3'
+    okhttpVersion = '4.10.0'
     powermockVersion = '2.0.9'
 }
 


### PR DESCRIPTION
This PR updates OkHttp to 4.10.0 to resolve [CVE-2022-24329](https://www.cve.org/CVERecord?id=CVE-2022-24329)