### PR TITLE
Consider SocketException as network error

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
@@ -7,6 +7,7 @@ import com.auth0.android.NetworkErrorException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import com.auth0.android.provider.TokenValidationException
+import java.net.SocketException
 
 public class AuthenticationException : Auth0Exception {
     private var code: String? = null
@@ -108,6 +109,7 @@ public class AuthenticationException : Auth0Exception {
         get() = cause is NetworkErrorException
                 || cause?.cause is UnknownHostException
                 || cause?.cause is SocketTimeoutException
+                || cause?.cause is SocketException
 
     // When there is no Browser app installed to handle the web authentication
     public val isBrowserAppNotAvailable: Boolean

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.io.FileReader
 import java.io.IOException
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.*
@@ -216,6 +217,16 @@ public class AuthenticationExceptionTest {
         val ex = AuthenticationException(
             "Request has definitely failed", NetworkErrorException(
                 UnknownHostException()
+            )
+        )
+        MatcherAssert.assertThat(ex.isNetworkError, CoreMatchers.`is`(true))
+    }
+
+    @Test
+    public fun shouldHaveNetworkErrorForSocketException() {
+        val ex = AuthenticationException(
+            "Request has definitely failed", NetworkErrorException(
+                SocketException()
             )
         )
         MatcherAssert.assertThat(ex.isNetworkError, CoreMatchers.`is`(true))


### PR DESCRIPTION
### Changes
Currently NetworkErrorException is not working properly. The following comment is added for it to be fixed in the next major

    // When the request failed due to network issues
    // Currently [NetworkErrorException] is not properly thrown from [createErrorAdapter] in
    // [AuthenticationAPIClient] and [UserAPIClient]. This will be fixed in the next major to avoid
    // breaking change in the current major. We are not using IOException to check for the error
    // since it is too broad.

As it can be seen in the previous PR - https://github.com/auth0/Auth0.Android/pull/235. NetworkErrorException should be thrown if OkHttp fails because of network issues. But currently this is not being done

A valid issue was raised to conside SocketException as a network error - https://github.com/auth0/Auth0.Android/issues/657. We are fixing this by adding it to the assertion

### References
https://github.com/auth0/Auth0.Android/issues/657

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [X] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

