### PR TITLE
Bump ship orb to use latest dev version for android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@dev:03e96a0
+  ship: auth0/ship@dev:51f3320
 jobs:
   build:
     environment:


### PR DESCRIPTION
### Changes

As the CI is failing when querying maven, the Ship Orb got an update that changes the `cURL` command.
This PR bumps the config to use that latest version of the orbl

### References

https://github.com/auth0/ship-orb/pull/10

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
