### PR TITLE
Gson crashes when minified with R8 strict mode

### DIFF
--- a/proguard/proguard-gson.pro
+++ b/proguard/proguard-gson.pro
@@ -8,7 +8,9 @@
 #R8
 # - See https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md
 # - See https://medium.com/@harryaung/mysterious-null-crash-with-gson-serializedname-fields-when-r8-proguard-is-on-f8a4bd036e34
--keepclassmembers,allowobfuscation class * {
+-if class *
+-keepclasseswithmembers class <1> {
+  <init>(...);
   @com.google.gson.annotations.SerializedName <fields>;
 }
 -keep,allowobfuscation @interface com.google.gson.annotations.SerializedName


### PR DESCRIPTION
The proguard rules are not exhaustive enough, and crash when running R8 in strict mode.

Here `<init>()` is being accessed by reflection but not kept: https://github.com/auth0/Auth0.Android/blob/801140e41e2288060d96f683cf3bbd6040a4b48a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt#L436

Example stacktrace:

```
java.lang.RuntimeException: Unable to create instance of class mdi.sdk.jr5. Registering an InstanceCreator or a TypeAdapter for this type, or adding a no-args constructor may fix this problem.
    com.google.gson.internal.ConstructorConstructor$16.construct(ConstructorConstructor.java:275)
    com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:211)
    com.auth0.android.request.internal.JsonRequiredTypeAdapterFactory$1.read(JsonRequiredTypeAdapterFactory.java:31)
    com.google.gson.TypeAdapter$1.read(TypeAdapter.java:199)
    com.google.gson.Gson.fromJson(Gson.java:991)
    com.google.gson.Gson.fromJson(Gson.java:956)
    com.google.gson.Gson.fromJson(Gson.java:905)
    com.google.gson.Gson.fromJson(Gson.java:876)
    com.auth0.android.authentication.storage.SecureCredentialsManager.continueGetCredentials$lambda-3(SecureCredentialsManager.java:436)
    com.auth0.android.authentication.storage.SecureCredentialsManager$$InternalSyntheticLambda$1$c09ebe59feb1659569cade6fd369c5089a7c5416c6136c04dd1d923283ecba7f$0.run(SecureCredentialsManager.java:85)
    java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
    java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
    java.lang.Thread.run(Thread.java:1012)
Caused by: java.lang.UnsupportedOperationException: Abstract class can't be instantiated! Class name: mdi.sdk.jr5
    com.google.gson.internal.UnsafeAllocator.assertInstantiable(UnsafeAllocator.java:121)
    com.google.gson.internal.UnsafeAllocator$1.newInstance(UnsafeAllocator.java:49)
    com.google.gson.internal.ConstructorConstructor$16.construct(ConstructorConstructor.java:272)
    com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:211)
    com.auth0.android.request.internal.JsonRequiredTypeAdapterFactory$1.read(JsonRequiredTypeAdapterFactory.java:31)
    com.google.gson.TypeAdapter$1.read(TypeAdapter.java:199)
    com.google.gson.Gson.fromJson(Gson.java:991)
    com.google.gson.Gson.fromJson(Gson.java:956)
    com.google.gson.Gson.fromJson(Gson.java:905)
    com.google.gson.Gson.fromJson(Gson.java:876)
    com.auth0.android.authentication.storage.SecureCredentialsManager.continueGetCredentials$lambda-3(SecureCredentialsManager.java:436)
    com.auth0.android.authentication.storage.SecureCredentialsManager$$InternalSyntheticLambda$1$c09ebe59feb1659569cade6fd369c5089a7c5416c6136c04dd1d923283ecba7f$0.run(SecureCredentialsManager.java:85)
    java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
    java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
    java.lang.Thread.run(Thread.java:1012)

```

Reproduced on AGP 7.4.0

### Changes

Updated proguard rules to the ones suggested by Google.

### References

[Relevant Issue Tracker Bug](https://issuetracker.google.com/issues/150189783#comment11)

### Testing

Build release version of app that uses `SecureCredentialsManager` and run.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
