### PR TITLE
Added forceRefresh option to getCredentials

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -97,11 +97,34 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
         minTtl: Int,
         parameters: Map<String, String>
     ): Credentials {
+        return awaitCredentials(scope, minTtl, parameters, false)
+    }
+
+    /**
+     * Retrieves the credentials from the storage and refresh them if they have already expired.
+     * It will throw [CredentialsManagerException] if the saved access_token or id_token is null,
+     * or if the tokens have already expired and the refresh_token is null.
+     * This is a Coroutine that is exposed only for Kotlin.
+     *
+     * @param scope    the scope to request for the access token. If null is passed, the previous scope will be kept.
+     * @param minTtl   the minimum time in seconds that the access token should last before expiration.
+     * @param parameters additional parameters to send in the request to refresh expired credentials
+     * @param forceRefresh This will avoid returning the existing credentials and retrieves a new one even if valid credentials exist.
+     */
+    @JvmSynthetic
+    @Throws(CredentialsManagerException::class)
+    public suspend fun awaitCredentials(
+        scope: String?,
+        minTtl: Int,
+        parameters: Map<String, String>,
+        forceRefresh: Boolean
+    ): Credentials {
         return suspendCancellableCoroutine { continuation ->
             getCredentials(
                 scope,
                 minTtl,
                 parameters,
+                forceRefresh,
                 object : Callback<Credentials, CredentialsManagerException> {
                     override fun onSuccess(result: Credentials) {
                         continuation.resume(result)
@@ -158,6 +181,27 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
         parameters: Map<String, String>,
         callback: Callback<Credentials, CredentialsManagerException>
     ) {
+        getCredentials(scope, minTtl, parameters, false, callback)
+    }
+
+    /**
+     * Retrieves the credentials from the storage and refresh them if they have already expired.
+     * It will fail with [CredentialsManagerException] if the saved access_token or id_token is null,
+     * or if the tokens have already expired and the refresh_token is null.
+     *
+     * @param scope    the scope to request for the access token. If null is passed, the previous scope will be kept.
+     * @param minTtl   the minimum time in seconds that the access token should last before expiration.
+     * @param parameters additional parameters to send in the request to refresh expired credentials.
+     * @param forceRefresh This will avoid returning the existing credentials and retrieves a new one even if valid credentials exist.
+     * @param callback the callback that will receive a valid [Credentials] or the [CredentialsManagerException].
+     */
+    public fun getCredentials(
+        scope: String?,
+        minTtl: Int,
+        parameters: Map<String, String>,
+        forceRefresh: Boolean,
+        callback: Callback<Credentials, CredentialsManagerException>
+    ) {
         serialExecutor.execute {
             val accessToken = storage.retrieveString(KEY_ACCESS_TOKEN)
             val refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN)
@@ -173,7 +217,7 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
             }
             val willAccessTokenExpire = willExpire(expiresAt!!, minTtl.toLong())
             val scopeChanged = hasScopeChanged(storedScope, scope)
-            if (!willAccessTokenExpire && !scopeChanged) {
+            if (!forceRefresh && !willAccessTokenExpire && !scopeChanged) {
                 callback.onSuccess(
                     recreateCredentials(
                         idToken.orEmpty(),

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -54,6 +54,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     private var authIntent: Intent? = null
     private var scope: String? = null
     private var minTtl = 0
+    private var forceRefresh = false
 
     /**
      * Creates a new SecureCredentialsManager to handle Credentials
@@ -145,7 +146,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
             return false
         }
         if (resultCode == Activity.RESULT_OK) {
-            continueGetCredentials(scope, minTtl, emptyMap(), decryptCallback!!)
+            continueGetCredentials(scope, minTtl, emptyMap(), forceRefresh, decryptCallback!!)
         } else {
             decryptCallback!!.onFailure(CredentialsManagerException("The user didn't pass the authentication challenge."))
             decryptCallback = null
@@ -255,11 +256,38 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         minTtl: Int,
         parameters: Map<String, String>
     ): Credentials {
+        return awaitCredentials(scope, minTtl, parameters, false)
+    }
+
+    /**
+     * Tries to obtain the credentials from the Storage. The method will return [Credentials].
+     * If something unexpected happens, then [CredentialsManagerException] exception will be thrown. Some devices are not compatible
+     * at all with the cryptographic implementation and will have [CredentialsManagerException.isDeviceIncompatible] return true.
+     * This is a Coroutine that is exposed only for Kotlin.
+     *
+     * If a LockScreen is setup and [SecureCredentialsManager.requireAuthentication] was called, the user will be asked to authenticate before accessing
+     * the credentials. Your activity must override the [Activity.onActivityResult] method and call
+     * [SecureCredentialsManager.checkAuthenticationResult] with the received values.
+     *
+     * @param scope    the scope to request for the access token. If null is passed, the previous scope will be kept.
+     * @param minTtl   the minimum time in seconds that the access token should last before expiration.
+     * @param parameters additional parameters to send in the request to refresh expired credentials
+     * @param forceRefresh This will avoid returning the existing credentials and retrieves a new one even if valid credentials exist.
+     */
+    @JvmSynthetic
+    @Throws(CredentialsManagerException::class)
+    public suspend fun awaitCredentials(
+        scope: String?,
+        minTtl: Int,
+        parameters: Map<String, String>,
+        forceRefresh: Boolean,
+    ): Credentials {
         return suspendCancellableCoroutine { continuation ->
             getCredentials(
                 scope,
                 minTtl,
                 parameters,
+                forceRefresh,
                 object : Callback<Credentials, CredentialsManagerException> {
                     override fun onSuccess(result: Credentials) {
                         continuation.resume(result)
@@ -331,6 +359,32 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         parameters: Map<String, String>,
         callback: Callback<Credentials, CredentialsManagerException>
     ) {
+        getCredentials(scope, minTtl, parameters, false, callback)
+    }
+
+    /**
+     * Tries to obtain the credentials from the Storage. The callback's [Callback.onSuccess] method will be called with the result.
+     * If something unexpected happens, the [Callback.onFailure] method will be called with the error. Some devices are not compatible
+     * at all with the cryptographic implementation and will have [CredentialsManagerException.isDeviceIncompatible] return true.
+     *
+     *
+     * If a LockScreen is setup and [SecureCredentialsManager.requireAuthentication] was called, the user will be asked to authenticate before accessing
+     * the credentials. Your activity must override the [Activity.onActivityResult] method and call
+     * [SecureCredentialsManager.checkAuthenticationResult] with the received values.
+     *
+     * @param scope    the scope to request for the access token. If null is passed, the previous scope will be kept.
+     * @param minTtl   the minimum time in seconds that the access token should last before expiration.
+     * @param parameters additional parameters to send in the request to refresh expired credentials.
+     * @param forceRefresh This will avoid returning the existing credentials and retrieves a new one even if valid credentials exist.
+     * @param callback the callback to receive the result in.
+     */
+    public fun getCredentials(
+        scope: String?,
+        minTtl: Int,
+        parameters: Map<String, String>,
+        forceRefresh: Boolean,
+        callback: Callback<Credentials, CredentialsManagerException>
+    ) {
         if (!hasValidCredentials(minTtl.toLong())) {
             callback.onFailure(CredentialsManagerException("No Credentials were previously set."))
             return
@@ -343,11 +397,12 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
             decryptCallback = callback
             this.scope = scope
             this.minTtl = minTtl
+            this.forceRefresh = forceRefresh
             activityResultContract?.launch(authIntent)
                 ?: activity?.startActivityForResult(authIntent, authenticationRequestCode)
             return
         }
-        continueGetCredentials(scope, minTtl, parameters, callback)
+        continueGetCredentials(scope, minTtl, parameters, forceRefresh, callback)
     }
 
     /**
@@ -396,6 +451,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         scope: String?,
         minTtl: Int,
         parameters: Map<String, String>,
+        forceRefresh: Boolean,
         callback: Callback<Credentials, CredentialsManagerException>
     ) {
         serialExecutor.execute {
@@ -456,7 +512,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
             }
             val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
             val scopeChanged = hasScopeChanged(credentials.scope, scope)
-            if (!willAccessTokenExpire && !scopeChanged) {
+            if (!forceRefresh && !willAccessTokenExpire && !scopeChanged) {
                 callback.onSuccess(credentials)
                 decryptCallback = null
                 return@execute

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -1009,9 +1009,9 @@ public class CredentialsManagerTest {
         val jwtMock = mock<Jwt>()
         Mockito.`when`(jwtMock.expiresAt).thenReturn(newDate)
         Mockito.`when`(jwtDecoder.decode("newId")).thenReturn(jwtMock)
-        val renewedCredentials =
+        val expectedCredentials =
             Credentials("newId", "newAccess", "newType", "newRefresh", newDate, "oldscope")
-        Mockito.`when`(request.execute()).thenReturn(renewedCredentials)
+        Mockito.`when`(request.execute()).thenReturn(expectedCredentials)
         manager.getCredentials(
             scope = "oldscope",
             minTtl = 0,
@@ -1020,6 +1020,17 @@ public class CredentialsManagerTest {
             callback = callback
         )
         verify(request).execute()
+
+        verify(callback).onSuccess(credentialsCaptor.capture())
+        val retrievedCredentials = credentialsCaptor.firstValue
+        MatcherAssert.assertThat(retrievedCredentials, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(retrievedCredentials.accessToken, Is.`is`(expectedCredentials.accessToken))
+        MatcherAssert.assertThat(retrievedCredentials.idToken, Is.`is`(expectedCredentials.idToken))
+        MatcherAssert.assertThat(retrievedCredentials.refreshToken, Is.`is`(expectedCredentials.refreshToken))
+        MatcherAssert.assertThat(retrievedCredentials.type, Is.`is`(expectedCredentials.type))
+        MatcherAssert.assertThat(retrievedCredentials.expiresAt, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(retrievedCredentials.expiresAt.time, Is.`is`(expectedCredentials.expiresAt.time))
+        MatcherAssert.assertThat(retrievedCredentials.scope, Is.`is`(expectedCredentials.scope))
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -1720,6 +1720,16 @@ public class SecureCredentialsManagerTest {
             callback = callback
         )
         verify(request).execute()
+        verify(callback).onSuccess(credentialsCaptor.capture())
+        val retrievedCredentials = credentialsCaptor.firstValue
+        MatcherAssert.assertThat(retrievedCredentials, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(retrievedCredentials.accessToken, Is.`is`(expectedCredentials.accessToken))
+        MatcherAssert.assertThat(retrievedCredentials.idToken, Is.`is`(expectedCredentials.idToken))
+        MatcherAssert.assertThat(retrievedCredentials.refreshToken, Is.`is`(expectedCredentials.refreshToken))
+        MatcherAssert.assertThat(retrievedCredentials.type, Is.`is`(expectedCredentials.type))
+        MatcherAssert.assertThat(retrievedCredentials.expiresAt, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(retrievedCredentials.expiresAt.time, Is.`is`(expectedCredentials.expiresAt.time))
+        MatcherAssert.assertThat(retrievedCredentials.scope, Is.`is`(expectedCredentials.scope))
     }
 
     @Test


### PR DESCRIPTION
### Changes

We have added a new method that will allow us to force refresh tokens. This has been requested and discussed in the issue below. This feature is also useful in [react-native-auth0](https://github.com/auth0/react-native-auth0/) to update user object by force as requested [here](https://github.com/auth0/react-native-auth0/issues/572) 

### References

https://github.com/auth0/Auth0.Android/issues/614

https://github.com/auth0/react-native-auth0/issues/572

### Testing

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not