### PR TITLE
Add getCredentials overload to BaseCredentialsManager

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -38,6 +38,12 @@ public abstract class BaseCredentialsManager internal constructor(
         minTtl: Int,
         callback: Callback<Credentials, CredentialsManagerException>
     )
+    public abstract fun getCredentials(
+        scope: String?,
+        minTtl: Int,
+        parameters: Map<String, String>,
+        callback: Callback<Credentials, CredentialsManagerException>
+    ) 
 
     public abstract fun clearCredentials()
     public abstract fun hasValidCredentials(): Boolean

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -89,7 +89,7 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
      * @param parameters additional parameters to send in the request to refresh expired credentials
      * @param callback the callback that will receive a valid [Credentials] or the [CredentialsManagerException].
      */
-    public fun getCredentials(
+    override fun getCredentials(
         scope: String?,
         minTtl: Int,
         parameters: Map<String, String>,

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -249,7 +249,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
      * @param parameters additional parameters to send in the request to refresh expired credentials
      * @param callback the callback to receive the result in.
      */
-    public fun getCredentials(
+    override fun getCredentials(
         scope: String?,
         minTtl: Int,
         parameters: Map<String, String>,


### PR DESCRIPTION
### Changes

`BaseCredentialsManager` was missing one overload of `getCredentials`, even though that same signature is used in both `CredentialsManager` and `SecureCredentialsManager`.

This PR adds that method to the abstract `BaseCredentialsManager` class.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
