### PR TITLE
Catch different auth0 exceptions instead of just authentication excep…

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -14,6 +14,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.IntRange
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
+import com.auth0.android.Auth0Exception
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.AuthenticationCallback
@@ -508,7 +509,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                 saveCredentials(refreshed)
                 callback.onSuccess(refreshed)
                 decryptCallback = null
-            } catch (error: AuthenticationException) {
+            } catch (error: Auth0Exception) {
                 callback.onFailure(
                     CredentialsManagerException(
                         "An error occurred while trying to use the Refresh Token to renew the Credentials.",


### PR DESCRIPTION
### Changes
Currently, while getting an access token using the credential manager there is a chance that the method could fail because of saving. Though it is not highly feasible since this would have failed during save credentials itself, but just to be sure we are adding a check to catch Auth0Exception

### References
https://github.com/auth0/Auth0.Android/issues/599

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
