### PR TITLE
Allow `authorizeUrl` and `logoutUrl` customisation

### DIFF
--- a/auth0/src/main/java/com/auth0/android/Auth0.kt
+++ b/auth0/src/main/java/com/auth0/android/Auth0.kt
@@ -73,7 +73,7 @@ public open class Auth0 @JvmOverloads constructor(
      *
      * @return Url to call to perform the web flow of OAuth
      */
-    public val authorizeUrl: String
+    public open val authorizeUrl: String
         get() = domainUrl!!.newBuilder()
             .addEncodedPathSegment("authorize")
             .build()
@@ -84,7 +84,7 @@ public open class Auth0 @JvmOverloads constructor(
      *
      * @return Url to call to perform the web logout
      */
-    public val logoutUrl: String
+    public open val logoutUrl: String
         get() = domainUrl!!.newBuilder()
             .addEncodedPathSegment("v2")
             .addEncodedPathSegment("logout")

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -203,6 +203,20 @@ public class Auth0Test {
     }
 
     @Test
+    public void shouldAllowOverridingAuthorizeUrl() {
+        class MyAuth extends Auth0 {
+            public MyAuth() {
+                super(CLIENT_ID, DOMAIN);
+            }
+            @Override
+            public String getAuthorizeUrl() {
+                // Calling super to make sure it's fully visible as well as overridable.
+                return super.getAuthorizeUrl() + "something";
+            }
+        }
+    }
+
+    @Test
     public void shouldEnsureLogoutUrlIsOpen() throws NoSuchMethodException {
         Method method = Auth0.class.getMethod("getLogoutUrl");
         Assert.assertTrue(Modifier.isPublic(method.getModifiers()));

--- a/auth0/src/test/java/com/auth0/android/Auth0Test.java
+++ b/auth0/src/test/java/com/auth0/android/Auth0Test.java
@@ -26,6 +26,9 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
 @RunWith(RobolectricTestRunner.class)
 public class Auth0Test {
 
@@ -190,5 +193,19 @@ public class Auth0Test {
     @Test
     public void shouldThrowWhenConfigDomainIsHttp() {
         Assert.assertThrows("Invalid domain url: 'http://" + OTHER_DOMAIN + "'. Only HTTPS domain URLs are supported. If no scheme is passed, HTTPS will be used.", IllegalArgumentException.class, () -> new Auth0(CLIENT_ID, DOMAIN, "HTTP://" + OTHER_DOMAIN));
+    }
+
+    @Test
+    public void shouldEnsureAuthorizeUrlIsOpen() throws NoSuchMethodException {
+        Method method = Auth0.class.getMethod("getAuthorizeUrl");
+        Assert.assertTrue(Modifier.isPublic(method.getModifiers()));
+        Assert.assertFalse(Modifier.isFinal(method.getModifiers()));
+    }
+
+    @Test
+    public void shouldEnsureLogoutUrlIsOpen() throws NoSuchMethodException {
+        Method method = Auth0.class.getMethod("getLogoutUrl");
+        Assert.assertTrue(Modifier.isPublic(method.getModifiers()));
+        Assert.assertFalse(Modifier.isFinal(method.getModifiers()));
     }
 }

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -53,6 +53,7 @@ import java.lang.reflect.Modifier
 import java.util.*
 import java.util.concurrent.Executor
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 public class SecureCredentialsManagerTest {
@@ -1687,7 +1688,7 @@ public class SecureCredentialsManagerTest {
     public fun shouldBeMarkedSynchronous(){
         val method =
             SecureCredentialsManager::class.java.getMethod("saveCredentials", Credentials::class.java)
-        Modifier.isSynchronized(method.modifiers)
+        assertTrue(Modifier.isSynchronized(method.modifiers))
     }
 
     /*


### PR DESCRIPTION
### Changes

We will open up `authorizeUrl` and `logoutUrl`. This has been a request from the community who use this SDK for other IdP.

(Also fixed another related test)

### References

https://github.com/auth0/Auth0.Android/issues/617
https://github.com/auth0/Auth0.Android/issues/611

### Testing
We have added unit tests to ensure these methods are non final and accessible publically

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
