### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 Android API version 31 or later and Java 8+.
 
-> :warning: For Apps compiling and targeting using Android SDK version 30 and below can use Auth0.Android version 2.9.0
+> :warning: Applications targeting Android SDK version 30 and below should use version 2.9.0.
 
 Here’s what you need in `build.gradle` to target Java 8 byte code for Android and Kotlin plugins respectively.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@
 
 ### Requirements
 
-Android API version 21 or later and Java 8+.
+Android API version 31 or later and Java 8+.
+
+> :warning: For Apps compiling and targeting using Android SDK version 30 and below can use Auth0.Android version 2.9.0
 
 Here’s what you need in `build.gradle` to target Java 8 byte code for Android and Kotlin plugins respectively.
 

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -103,14 +103,14 @@ javadocJar {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'androidx.browser:browser:1.3.0'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.browser:browser:1.5.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.2.2'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.4.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
@@ -124,7 +124,7 @@ dependencies {
     testImplementation "com.squareup.okhttp3:okhttp-tls:$okhttpVersion"
     testImplementation 'com.jayway.awaitility:awaitility:1.7.0'
     testImplementation 'org.robolectric:robolectric:4.6.1'
-    testImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
+    testImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
 }
 

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -49,12 +49,11 @@ oss {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName project.version
 
@@ -103,9 +102,9 @@ javadocJar {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.browser:browser:1.5.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.browser:browser:1.4.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,12 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:label="@string/app_name"
         android:theme="@style/Theme.Auth0Android.NoActionBar"
         android:allowBackup="false">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
### Changes

- We have updated dependencies. This is due to an [issue](https://github.com/auth0/Auth0.Android/issues/640) in  `androidx.browser` that made us update to 1.4.0. 
- Updated other dependencies as well as cleanup

### ⚠️ Breaking Change
This version of Auth0.Android enables developers to use the library when building projects that target the API level 31. 

Developers using this version of Auth0.Android will need to update the the compileSdkVersion in their build.gradle to version 31. It's still possible to use targetSdkVersion lower than 31, but it's recommended to migrate as soon as possible.

When migrating to targetSdkVersion 31 and targeting Android 12 or higher, activities, services, or broadcast receivers that use intent filters, [must now explicitly declare the android:exported ](https://developer.android.com/about/versions/12/behavior-changes-12#exported)attribute for these app components.

### References

https://github.com/auth0/Auth0.Android/issues/640

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not
