### PR TITLE
Add more error pairs to isMultifactorCodeInvalid [SDK-4194]

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
@@ -157,6 +157,8 @@ public class AuthenticationException : Auth0Exception {
     /// When MFA code sent is invalid or expired
     public val isMultifactorCodeInvalid: Boolean
         get() = "a0.mfa_invalid_code" == code || "invalid_grant" == code && "Invalid otp_code." == description
+                || code == "invalid_grant" && description == "Invalid binding_code."
+                || code == "invalid_grant" && description == "MFA Authorization rejected."
 
     /// When password used for SignUp does not match connection's strength requirements.
     public val isPasswordNotStrongEnough: Boolean

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
@@ -315,6 +315,26 @@ public class AuthenticationExceptionTest {
     }
 
     @Test
+    public fun shouldHaveInvalidMultifactorCodeForWrongBindingCode() {
+        values[ERROR_KEY] = "invalid_grant"
+        values[ERROR_DESCRIPTION_KEY] = "Invalid binding_code."
+        val ex = AuthenticationException(
+            values
+        )
+        MatcherAssert.assertThat(ex.isMultifactorCodeInvalid, CoreMatchers.`is`(true))
+    }
+
+    @Test
+    public fun shouldHaveInvalidMultifactorCodeWhenAuthorizationRejected() {
+        values[ERROR_KEY] = "invalid_grant"
+        values[ERROR_DESCRIPTION_KEY] = "MFA Authorization rejected."
+        val ex = AuthenticationException(
+            values
+        )
+        MatcherAssert.assertThat(ex.isMultifactorCodeInvalid, CoreMatchers.`is`(true))
+    }
+
+    @Test
     public fun shouldHaveInvalidMultifactorCode() {
         values[CODE_KEY] = "a0.mfa_invalid_code"
         val ex = AuthenticationException(


### PR DESCRIPTION
### 📋 Changes

This PR expands the pairs of **error code** + **error description** checked inside the `AuthenticationError` property `isMultifactorCodeInvalid`, to include the following pairs:

| Error code      | Error description             |
| --------------- | ----------------------------- |
| `invalid_grant` | `Invalid otp_code.`           |
| `invalid_grant` | `Invalid binding_code.`       |
| `invalid_grant` | `MFA Authorization rejected.` |

### 🎯 Testing

Besides adding unit tests for the new pairs, the changes were tested manually.