### PR TITLE
Release 2.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [2.9.3](https://github.com/auth0/Auth0.Android/tree/2.9.3) (2023-05-19)
+[Full Changelog](https://github.com/auth0/Auth0.Android/compare/2.9.2...2.9.3)
+
+**Fixed**
+- Consider SocketException as network error [\#659](https://github.com/auth0/Auth0.Android/pull/659) ([poovamraj](https://github.com/poovamraj))
+- [ESD-28245] Fix not propagating error values from server [\#658](https://github.com/auth0/Auth0.Android/pull/658) ([poovamraj](https://github.com/poovamraj))
+
 ## [2.9.2](https://github.com/auth0/Auth0.Android/tree/2.9.2) (2023-05-05)
 [Full Changelog](https://github.com/auth0/Auth0.Android/compare/2.9.1...2.9.2)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To install Auth0.Android with [Gradle](https://gradle.org/), simply add the foll
 
 ```gradle
 dependencies {
-    implementation 'com.auth0.android:auth0:2.9.2'
+    implementation 'com.auth0.android:auth0:2.9.3'
 }
 ```
 


### PR DESCRIPTION

**Fixed**
- Consider SocketException as network error [\#659](https://github.com/auth0/Auth0.Android/pull/659) ([poovamraj](https://github.com/poovamraj))
- [ESD-28245] Fix not propagating error values from server [\#658](https://github.com/auth0/Auth0.Android/pull/658) ([poovamraj](https://github.com/poovamraj))


[ESD-28245]: https://auth0team.atlassian.net/browse/ESD-28245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ