### PR TITLE
Added rule to support Proguard in full mode

### DIFF
--- a/proguard/proguard-gson.pro
+++ b/proguard/proguard-gson.pro
@@ -14,3 +14,5 @@
   @com.google.gson.annotations.SerializedName <fields>;
 }
 -keep,allowobfuscation @interface com.google.gson.annotations.SerializedName
+-keep class com.google.gson.reflect.TypeToken { *; }
+-keep class * extends com.google.gson.reflect.TypeToken


### PR DESCRIPTION
### Changes
We have added new rules for Proguard to work in full mode. We were not able to reproduce this but it is recommended in the [documentation](https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#troubleshooting-gson-gson) and reported [here](https://github.com/auth0/Auth0.Android/issues/647)


### References
https://github.com/auth0/Auth0.Android/issues/647
https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#troubleshooting-gson-gson