### PR TITLE
Implement coroutines for Web Auth

### DIFF
--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -22,6 +22,11 @@ import com.auth0.android.result.Credentials
 import com.auth0.android.util.AuthenticationAPIMockServer
 import com.auth0.android.util.SSLTestUtils
 import com.nhaarman.mockitokotlin2.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
@@ -34,12 +39,10 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
+import org.mockito.*
+import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mock
-import org.mockito.Mockito
 import org.mockito.Mockito.`when`
-import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -2543,6 +2546,21 @@ public class WebAuthProviderTest {
         val intent = createAuthIntent("")
         Assert.assertTrue(resume(intent))
         verify(voidCallback).onSuccess(eq<Void?>(null))
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    public fun shouldResumeLogoutSuccessfullyWithCoroutines(): Unit = runTest {
+        val job = launch { logout(account)
+            .await(activity, Dispatchers.Unconfined) }
+        advanceUntilIdle()
+        verify(activity).startActivity(intentCaptor.capture())
+        val uri =
+            intentCaptor.firstValue.getParcelableExtra<Uri>(AuthenticationActivity.EXTRA_AUTHORIZE_URI)
+        assertThat(uri, `is`(notNullValue()))
+        val intent = createAuthIntent("")
+        Assert.assertTrue(resume(intent))
+        job.join()
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -39,10 +39,12 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.*
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -2549,21 +2551,6 @@ public class WebAuthProviderTest {
     }
 
     @Test
-    @ExperimentalCoroutinesApi
-    public fun shouldResumeLogoutSuccessfullyWithCoroutines(): Unit = runTest {
-        val job = launch { logout(account)
-            .await(activity, Dispatchers.Unconfined) }
-        advanceUntilIdle()
-        verify(activity).startActivity(intentCaptor.capture())
-        val uri =
-            intentCaptor.firstValue.getParcelableExtra<Uri>(AuthenticationActivity.EXTRA_AUTHORIZE_URI)
-        assertThat(uri, `is`(notNullValue()))
-        val intent = createAuthIntent("")
-        Assert.assertTrue(resume(intent))
-        job.join()
-    }
-
-    @Test
     public fun shouldResumeLogoutFailingWithIntent() {
         logout(account)
             .start(activity, voidCallback)
@@ -2604,6 +2591,21 @@ public class WebAuthProviderTest {
             WebAuthProvider.managerInstance,
             `is`(CoreMatchers.nullValue())
         )
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    public fun shouldResumeLogoutSuccessfullyWithCoroutines(): Unit = runTest {
+        val job = launch { logout(account)
+            .await(activity, Dispatchers.Unconfined) }
+        advanceUntilIdle()
+        verify(activity).startActivity(intentCaptor.capture())
+        val uri =
+            intentCaptor.firstValue.getParcelableExtra<Uri>(AuthenticationActivity.EXTRA_AUTHORIZE_URI)
+        assertThat(uri, `is`(notNullValue()))
+        val intent = createAuthIntent("")
+        Assert.assertTrue(resume(intent))
+        job.join()
     }
 
     //**  ** ** ** ** **  **//


### PR DESCRIPTION
### Changes
We have implemented coroutines API for Web Auth. This can be used so that 
- Callback can be avoided
- Can be called from another coroutine

Scope like `viewModelScope` can be used to trigger this method and we will use context to switch to the main thread.

### Testing
We have written unit test and did integration test manually

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not