### PR TITLE
[SDK-3350] Empty credentials before continuing should throw CredentialsManagerException

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -401,6 +401,11 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     ) {
         serialExecutor.execute {
             val encryptedEncoded = storage.retrieveString(KEY_CREDENTIALS)
+            if (encryptedEncoded.isNullOrBlank()) {
+                callback.onFailure(CredentialsManagerException("No Credentials were previously set."))
+                decryptCallback = null
+                return@execute
+            }
             val encrypted = Base64.decode(encryptedEncoded, Base64.DEFAULT)
             val json: String
             try {


### PR DESCRIPTION
### Changes
Trying to fetch the credentials JSON after it has been cleared was not throwing exception inside `continueGetCredentials`. We have added a CredentialsManagerException for this case.

This was missed out previously since `continueGetCredentials` would be called after the check for `validCredentials` in `getCredentials` method but this misses out 2 scenarios
- Credential being cleared before reaching `continuingGetCredentials` by another thread
- Credential being cleared before `checkAuthenticationResult`

### References
GH Issue - https://github.com/auth0/Auth0.Android/issues/555

### Testing

We have added a test case to our Unit test suite. We also did an integration test by the case mentioned in the [GH issue]( https://github.com/auth0/Auth0.Android/issues/555)

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

