### PR TITLE
Read correct build gradle file

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,6 +1,6 @@
 {
   "files": {
-    "auth0/src/build.gradle": [],
+    "auth0/build.gradle": [],
     "README.md": []
   },
   "prefixVersion": false


### PR DESCRIPTION
### Changes

Uses the correct path to read the build.gradle file.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
