### PR TITLE
Integrate Auth0 Ship CLI and Ship Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-version: 2
+version: 2.1
+orbs:
+  ship: auth0/ship@0.6.1
 jobs:
   build:
     environment:
@@ -24,3 +26,19 @@ jobs:
           name: Upload Coverage
           when: on_success
           command: bash <(curl -s https://codecov.io/bash) -Z -C $CIRCLE_SHA1
+workflows:
+  build-and-test:
+    jobs:
+      - build
+      - ship/java-publish:
+          prefix-tag: false
+          publish-command: ./gradlew clean assemble publishAndroidLibraryPublicationToMavenRepository -PossrhUsername="$OSSR_USERNAME" -PossrhPassword="$OSSR_PASSWORD" -PisSnapshot=false
+          context:
+            - publish-gh
+            - publish-sonatype
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - build

--- a/.shiprc
+++ b/.shiprc
@@ -1,0 +1,7 @@
+{
+  "files": {
+    "auth0/src/build.gradle": [],
+    "README.md": []
+  },
+  "prefixVersion": false
+}

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -22,9 +22,13 @@
  * THE SOFTWARE.
  */
 
+buildscript {
+    version = "2.7.0"
+}
+
 plugins {
     id 'kotlin-android'
-    id "com.auth0.gradle.oss-library.android" version "0.15.1"
+    id "com.auth0.gradle.oss-library.android" version "0.17.0"
     id "org.jetbrains.dokka" version "1.4.20"
 }
 


### PR DESCRIPTION
### Changes

Prepares the repository to be used with Auth0 Ship CLI and our Circle CI Ship Orb.
Also adds the version to `build.gradle` to ensure Auth0 Ship CLI can bump it.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
