### PR TITLE
Return refreshed Credentials in CredentialsManagerException to avoid logout

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.kt
@@ -1,6 +1,7 @@
 package com.auth0.android.authentication.storage
 
 import com.auth0.android.Auth0Exception
+import com.auth0.android.result.Credentials
 
 /**
  * Represents an error raised by the [CredentialsManager].
@@ -18,4 +19,13 @@ public class CredentialsManagerException internal constructor(
      */
     public val isDeviceIncompatible: Boolean
         get() = cause is IncompatibleDeviceException
+
+    /**
+     * Returns the refreshed [Credentials] if exception is thrown right before saving them.
+     * This will avoid users being logged out unnecessarily and allows to handle failure case as needed
+     *
+     * Set incase [IncompatibleDeviceException] or [CryptoException] is thrown while saving the refreshed [Credentials]
+     */
+    public var refreshedCredentials: Credentials? = null
+        internal set
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -532,6 +532,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                 request.addParameter("scope", scope)
             }
 
+            var freshCredentials: Credentials? = null
             try {
                 val fresh = request.execute()
                 val expiresAt = fresh.expiresAt.time
@@ -554,7 +555,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                 //non-empty refresh token for refresh token rotation scenarios
                 val updatedRefreshToken =
                     if (TextUtils.isEmpty(fresh.refreshToken)) credentials.refreshToken else fresh.refreshToken
-                val refreshed = Credentials(
+                freshCredentials = Credentials(
                     fresh.idToken,
                     fresh.accessToken,
                     fresh.type,
@@ -562,9 +563,6 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                     fresh.expiresAt,
                     fresh.scope
                 )
-                saveCredentials(refreshed)
-                callback.onSuccess(refreshed)
-                decryptCallback = null
             } catch (error: Auth0Exception) {
                 callback.onFailure(
                     CredentialsManagerException(
@@ -572,6 +570,25 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                         error
                     )
                 )
+                decryptCallback = null
+            }
+
+            if (freshCredentials != null) {
+                try {
+                    saveCredentials(freshCredentials)
+                    callback.onSuccess(freshCredentials)
+                } catch (error: CredentialsManagerException) {
+                    val exception = CredentialsManagerException(
+                        "An error occurred while saving the refreshed Credentials.", error)
+                    if(error.cause is IncompatibleDeviceException || error.cause is CryptoException) {
+                        exception.refreshedCredentials = freshCredentials
+                    }
+                    callback.onFailure(exception)
+                }
+                decryptCallback = null
+            } else {
+                val exception = CredentialsManagerException("Received empty credentials.")
+                callback.onFailure(exception)
                 decryptCallback = null
             }
         }

--- a/auth0/src/main/java/com/auth0/android/result/Credentials.kt
+++ b/auth0/src/main/java/com/auth0/android/result/Credentials.kt
@@ -75,6 +75,10 @@ public open class Credentials(
     public var recoveryCode: String? = null
         internal set
 
+    override fun toString(): String {
+        return "Credentials(idToken='xxxxx', accessToken='xxxxx', type='$type', refreshToken='xxxxx', expiresAt='$expiresAt', scope='$scope')"
+    }
+
     public val user: UserProfile get() {
         val (_, payload) = Jwt.splitToken(idToken)
         val gson = GsonProvider.gson

--- a/auth0/src/test/java/com/auth0/android/result/CredentialsTest.kt
+++ b/auth0/src/test/java/com/auth0/android/result/CredentialsTest.kt
@@ -6,6 +6,7 @@ import org.hamcrest.Matchers
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.text.SimpleDateFormat
 import java.util.*
 
 private val idToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vbXktZG9tYWluLmF1dGgwLmNvbSIsInN1YiI6ImF1dGgwfDEyMzQ1NiIsImF1ZCI6Im15X2NsaWVudF9pZCIsImV4cCI6MTMxMTI4MTk3MCwiaWF0IjoxMzExMjgwOTcwLCJuYW1lIjoiSmFuZSBEb2UiLCJnaXZlbl9uYW1lIjoiSmFuZSIsImZhbWlseV9uYW1lIjoiRG9lIiwiZ2VuZGVyIjoiZmVtYWxlIiwiYmlydGhkYXRlIjoiMDAwMC0xMC0zMSIsImVtYWlsIjoiamFuZWRvZUBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJodHRwOi8vZXhhbXBsZS5jb20vamFuZWRvZS9tZS5qcGcifQ.FKw0UVWANEqibD9VTC9WLzstlyc_IRnyPSpUMDP3hKc"
@@ -65,5 +66,13 @@ public class CredentialsTest {
         MatcherAssert.assertThat(json, Matchers.not(Matchers.containsString("auth0|123456")))
         val obj = gson.fromJson(json, Credentials::class.java)
         MatcherAssert.assertThat(obj.user.getId(), Matchers.`is`("auth0|123456"))
+    }
+
+    @Test
+    public fun shouldNotPrintCredentials() {
+        val date = Date()
+        val credentials: Credentials =
+            CredentialsMock(idToken, "accessToken", "type", "refreshToken", date, "scope")
+        MatcherAssert.assertThat(credentials.toString(), Matchers.`is`("Credentials(idToken='xxxxx', accessToken='xxxxx', type='type', refreshToken='xxxxx', expiresAt='$date', scope='scope')"))
     }
 }


### PR DESCRIPTION
### Changes
To avoid Logout because of not storing the refreshed credentials. We are providing the Credentials back to the user through our Exception.

Since Exceptions are highly logged we are masking sensitive data from it to avoid exposing them.

### References
https://github.com/auth0/Auth0.Android/issues/661

### Testing
- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

