### PR TITLE
Add required scopes to token and renewAuth requests

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -555,7 +555,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @return a request to start
      */
     public fun renewAuth(refreshToken: String): Request<Credentials, AuthenticationException> {
-        val parameters = ParameterBuilder.newBuilder()
+        val parameters = ParameterBuilder.newBuilderWithRequiredScope()
             .setClientId(clientId)
             .setRefreshToken(refreshToken)
             .setGrantType(ParameterBuilder.GRANT_TYPE_REFRESH_TOKEN)
@@ -690,7 +690,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         codeVerifier: String,
         redirectUri: String
     ): Request<Credentials, AuthenticationException> {
-        val parameters = ParameterBuilder.newBuilder()
+        val parameters = ParameterBuilder.newBuilderWithRequiredScope()
             .setClientId(clientId)
             .setGrantType(ParameterBuilder.GRANT_TYPE_AUTHORIZATION_CODE)
             .set(OAUTH_CODE_KEY, authorizationCode)

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
@@ -181,6 +181,12 @@ public class ParameterBuilder private constructor(parameters: Map<String, String
                 .setScope(OidcUtils.DEFAULT_SCOPE)
         }
 
+        @JvmStatic
+        public fun newBuilderWithRequiredScope(): ParameterBuilder {
+            return newBuilder()
+                .setScope(OidcUtils.REQUIRED_SCOPE)
+        }
+
         /**
          * Creates a new instance of the builder.
          *

--- a/auth0/src/main/java/com/auth0/android/request/internal/OidcUtils.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/OidcUtils.kt
@@ -1,5 +1,6 @@
 package com.auth0.android.request.internal
 
+import androidx.annotation.VisibleForTesting
 import java.util.*
 
 /**
@@ -8,7 +9,8 @@ import java.util.*
 internal object OidcUtils {
     internal const val KEY_SCOPE = "scope"
     internal const val DEFAULT_SCOPE = "openid profile email"
-    private const val REQUIRED_SCOPE = "openid"
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal const val REQUIRED_SCOPE = "openid"
 
     /**
      * Given a string, it will check if it contains the scope of "openid".

--- a/auth0/src/main/java/com/auth0/android/request/internal/OidcUtils.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/OidcUtils.kt
@@ -9,7 +9,6 @@ import java.util.*
 internal object OidcUtils {
     internal const val KEY_SCOPE = "scope"
     internal const val DEFAULT_SCOPE = "openid profile email"
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal const val REQUIRED_SCOPE = "openid"
 
     /**

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -9,6 +9,7 @@ import com.auth0.android.request.HttpMethod
 import com.auth0.android.request.NetworkingClient
 import com.auth0.android.request.RequestOptions
 import com.auth0.android.request.ServerResponse
+import com.auth0.android.request.internal.OidcUtils
 import com.auth0.android.request.internal.RequestFactory
 import com.auth0.android.request.internal.ThreadSwitcherShadow
 import com.auth0.android.result.*
@@ -2200,7 +2201,7 @@ public class AuthenticationAPIClientTest {
         )
         assertThat(request.path, Matchers.equalTo("/oauth/token"))
         val body = bodyFromRequest<String>(request)
-        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
+        assertThat(body, Matchers.hasEntry("scope", OidcUtils.REQUIRED_SCOPE))
         assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
         assertThat(body, Matchers.hasEntry("refresh_token", "refreshToken"))
         assertThat(body, Matchers.hasEntry("grant_type", "refresh_token"))
@@ -2229,7 +2230,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
         assertThat(body, Matchers.hasEntry("refresh_token", "refreshToken"))
         assertThat(body, Matchers.hasEntry("grant_type", "refresh_token"))
-        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
+        assertThat(body, Matchers.hasEntry("scope", OidcUtils.REQUIRED_SCOPE))
         assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
     }
 
@@ -2252,7 +2253,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
         assertThat(body, Matchers.hasEntry("refresh_token", "refreshToken"))
         assertThat(body, Matchers.hasEntry("grant_type", "refresh_token"))
-        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
+        assertThat(body, Matchers.hasEntry("scope", OidcUtils.REQUIRED_SCOPE))
         assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
     }
 
@@ -2363,6 +2364,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("code", "code"))
         assertThat(body, Matchers.hasEntry("code_verifier", "codeVerifier"))
         assertThat(body, Matchers.hasEntry("redirect_uri", "http://redirect.uri"))
+        assertThat(body, Matchers.hasEntry("scope", OidcUtils.REQUIRED_SCOPE))
         assertThat(
             callback, AuthenticationCallbackMatcher.hasPayloadOfType(
                 Credentials::class.java
@@ -2388,6 +2390,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("code", "code"))
         assertThat(body, Matchers.hasEntry("code_verifier", "codeVerifier"))
         assertThat(body, Matchers.hasEntry("redirect_uri", "http://redirect.uri"))
+        assertThat(body, Matchers.hasEntry("scope", OidcUtils.REQUIRED_SCOPE))
         assertThat(
             callback, AuthenticationCallbackMatcher.hasError(
                 Credentials::class.java


### PR DESCRIPTION
### Changes
We have added required scope to `renewAuth` and `token` requests in `AuthenticationAPIClient`. Up until now these methods wouldn't have worked without adding scope "openid" to the request. This didn't have effect on internal usage as we always added the default scopes. But usage outside through the API client will fail always until the scope is added.

### References
https://github.com/auth0/Auth0.Android/issues/648

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not
