### PR TITLE
Remove old encryption keys from KeyStore & storage when cleaning up on failure.

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
@@ -238,6 +238,7 @@ class CryptoUtil {
             KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
             keyStore.load(null);
             keyStore.deleteEntry(KEY_ALIAS);
+            keyStore.deleteEntry(OLD_KEY_ALIAS);
             Log.d(TAG, "Deleting the existing RSA key pair from the KeyStore.");
         } catch (KeyStoreException | CertificateException | IOException | NoSuchAlgorithmException e) {
             Log.e(TAG, "Failed to remove the RSA KeyEntry from the Android KeyStore.", e);
@@ -252,6 +253,8 @@ class CryptoUtil {
     private void deleteAESKeys() {
         storage.remove(KEY_ALIAS);
         storage.remove(KEY_IV_ALIAS);
+        storage.remove(OLD_KEY_ALIAS);
+        storage.remove(OLD_KEY_IV_ALIAS);
     }
 
     /**


### PR DESCRIPTION
* Remove old encryption keys from KeyStore & storage when cleaning up on failure.
* Update tests, including various tests that were failing to verify what they thought they were verifying.

The background here is we were getting reports of users being unable to sign in with valid credentials, and we traced it to the scenario of the lock screen settings change causing the KeyStore needing to be reset. However these users also had had our app long enough that their keys were stored using the older key aliases, and the logic to clean up and allow for retry after the first CredentialsManagerException was failing to account for this combination, and the retry would fail in the same way because those older keys were still present.

In updating the tests to include verification of the new desired behavior, I identified that many of the CryptoUtil tests used a pattern of verifying within an exception verification block after the exception was thrown, causing those verify steps to be skipped. I updated those tests to move the verify steps outside of the exception verification block. This resulted in one test now failing unrelated to my changes. I broke that test into 2 tests to account for the failure. I also updated the names of a few tests that were claiming to validate one outcome but were actually validating a different outcome.

### References

See issue #618 

### Testing

- [x] This change adds unit test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
