### PR TITLE
Avoid null pointer exception because of error description

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/CallbackHelper.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CallbackHelper.java
@@ -54,10 +54,8 @@ abstract class CallbackHelper {
         final String[] entries = valueString.length() > 0 ? valueString.split("&") : new String[]{};
         Map<String, String> values = new HashMap<>(entries.length);
         for (String entry : entries) {
-            final String[] value = entry.split("=");
-            if (value.length == 2) {
-                values.put(value[0], value[1]);
-            }
+            int idx = entry.indexOf("=");
+            values.put(entry.substring(0, idx), entry.substring(idx + 1));
         }
         return values;
     }

--- a/auth0/src/main/java/com/auth0/android/provider/CallbackHelper.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CallbackHelper.java
@@ -55,7 +55,11 @@ abstract class CallbackHelper {
         Map<String, String> values = new HashMap<>(entries.length);
         for (String entry : entries) {
             int idx = entry.indexOf("=");
-            values.put(entry.substring(0, idx), entry.substring(idx + 1));
+            final String key = idx > 0 ? entry.substring(0, idx) : entry;
+            final String value = idx > 0 && entry.length() > idx + 1 ? entry.substring(idx + 1) : null;
+            if (value != null) {
+                values.put(key, value);
+            }
         }
         return values;
     }

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -192,6 +192,7 @@ internal class OAuthManager(
             TAG,
             "Error, access denied. Check that the required Permissions are granted and that the Application has this Connection configured in Auth0 Dashboard."
         )
+        val unknownErrorDescription = "An unexpected error occurred."
         when {
             ERROR_VALUE_ACCESS_DENIED.equals(errorValue, ignoreCase = true) -> {
                 throw AuthenticationException(
@@ -200,16 +201,16 @@ internal class OAuthManager(
                 )
             }
             ERROR_VALUE_UNAUTHORIZED.equals(errorValue, ignoreCase = true) -> {
-                throw AuthenticationException(ERROR_VALUE_UNAUTHORIZED, errorDescription!!)
+                throw AuthenticationException(ERROR_VALUE_UNAUTHORIZED, errorDescription ?: unknownErrorDescription)
             }
             ERROR_VALUE_LOGIN_REQUIRED == errorValue -> {
                 //Whitelist to allow SSO errors go through
-                throw AuthenticationException(errorValue, errorDescription!!)
+                throw AuthenticationException(errorValue, errorDescription ?: unknownErrorDescription)
             }
             else -> {
                 throw AuthenticationException(
                     errorValue,
-                    errorDescription ?: "An unexpected error occurred."
+                    errorDescription ?: unknownErrorDescription
                 )
             }
         }

--- a/auth0/src/test/java/com/auth0/android/provider/CallbackHelperTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CallbackHelperTest.java
@@ -78,6 +78,19 @@ public class CallbackHelperTest {
     }
 
     @Test
+    public void shouldParseQueryValuesWithEqual() {
+        String uriString = "testandroid://auth.testandroid.com/android/com.testandroid.app/callback?error=unauthorized&error_description=Please%20verify%20your%20email%20before%20logging%20in.e%3Dfoo%2Bt2%40gmail.com&state=abscefg-QWERTYUIOPasdfgHJKLMNBVCXZdd";
+        Uri uri = Uri.parse(uriString);
+        final Map<String, String> values = CallbackHelper.getValuesFromUri(uri);
+
+        assertThat(values, is(notNullValue()));
+        assertThat(values, aMapWithSize(3));
+        assertThat(values, hasEntry("error", "unauthorized"));
+        assertThat(values, hasEntry("state", "abscefg-QWERTYUIOPasdfgHJKLMNBVCXZdd"));
+        assertThat(values, hasEntry("error_description", "Please verify your email before logging in.e=foo+t2@gmail.com"));
+    }
+
+    @Test
     public void shouldParseQueryValues() {
         String uriString = "https://lbalmaceda.auth0.com/android/com.auth0.android.lock.app/callback?code=soMec0d3ML8B&state=810132b-486aa-4aa8-1768-a1dcd3368fae";
         Uri uri = Uri.parse(uriString);


### PR DESCRIPTION
### Changes
To avoid causing an exception in case error description is null, we will pass unknown error description

### References
https://github.com/auth0/Auth0.Android/issues/662

### Testing
- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not