### PR TITLE
Add AuthenticationException.isTooManyAttempts error

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
@@ -194,6 +194,10 @@ public class AuthenticationException : Auth0Exception {
     public val isIdTokenValidationError: Boolean
         get() = cause is TokenValidationException
 
+    /// When the user is blocked due to too many attempts to log in
+    public val isTooManyAttempts: Boolean
+        get() = "too_many_attempts" == code
+
     internal companion object {
         internal const val ERROR_VALUE_AUTHENTICATION_CANCELED = "a0.authentication_canceled"
         private const val ERROR_KEY = "error"

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
@@ -484,6 +484,15 @@ public class AuthenticationExceptionTest {
         MatcherAssert.assertThat(ex.isRefreshTokenDeleted, CoreMatchers.`is`(true))
     }
 
+    @Test
+    public fun shouldHaveTooManyAttempts() {
+        values[CODE_KEY] = "too_many_attempts"
+        val ex = AuthenticationException(
+            values
+        )
+        MatcherAssert.assertThat(ex.isTooManyAttempts, CoreMatchers.`is`(true))
+    }
+
     private companion object {
         private const val PASSWORD_STRENGTH_ERROR_RESPONSE =
             "src/test/resources/password_strength_error.json"


### PR DESCRIPTION
### Changes

This change adds a convenience method `isTooManyAttempts` to the AuthenticationException class to match the Auth0.Swift implementation.

### References
https://github.com/auth0/Auth0.swift/blob/568f15ee30a5d911a24e3bd75de8297bd5a87e28/Auth0/AuthenticationError.swift#L109

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [ X] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ X] All existing and new tests complete without errors
