### PR TITLE
Migrate deprecated AGP dsl

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -11,7 +11,7 @@ When building the project with `build`, an error appeared regarding an `invalid 
 ```gradle
 android {
     //...
-    lintOptions {
+    lint {
        warning 'InvalidPackage'
     }
 }

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ Next, define the Manifest Placeholders for the Auth0 Domain and Scheme which are
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdk 30
     defaultConfig {
         applicationId "com.auth0.samples"
-        minSdkVersion 21
-        targetSdkVersion 30
+        minSdk 21
+        targetSdk 30
         //...
 
         //---> Add the next line
@@ -159,7 +159,7 @@ WebAuthProvider.login(account)
 try {
     val credentials = WebAuthProvider.login(account)
         .await(requireContext())
-    println(credentials)    
+    println(credentials)
 } catch(e: AuthenticationException) {
     e.printStacktrace()
 }
@@ -333,7 +333,7 @@ authentication
             manager.saveCredentials(credentials)
         }
     })
-``` 
+```
 
 <details>
   <summary>Using coroutines</summary>
@@ -403,7 +403,7 @@ manager.getCredentials(object : Callback<Credentials, CredentialsManagerExceptio
         // Use the credentials
     }
 })
-``` 
+```
 
 <details>
   <summary>Using coroutines</summary>

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -49,11 +49,11 @@ oss {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 31
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 31
+        minSdk 21
+        targetSdk 31
         versionCode 1
         versionName project.version
 
@@ -63,7 +63,7 @@ android {
         consumerProguardFiles '../proguard/proguard-gson.pro', '../proguard/proguard-okio.pro'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    lintOptions {
+    lint {
         htmlReport true
         abortOnError true
     }

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -63,7 +63,7 @@ android {
         consumerProguardFiles '../proguard/proguard-gson.pro', '../proguard/proguard-okio.pro'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    lint {
+    lintOptions {
         htmlReport true
         abortOnError true
     }

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -50,6 +50,7 @@ oss {
 
 android {
     compileSdk 31
+    namespace "com.auth0.android.auth0"
 
     defaultConfig {
         minSdk 21

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 android {
     compileSdk 31
+    namespace "com.auth0.sample"
 
     defaultConfig {
         minSdk 21

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 31
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 31
+        minSdk 21
+        targetSdk 31
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
Something like `compileSdkVersion` is deprecated, we should migrate these API usages in both project and docs.