### PR TITLE
Added documentation to use parameter

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -5,6 +5,7 @@
   - [Specify audience](#specify-audience)
   - [Specify scope](#specify-scope)
   - [Specify Connection scope](#specify-connection-scope)
+  - [Specify Parameter](#specify-parameter)
   - [Customize the Custom Tabs UI](#customize-the-custom-tabs-ui)
   - [Changing the Return To URL scheme](#changing-the-return-to-url-scheme)
   - [Trusted Web Activity](#trusted-web-activity-experimental)
@@ -78,6 +79,16 @@ WebAuthProvider.login(account)
 ```kotlin
 WebAuthProvider.login(account)
     .withConnectionScope("email", "profile", "calendar:read")
+    .start(this, callback)
+```
+
+## Specify Parameter
+
+To [prompt](https://auth0.com/docs/customize/universal-login-pages/customize-login-text-prompts#prompt-values) the user to login or to send custom parameters in the request, `.withParameters` method can be used.
+
+```kotlin
+WebAuthProvider.login(account)
+    .withParameters(mapOf("prompt" to "login", "custom" to "value"))
     .start(this, callback)
 ```
 


### PR DESCRIPTION
### Changes
We had a PR to add guidance on how to use prompts to open login screen instead of direct login. We were not able to directly make changes to the PR so we made the following changes and added to the documentation on how to use parameters to send custom values or to use prompts.

### References
https://github.com/auth0/Auth0.Android/pull/642
