### PR TITLE
[ESD-28245] Fix not propagating error values from server

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -208,8 +208,8 @@ internal class OAuthManager(
             }
             else -> {
                 throw AuthenticationException(
-                    ERROR_VALUE_INVALID_CONFIGURATION,
-                    "The application isn't configured properly for the social connection. Please check your Auth0's application configuration"
+                    errorValue,
+                    errorDescription ?: "An unexpected error occurred."
                 )
             }
         }

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -1428,8 +1428,8 @@ public class WebAuthProviderTest {
                 "urlType",
                 1111L,
                 "1234567890",
-                "some other error",
-                null,
+                "a0.invalid_configuration",
+                "The application isn't configured properly for the social connection. Please check your Auth0's application configuration",
                 null
             )
         )


### PR DESCRIPTION
### Changes
Currently any error values we receive from the server are swallowed on the SDK side. This is avoiding users from getting intuitive error messages that can help them fix the integration

### References
ESD-28245

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not
