### PR TITLE
Add Invalid refresh token flag

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
@@ -190,6 +190,11 @@ public class AuthenticationException : Auth0Exception {
                 && 403 == statusCode
                 && "The refresh_token was generated for a user who doesn't exist anymore." == description
 
+    // When the provided refresh token is invalid or expired
+    public val isInvalidRefreshToken: Boolean
+        get() = "invalid_grant" == code
+                && "Unknown or invalid refresh token." == description
+
     // ID token validation error
     public val isIdTokenValidationError: Boolean
         get() = cause is TokenValidationException

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
@@ -485,6 +485,15 @@ public class AuthenticationExceptionTest {
     }
 
     @Test
+    public fun shouldHaveRefreshTokenInvalid() {
+        values[ERROR_KEY] = "invalid_grant"
+        values[ERROR_DESCRIPTION_KEY] =
+            "Unknown or invalid refresh token."
+        val ex = AuthenticationException(values)
+        MatcherAssert.assertThat(ex.isInvalidRefreshToken, CoreMatchers.`is`(true))
+    }
+
+    @Test
     public fun shouldHaveTooManyAttempts() {
         values[CODE_KEY] = "too_many_attempts"
         val ex = AuthenticationException(


### PR DESCRIPTION
### Changes

Added `isInvalidRefreshToken` to `AuthenticationException`  to detect invalid or expired Refresh Tokens

### References

https://github.com/auth0/Auth0.Android/issues/625

### Testing
- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not
