### PR TITLE
Revert changes from #654. Fix renew Credentials logic

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -555,7 +555,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @return a request to start
      */
     public fun renewAuth(refreshToken: String): Request<Credentials, AuthenticationException> {
-        val parameters = ParameterBuilder.newBuilderWithRequiredScope()
+        val parameters = ParameterBuilder.newBuilder()
             .setClientId(clientId)
             .setRefreshToken(refreshToken)
             .setGrantType(ParameterBuilder.GRANT_TYPE_REFRESH_TOKEN)
@@ -690,7 +690,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         codeVerifier: String,
         redirectUri: String
     ): Request<Credentials, AuthenticationException> {
-        val parameters = ParameterBuilder.newBuilderWithRequiredScope()
+        val parameters = ParameterBuilder.newBuilder()
             .setClientId(clientId)
             .setGrantType(ParameterBuilder.GRANT_TYPE_AUTHORIZATION_CODE)
             .set(OAUTH_CODE_KEY, authorizationCode)

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
@@ -181,12 +181,6 @@ public class ParameterBuilder private constructor(parameters: Map<String, String
                 .setScope(OidcUtils.DEFAULT_SCOPE)
         }
 
-        @JvmStatic
-        public fun newBuilderWithRequiredScope(): ParameterBuilder {
-            return newBuilder()
-                .setScope(OidcUtils.REQUIRED_SCOPE)
-        }
-
         /**
          * Creates a new instance of the builder.
          *

--- a/auth0/src/main/java/com/auth0/android/request/internal/OidcUtils.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/OidcUtils.kt
@@ -1,6 +1,5 @@
 package com.auth0.android.request.internal
 
-import androidx.annotation.VisibleForTesting
 import java.util.*
 
 /**
@@ -9,7 +8,7 @@ import java.util.*
 internal object OidcUtils {
     internal const val KEY_SCOPE = "scope"
     internal const val DEFAULT_SCOPE = "openid profile email"
-    internal const val REQUIRED_SCOPE = "openid"
+    private const val REQUIRED_SCOPE = "openid"
 
     /**
      * Given a string, it will check if it contains the scope of "openid".

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -9,7 +9,6 @@ import com.auth0.android.request.HttpMethod
 import com.auth0.android.request.NetworkingClient
 import com.auth0.android.request.RequestOptions
 import com.auth0.android.request.ServerResponse
-import com.auth0.android.request.internal.OidcUtils
 import com.auth0.android.request.internal.RequestFactory
 import com.auth0.android.request.internal.ThreadSwitcherShadow
 import com.auth0.android.result.*
@@ -2201,7 +2200,7 @@ public class AuthenticationAPIClientTest {
         )
         assertThat(request.path, Matchers.equalTo("/oauth/token"))
         val body = bodyFromRequest<String>(request)
-        assertThat(body, Matchers.hasEntry("scope", OidcUtils.REQUIRED_SCOPE))
+        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
         assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
         assertThat(body, Matchers.hasEntry("refresh_token", "refreshToken"))
         assertThat(body, Matchers.hasEntry("grant_type", "refresh_token"))
@@ -2230,7 +2229,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
         assertThat(body, Matchers.hasEntry("refresh_token", "refreshToken"))
         assertThat(body, Matchers.hasEntry("grant_type", "refresh_token"))
-        assertThat(body, Matchers.hasEntry("scope", OidcUtils.REQUIRED_SCOPE))
+        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
         assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
     }
 
@@ -2253,7 +2252,7 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
         assertThat(body, Matchers.hasEntry("refresh_token", "refreshToken"))
         assertThat(body, Matchers.hasEntry("grant_type", "refresh_token"))
-        assertThat(body, Matchers.hasEntry("scope", OidcUtils.REQUIRED_SCOPE))
+        assertThat(body, Matchers.not(Matchers.hasKey("scope")))
         assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
     }
 
@@ -2364,7 +2363,6 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("code", "code"))
         assertThat(body, Matchers.hasEntry("code_verifier", "codeVerifier"))
         assertThat(body, Matchers.hasEntry("redirect_uri", "http://redirect.uri"))
-        assertThat(body, Matchers.hasEntry("scope", OidcUtils.REQUIRED_SCOPE))
         assertThat(
             callback, AuthenticationCallbackMatcher.hasPayloadOfType(
                 Credentials::class.java
@@ -2390,7 +2388,6 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("code", "code"))
         assertThat(body, Matchers.hasEntry("code_verifier", "codeVerifier"))
         assertThat(body, Matchers.hasEntry("redirect_uri", "http://redirect.uri"))
-        assertThat(body, Matchers.hasEntry("scope", OidcUtils.REQUIRED_SCOPE))
         assertThat(
             callback, AuthenticationCallbackMatcher.hasError(
                 Credentials::class.java


### PR DESCRIPTION
### Changes
We are reverting changes from #654

This changes caused a regression were existing credentials were not fetched with the same scope. This can cause access tokens to have lesser access. To fix this we are reverting this change and ensuring the `scope` parameter is empty if none is specified.

### References
#654 

### Testing
- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not