### PR TITLE
Update Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
+
 orbs:
   ship: auth0/ship@dev:51f3320
+  codecov: codecov/codecov@3
+  
 jobs:
   build:
     environment:
@@ -22,10 +25,8 @@ jobs:
       - store_test_results:
           path: auth0/build/test-results
 
-      - run:
-          name: Upload Coverage
-          when: on_success
-          command: bash <(curl -s https://codecov.io/bash) -Z -C $CIRCLE_SHA1
+      - codecov/upload
+
 workflows:
   build-and-test:
     jobs:


### PR DESCRIPTION
This PR replaces the deprecated Codecov bash uploader in our CircleCI configuration with the recommended Orb