### PR TITLE
Release 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [2.10.0](https://github.com/auth0/Auth0.Android/tree/2.10.0) (2023-07-18)
+[Full Changelog](https://github.com/auth0/Auth0.Android/compare/2.9.3...2.10.0)
+
+**Added**
+- Return refreshed Credentials in CredentialsManagerException to avoid logout [\#666](https://github.com/auth0/Auth0.Android/pull/666) ([poovamraj](https://github.com/poovamraj))
+- [SDK-4413] Support Organization Name [\#669](https://github.com/auth0/Auth0.Android/pull/669) ([poovamraj](https://github.com/poovamraj))
+- Add more error pairs to isMultifactorCodeInvalid [SDK-4194] [\#664](https://github.com/auth0/Auth0.Android/pull/664) ([poovamraj](https://github.com/poovamraj))
+
+**Fixed**
+- Avoid null pointer exception because of error description [\#667](https://github.com/auth0/Auth0.Android/pull/667) ([poovamraj](https://github.com/poovamraj))
+- Revert changes from #654. Fix renew Credentials logic [\#670](https://github.com/auth0/Auth0.Android/pull/670) ([poovamraj](https://github.com/poovamraj))
+
+**Security**
+- chore(security): Update and pin Graddle workflow actions [\#671](https://github.com/auth0/Auth0.Android/pull/671) ([evansims](https://github.com/evansims))
+
 ## [2.9.3](https://github.com/auth0/Auth0.Android/tree/2.9.3) (2023-05-19)
 [Full Changelog](https://github.com/auth0/Auth0.Android/compare/2.9.2...2.9.3)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To install Auth0.Android with [Gradle](https://gradle.org/), simply add the foll
 
 ```gradle
 dependencies {
-    implementation 'com.auth0.android:auth0:2.9.3'
+    implementation 'com.auth0.android:auth0:2.10.0'
 }
 ```
 


### PR DESCRIPTION

**Added**
- Return refreshed Credentials in CredentialsManagerException to avoid logout [\#666](https://github.com/auth0/Auth0.Android/pull/666) ([poovamraj](https://github.com/poovamraj))
- [SDK-4413] Support Organization Name [\#669](https://github.com/auth0/Auth0.Android/pull/669) ([poovamraj](https://github.com/poovamraj))
- Add more error pairs to isMultifactorCodeInvalid [SDK-4194] [\#664](https://github.com/auth0/Auth0.Android/pull/664) ([poovamraj](https://github.com/poovamraj))

**Fixed**
- Avoid null pointer exception because of error description [\#667](https://github.com/auth0/Auth0.Android/pull/667) ([poovamraj](https://github.com/poovamraj))
- Revert changes from #654. Fix renew Credentials logic [\#670](https://github.com/auth0/Auth0.Android/pull/670) ([poovamraj](https://github.com/poovamraj))

**Security**
- chore(security): Update and pin Graddle workflow actions [\#671](https://github.com/auth0/Auth0.Android/pull/671) ([evansims](https://github.com/evansims))


[SDK-4413]: https://auth0team.atlassian.net/browse/SDK-4413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-4194]: https://auth0team.atlassian.net/browse/SDK-4194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ