### PR TITLE
Fixed wrong README info

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 Android API version 31 or later and Java 8+.
 
-> :warning: Applications targeting Android SDK version 30 and below should use version 2.9.1.
+> :warning: Applications targeting Android SDK version 30 and below should use version 2.9.0.
 
 Here’s what you need in `build.gradle` to target Java 8 byte code for Android and Kotlin plugins respectively.
 


### PR DESCRIPTION
The tooling has updated the README notice by mistake. We have fixed this to provide proper version.