### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,17 @@ WebAuthProvider.login(account)
     .withScheme("myapp")
     .start(this, callback)
 ```
-
 > Note that the schemes [can only have lowercase letters](https://developer.android.com/guide/topics/manifest/data-element).
+
+#### Always require the user to login on the web
+If you want the user to always be prompted to log in whenever he opens the WebAuth flow, use the `.withParameters` function on the `WebAuthProvider.Builder` providing a map with `"prompt"` as `key` and `"login"` as `value. This will force the webpage to ignore a valid login don previously and ask the user to authenticate again.
+
+```kotlin
+WebAuthProvider.login(account)
+    .withParameters(mapOf("prompt" to "login"))
+    .start(this, callback)
+```
+
 
 ### Clearing the session
 


### PR DESCRIPTION
### Changes

Added in the documentation how to force-request the user to log in each time the WebView is opened.
This is somehow documented[here](https://github.com/auth0/Auth0.swift/blob/master/FAQ.md#4-how-can-i-programmatically-close-the-alert-box) for the iOS version of the Auth0 SDK.
I think t would be nice to have it documented here as well., can become useful to someone.