### PR TITLE
Configure project for signing on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ workflows:
           prefix-tag: false
           package-group: com/auth0/android
           package-name: auth0
-          publish-command: ./gradlew publishAndroidLibraryPublicationToMavenRepository -PossrhUsername="$OSSR_USERNAME" -PossrhPassword="$OSSR_PASSWORD" -PisSnapshot=false
+          publish-command: ./gradlew publishAndroidLibraryPublicationToMavenRepository -PossrhUsername="$OSSR_USERNAME" -PossrhPassword="$OSSR_PASSWORD" -PsigningKey="$SIGNING_KEY" -PsigningPassword="$SIGNING_PASSWORD" -PisSnapshot=false
           context:
             - publish-gh
             - publish-sonatype

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ship: auth0/ship@dev:51f3320
+  ship: auth0/ship@0.7.2
   codecov: codecov/codecov@3
   
 jobs:
@@ -33,9 +33,6 @@ workflows:
       - build
       - ship/android-publish:
           prefix-tag: false
-          package-group: com/auth0/android
-          package-name: auth0
-          publish-command: ./gradlew publishAndroidLibraryPublicationToMavenRepository -PossrhUsername="$OSSR_USERNAME" -PossrhPassword="$OSSR_PASSWORD" -PsigningKey="$SIGNING_KEY" -PsigningPassword="$SIGNING_PASSWORD" -PisSnapshot=false
           context:
             - publish-gh
             - publish-sonatype

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -32,8 +32,8 @@ plugins {
     id "org.jetbrains.dokka" version "1.4.20"
 }
 
-def signingKey = findProperty('SIGNING_KEY')
-def signingKeyPwd = findProperty('SIGNING_PASSWORD')
+def signingKey = findProperty('signingKey')
+def signingKeyPwd = findProperty('signingPassword')
 
 signing {
     useInMemoryPgpKeys(signingKey, signingKeyPwd)
@@ -46,6 +46,7 @@ oss {
     repository 'Auth0.Android'
     organization 'auth0'
     description 'Android toolkit for Auth0 API'
+    skipAssertSigningConfiguration true
 
     developers {
         auth0 {

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -28,7 +28,7 @@ buildscript {
 
 plugins {
     id 'kotlin-android'
-    id "com.auth0.gradle.oss-library.android" version "0.17.0"
+    id "com.auth0.gradle.oss-library.android" version "0.17.1"
     id "org.jetbrains.dokka" version "1.4.20"
 }
 


### PR DESCRIPTION
### Changes

This PR sets the `skipAssertSigningConfiguration` flag to true, ensuring the OSS Gradle Plugin does not throw an error regarding missing properties, as we do not use these properties when signing on Circle CI.

It also updates the Circle CI config to ensure the signing project properties are correctly set based on environment variables.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
