### PR TITLE
Fix org name verification logic

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/IdTokenVerifier.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/IdTokenVerifier.kt
@@ -73,7 +73,7 @@ internal class IdTokenVerifier {
                 if (TextUtils.isEmpty(orgNameClaim)) {
                     throw OrgNameClaimMissingException()
                 }
-                if (!organizationInput.equals(orgNameClaim, true)) {
+                if (organizationInput.lowercase() != orgNameClaim) {
                     throw OrgNameClaimMismatchException(organizationInput, orgNameClaim)
                 }
             }

--- a/auth0/src/test/java/com/auth0/android/provider/IdTokenVerifierTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/IdTokenVerifierTest.java
@@ -306,12 +306,16 @@ public class IdTokenVerifierTest {
 
     @Test
     public void shouldFailWhenInputClaimHasDifferentCaseThanOrgNameReceived() throws Exception {
-        Map<String, Object> jwtBody = createJWTBody();
-        jwtBody.put("org_name", "__tESt_OrG_nAme__");
-        String token = createTestJWT("none", jwtBody);
-        Jwt jwt = new Jwt(token);
-        options.setOrganization(EXPECTED_ORGANIZATION_NAME);
-        idTokenVerifier.verify(jwt, options, true);
+        String message = "Organization Name (org_name) claim mismatch in the ID token; expected \"__test_org_name__\", found \"__tESt_OrG_nAme__\"";
+        Exception e = Assert.assertThrows(message, OrgNameClaimMismatchException.class, () -> {
+            Map<String, Object> jwtBody = createJWTBody();
+            jwtBody.put("org_name", "__tESt_OrG_nAme__");
+            String token = createTestJWT("none", jwtBody);
+            Jwt jwt = new Jwt(token);
+            options.setOrganization(EXPECTED_ORGANIZATION_NAME);
+            idTokenVerifier.verify(jwt, options, true);
+        });
+        assertEquals("com.auth0.android.provider.TokenValidationException: " + message, e.toString());
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/provider/IdTokenVerifierTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/IdTokenVerifierTest.java
@@ -305,12 +305,22 @@ public class IdTokenVerifierTest {
     }
 
     @Test
-    public void shouldNotFailWhenOrganizationNameClaimIsRequiredAndHasSameValueInDifferentCase() throws Exception {
+    public void shouldFailWhenInputClaimHasDifferentCaseThanOrgNameReceived() throws Exception {
         Map<String, Object> jwtBody = createJWTBody();
         jwtBody.put("org_name", "__tESt_OrG_nAme__");
         String token = createTestJWT("none", jwtBody);
         Jwt jwt = new Jwt(token);
         options.setOrganization(EXPECTED_ORGANIZATION_NAME);
+        idTokenVerifier.verify(jwt, options, true);
+    }
+
+    @Test
+    public void shouldNotFailWhenOrgNameInputHasDifferentCaseThanClaimReceived() throws Exception {
+        Map<String, Object> jwtBody = createJWTBody();
+        jwtBody.put("org_name", EXPECTED_ORGANIZATION_NAME);
+        String token = createTestJWT("none", jwtBody);
+        Jwt jwt = new Jwt(token);
+        options.setOrganization("__tESt_OrG_nAme__");
         idTokenVerifier.verify(jwt, options, true);
     }
 


### PR DESCRIPTION
📋 Changes
This PR changes the comparison of the expected and actual org_name claim to be case-sensitive, and only lowercasing the expected value.