### PR TITLE
Handle SecurityException thrown while launching the browser

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
@@ -27,7 +27,13 @@ public class AuthenticationException : Auth0Exception {
         this.description = description
     }
 
-    public constructor(message: String, cause: Auth0Exception? = null) : super(message, cause)
+    public constructor(message: String, cause: Exception? = null) : super(message, cause)
+
+    public constructor(code: String, description: String, cause: Exception) : this(DEFAULT_MESSAGE, cause) {
+        this.code = code
+        this.description = description
+    }
+
     public constructor(payload: String?, statusCode: Int) : this(DEFAULT_MESSAGE) {
         code = if (payload != null) NON_JSON_ERROR else EMPTY_BODY_ERROR
         description = payload ?: EMPTY_RESPONSE_BODY_DESCRIPTION

--- a/auth0/src/main/java/com/auth0/android/callback/RunnableTask.kt
+++ b/auth0/src/main/java/com/auth0/android/callback/RunnableTask.kt
@@ -1,0 +1,5 @@
+package com.auth0.android.callback
+
+internal interface RunnableTask<T> {
+    fun apply(t: T)
+}

--- a/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/AuthenticationActivity.kt
@@ -6,15 +6,11 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.annotation.VisibleForTesting
-import com.auth0.android.Auth0Exception
 import com.auth0.android.authentication.AuthenticationException
-import com.auth0.android.callback.Callback
 import com.auth0.android.callback.RunnableTask
 import com.auth0.android.provider.WebAuthProvider.failure
 import com.auth0.android.provider.WebAuthProvider.resume
 import com.google.androidbrowserhelper.trusted.TwaLauncher
-import java.lang.Exception
-import java.util.function.Consumer
 
 public open class AuthenticationActivity : Activity() {
     private var intentLaunched = false

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -117,13 +117,8 @@ class CustomTabsController extends CustomTabsServiceConnection {
             Log.v(TAG, "Custom Tab Context was no longer valid.");
             return;
         }
-        Thread.UncaughtExceptionHandler exceptionHandler = (th, ex) -> {
-            AuthenticationException e = new AuthenticationException(
-                    "a0.browser_not_available", "Error launching browser for authentication", new Exception(ex));
-            CommonThreadSwitcher.getInstance().mainThread(() -> failureCallback.apply(e));
-        };
 
-        Thread thread = new Thread(() -> {
+        new Thread(() -> {
             try {
                 if (launchAsTwa) {
                     this.launchedAsTwa = true;
@@ -139,10 +134,12 @@ class CustomTabsController extends CustomTabsServiceConnection {
                 }
             } catch (ActivityNotFoundException ex) {
                 Log.e(TAG, "Could not find any Browser application installed in this device to handle the intent.");
+            } catch (SecurityException ex) {
+                AuthenticationException e = new AuthenticationException(
+                        "a0.browser_not_available", "Error launching browser for authentication", ex);
+                CommonThreadSwitcher.getInstance().mainThread(() -> failureCallback.apply(e));
             }
-        });
-        thread.setUncaughtExceptionHandler(exceptionHandler);
-        thread.start();
+        }).start();
     }
 
     private void launchAsDefault(Context context, Uri uri) {

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -13,9 +13,7 @@ import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsServiceConnection;
 import androidx.browser.customtabs.CustomTabsSession;
 
-import com.auth0.android.Auth0Exception;
 import com.auth0.android.authentication.AuthenticationException;
-import com.auth0.android.callback.Callback;
 import com.auth0.android.callback.RunnableTask;
 import com.auth0.android.request.internal.CommonThreadSwitcher;
 import com.google.androidbrowserhelper.trusted.TwaLauncher;
@@ -24,8 +22,6 @@ import java.lang.ref.WeakReference;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 
 @SuppressWarnings("WeakerAccess")

--- a/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/LogoutManager.kt
@@ -37,6 +37,10 @@ internal class LogoutManager(
         return true
     }
 
+    override fun failure(exception: AuthenticationException) {
+        callback.onFailure(exception)
+    }
+
     private fun buildLogoutUri(): Uri {
         val logoutUri = Uri.parse(account.logoutUrl)
         val builder = logoutUri.buildUpon()

--- a/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/OAuthManager.kt
@@ -133,6 +133,10 @@ internal class OAuthManager(
         return true
     }
 
+    public override fun failure(exception: AuthenticationException) {
+        callback.onFailure(exception)
+    }
+
     private fun assertValidIdToken(
         idToken: String?,
         validationCallback: Callback<Void?, Auth0Exception>

--- a/auth0/src/main/java/com/auth0/android/provider/ResumableManager.java
+++ b/auth0/src/main/java/com/auth0/android/provider/ResumableManager.java
@@ -1,5 +1,10 @@
 package com.auth0.android.provider;
 
+import androidx.annotation.NonNull;
+
+import com.auth0.android.Auth0Exception;
+import com.auth0.android.authentication.AuthenticationException;
+
 /**
  * Internal class, used to generify the handling of different Web Auth flows.
  * See {@link WebAuthProvider}
@@ -14,4 +19,6 @@ abstract class ResumableManager {
      * @see AuthorizeResult
      */
     abstract boolean resume(AuthorizeResult result);
+
+    abstract void failure(@NonNull AuthenticationException exception);
 }

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -82,6 +82,11 @@ public object WebAuthProvider {
     }
 
     @JvmStatic
+    internal fun failure(exception: AuthenticationException) {
+        managerInstance!!.failure(exception)
+    }
+
+    @JvmStatic
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun resetManagerInstance() {
         managerInstance = null

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -81,7 +81,6 @@ public object WebAuthProvider {
         return success
     }
 
-    @JvmStatic
     internal fun failure(exception: AuthenticationException) {
         managerInstance!!.failure(exception)
     }

--- a/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.kt
@@ -46,6 +46,9 @@ public class AuthenticationActivityTest {
     @Captor
     private lateinit var launchAsTwaCaptor: ArgumentCaptor<Boolean>
 
+    @Captor
+    private lateinit var failureCallbackCaptor: ArgumentCaptor<RunnableTask<AuthenticationException>>
+
     private lateinit var callerActivity: Activity
     private lateinit var activity: AuthenticationActivityMock
     private lateinit var activityController: ActivityController<AuthenticationActivityMock>
@@ -88,11 +91,7 @@ public class AuthenticationActivityTest {
         createActivity(intentCaptor.value)
         activityController.create().start().resume()
         Mockito.verify(customTabsController).bindService()
-        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), object :
-            RunnableTask<AuthenticationException> {
-            override fun apply(error: AuthenticationException) {
-            }
-        })
+        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), failureCallbackCaptor.capture())
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(uri))
         MatcherAssert.assertThat(activity.deliveredIntent, Is.`is`(Matchers.nullValue()))
@@ -123,11 +122,7 @@ public class AuthenticationActivityTest {
         createActivity(intentCaptor.value)
         activityController.create().start().resume()
         Mockito.verify(customTabsController).bindService()
-        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), object :
-            RunnableTask<AuthenticationException> {
-            override fun apply(error: AuthenticationException) {
-            }
-        })
+        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), failureCallbackCaptor.capture())
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(uri))
         MatcherAssert.assertThat(activity.deliveredIntent, Is.`is`(Matchers.nullValue()))
@@ -158,11 +153,7 @@ public class AuthenticationActivityTest {
         createActivity(intentCaptor.value)
         activityController.create().start().resume()
         Mockito.verify(customTabsController).bindService()
-        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), object :
-            RunnableTask<AuthenticationException> {
-            override fun apply(error: AuthenticationException) {
-            }
-        })
+        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), failureCallbackCaptor.capture())
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(uri))
         MatcherAssert.assertThat(launchAsTwaCaptor.value, Is.`is`(Matchers.notNullValue()))
@@ -192,11 +183,7 @@ public class AuthenticationActivityTest {
         createActivity(intentCaptor.value)
         activityController.create().start().resume()
         Mockito.verify(customTabsController).bindService()
-        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), object :
-            RunnableTask<AuthenticationException> {
-            override fun apply(error: AuthenticationException) {
-            }
-        })
+        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), failureCallbackCaptor.capture())
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(uri))
         MatcherAssert.assertThat(launchAsTwaCaptor.value, Is.`is`(Matchers.notNullValue()))

--- a/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/AuthenticationActivityTest.kt
@@ -6,6 +6,8 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.test.espresso.intent.matcher.IntentMatchers
+import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.callback.RunnableTask
 import com.auth0.android.provider.AuthenticationActivity
 import com.auth0.android.provider.CustomTabsOptions
 import org.hamcrest.CoreMatchers
@@ -86,7 +88,11 @@ public class AuthenticationActivityTest {
         createActivity(intentCaptor.value)
         activityController.create().start().resume()
         Mockito.verify(customTabsController).bindService()
-        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture())
+        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), object :
+            RunnableTask<AuthenticationException> {
+            override fun apply(error: AuthenticationException) {
+            }
+        })
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(uri))
         MatcherAssert.assertThat(activity.deliveredIntent, Is.`is`(Matchers.nullValue()))
@@ -117,7 +123,11 @@ public class AuthenticationActivityTest {
         createActivity(intentCaptor.value)
         activityController.create().start().resume()
         Mockito.verify(customTabsController).bindService()
-        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture())
+        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), object :
+            RunnableTask<AuthenticationException> {
+            override fun apply(error: AuthenticationException) {
+            }
+        })
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(uri))
         MatcherAssert.assertThat(activity.deliveredIntent, Is.`is`(Matchers.nullValue()))
@@ -148,7 +158,11 @@ public class AuthenticationActivityTest {
         createActivity(intentCaptor.value)
         activityController.create().start().resume()
         Mockito.verify(customTabsController).bindService()
-        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture())
+        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), object :
+            RunnableTask<AuthenticationException> {
+            override fun apply(error: AuthenticationException) {
+            }
+        })
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(uri))
         MatcherAssert.assertThat(launchAsTwaCaptor.value, Is.`is`(Matchers.notNullValue()))
@@ -178,7 +192,11 @@ public class AuthenticationActivityTest {
         createActivity(intentCaptor.value)
         activityController.create().start().resume()
         Mockito.verify(customTabsController).bindService()
-        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture())
+        Mockito.verify(customTabsController).launchUri(uriCaptor.capture(), launchAsTwaCaptor.capture(), object :
+            RunnableTask<AuthenticationException> {
+            override fun apply(error: AuthenticationException) {
+            }
+        })
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(Matchers.notNullValue()))
         MatcherAssert.assertThat(uriCaptor.value, Is.`is`(uri))
         MatcherAssert.assertThat(launchAsTwaCaptor.value, Is.`is`(Matchers.notNullValue()))

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -127,7 +127,7 @@ public class CustomTabsControllerTest {
     @Test
     public void shouldBindAndLaunchUri() throws Exception {
         bindService(controller, true);
-        controller.launchUri(uri, false);
+        controller.launchUri(uri, false, (ex) -> {});
         connectBoundService();
 
         verify(context, timeout(MAX_TEST_WAIT_TIME_MS)).startActivity(launchIntentCaptor.capture());
@@ -146,7 +146,7 @@ public class CustomTabsControllerTest {
     @Test
     public void shouldBindAndLaunchUriAsTwa() throws Exception {
         bindService(controller, true);
-        controller.launchUri(uri, true);
+        controller.launchUri(uri, true, (ex) -> {});
         connectBoundService();
         ArgumentCaptor<TrustedWebActivityIntentBuilder> trustedWebActivityIntentBuilderArgumentCaptor
                 = ArgumentCaptor.forClass(TrustedWebActivityIntentBuilder.class);
@@ -176,7 +176,7 @@ public class CustomTabsControllerTest {
         when(browserPicker.getBestBrowserPackage(context.getPackageManager())).thenReturn(null);
         CustomTabsOptions ctOptions = CustomTabsOptions.newBuilder().withBrowserPicker(browserPicker).build();
         CustomTabsController controller = new CustomTabsController(context, ctOptions, twaLauncher);
-        controller.launchUri(uri, false);
+        controller.launchUri(uri, false, (ex) -> {});
 
         verify(context, timeout(MAX_TEST_WAIT_TIME_MS)).startActivity(launchIntentCaptor.capture());
         Intent intent = launchIntentCaptor.getValue();
@@ -199,7 +199,7 @@ public class CustomTabsControllerTest {
         CustomTabsController controller = new CustomTabsController(context, ctOptions, twaLauncher);
 
         bindService(controller, true);
-        controller.launchUri(uri, false);
+        controller.launchUri(uri, false, (ex) -> {});
         connectBoundService();
 
         verify(context, timeout(MAX_TEST_WAIT_TIME_MS)).startActivity(launchIntentCaptor.capture());
@@ -228,7 +228,7 @@ public class CustomTabsControllerTest {
         CustomTabsController controller = new CustomTabsController(context, ctOptions, twaLauncher);
 
         bindService(controller, true);
-        controller.launchUri(uri, true);
+        controller.launchUri(uri, true, (ex) -> {});
         connectBoundService();
 
 
@@ -257,7 +257,7 @@ public class CustomTabsControllerTest {
     @Test
     public void shouldFailToBindButLaunchUri() {
         bindService(controller, false);
-        controller.launchUri(uri, false);
+        controller.launchUri(uri, false, (ex) -> {});
 
         verify(context, timeout(MAX_TEST_WAIT_TIME_MS)).startActivity(launchIntentCaptor.capture());
         Intent intent = launchIntentCaptor.getValue();
@@ -271,7 +271,7 @@ public class CustomTabsControllerTest {
     public void shouldNotLaunchUriIfContextNoLongerValid() {
         bindService(controller, true);
         controller.clearContext();
-        controller.launchUri(uri, false);
+        controller.launchUri(uri, false, (ex) -> {});
         verify(context, never()).startActivity(any(Intent.class));
     }
 
@@ -280,7 +280,7 @@ public class CustomTabsControllerTest {
         doThrow(ActivityNotFoundException.class)
                 .doNothing()
                 .when(context).startActivity(any(Intent.class));
-        controller.launchUri(uri, false);
+        controller.launchUri(uri, false, (ex) -> {});
 
         verify(context, timeout(MAX_TEST_WAIT_TIME_MS)).startActivity(launchIntentCaptor.capture());
         List<Intent> intents = launchIntentCaptor.getAllValues();

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.graphics.Color;
 import android.net.Uri;
+import android.os.Looper;
 
 import androidx.browser.customtabs.CustomTabsCallback;
 import androidx.browser.customtabs.CustomTabsClient;
@@ -296,6 +297,17 @@ public class CustomTabsControllerTest {
         assertThat(customTabIntent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(false));
         assertThat(customTabIntent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.NO_TITLE));
         assertThat(customTabIntent.getIntExtra(CustomTabsIntent.EXTRA_SHARE_STATE, CustomTabsIntent.SHARE_STATE_OFF), is(CustomTabsIntent.SHARE_STATE_OFF));
+    }
+
+    @Test
+    public void shouldThrowExceptionIfFailedToLaunchBecauseOfException() {
+        Exception e = new SecurityException();
+        doThrow(e)
+                .when(context).startActivity(any(Intent.class));
+        controller.launchUri(uri, false, (ex) -> {
+            assertThat(ex, is(e));
+            assertThat(Looper.myLooper(), is(Looper.getMainLooper()));
+        });
     }
 
     //Helper Methods

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -38,6 +38,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
@@ -50,6 +51,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.auth0.android.authentication.AuthenticationException;
 import com.google.androidbrowserhelper.trusted.TwaLauncher;
 import com.google.androidbrowserhelper.trusted.splashscreens.SplashScreenStrategy;
 
@@ -305,7 +307,10 @@ public class CustomTabsControllerTest {
         doThrow(e)
                 .when(context).startActivity(any(Intent.class));
         controller.launchUri(uri, false, (ex) -> {
-            assertThat(ex, is(e));
+            assertThat(ex, isA(AuthenticationException.class));
+            assertThat(ex.getCause(), is(eq(e)));
+            assertThat(ex.getCode(), is("a0.browser_not_available"));
+            assertThat(ex.getDescription(), is("Error launching browser for authentication"));
             assertThat(Looper.myLooper(), is(Looper.getMainLooper()));
         });
     }

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -130,7 +130,7 @@ public class CustomTabsControllerTest {
     @Test
     public void shouldBindAndLaunchUri() throws Exception {
         bindService(controller, true);
-        controller.launchUri(uri, false, (ex) -> {});
+        controller.launchUri(uri, false, null);
         connectBoundService();
 
         verify(context, timeout(MAX_TEST_WAIT_TIME_MS)).startActivity(launchIntentCaptor.capture());
@@ -149,7 +149,7 @@ public class CustomTabsControllerTest {
     @Test
     public void shouldBindAndLaunchUriAsTwa() throws Exception {
         bindService(controller, true);
-        controller.launchUri(uri, true, (ex) -> {});
+        controller.launchUri(uri, true, null);
         connectBoundService();
         ArgumentCaptor<TrustedWebActivityIntentBuilder> trustedWebActivityIntentBuilderArgumentCaptor
                 = ArgumentCaptor.forClass(TrustedWebActivityIntentBuilder.class);
@@ -179,7 +179,7 @@ public class CustomTabsControllerTest {
         when(browserPicker.getBestBrowserPackage(context.getPackageManager())).thenReturn(null);
         CustomTabsOptions ctOptions = CustomTabsOptions.newBuilder().withBrowserPicker(browserPicker).build();
         CustomTabsController controller = new CustomTabsController(context, ctOptions, twaLauncher);
-        controller.launchUri(uri, false, (ex) -> {});
+        controller.launchUri(uri, false, null);
 
         verify(context, timeout(MAX_TEST_WAIT_TIME_MS)).startActivity(launchIntentCaptor.capture());
         Intent intent = launchIntentCaptor.getValue();
@@ -202,7 +202,7 @@ public class CustomTabsControllerTest {
         CustomTabsController controller = new CustomTabsController(context, ctOptions, twaLauncher);
 
         bindService(controller, true);
-        controller.launchUri(uri, false, (ex) -> {});
+        controller.launchUri(uri, false, null);
         connectBoundService();
 
         verify(context, timeout(MAX_TEST_WAIT_TIME_MS)).startActivity(launchIntentCaptor.capture());
@@ -231,7 +231,7 @@ public class CustomTabsControllerTest {
         CustomTabsController controller = new CustomTabsController(context, ctOptions, twaLauncher);
 
         bindService(controller, true);
-        controller.launchUri(uri, true, (ex) -> {});
+        controller.launchUri(uri, true, null);
         connectBoundService();
 
 
@@ -260,7 +260,7 @@ public class CustomTabsControllerTest {
     @Test
     public void shouldFailToBindButLaunchUri() {
         bindService(controller, false);
-        controller.launchUri(uri, false, (ex) -> {});
+        controller.launchUri(uri, false, null);
 
         verify(context, timeout(MAX_TEST_WAIT_TIME_MS)).startActivity(launchIntentCaptor.capture());
         Intent intent = launchIntentCaptor.getValue();
@@ -283,7 +283,7 @@ public class CustomTabsControllerTest {
         doThrow(ActivityNotFoundException.class)
                 .doNothing()
                 .when(context).startActivity(any(Intent.class));
-        controller.launchUri(uri, false, (ex) -> {});
+        controller.launchUri(uri, false, null);
 
         verify(context, timeout(MAX_TEST_WAIT_TIME_MS)).startActivity(launchIntentCaptor.capture());
         List<Intent> intents = launchIntentCaptor.getAllValues();

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Auth0 SDK Sample</string>
-    <string name="com_auth0_domain">lbalmaceda.auth0.com</string>
-    <string name="com_auth0_client_id">PX2vJhpALUNT66NHdCdD30XWqlIR4oEZ</string>
+    <string name="com_auth0_domain">poovamraj.eu.auth0.com</string>
+    <string name="com_auth0_client_id">swarLtLAd0aW55ajPUPzYPXjtB3UtZki</string>
     <string name="com_auth0_scheme">demo</string>
 </resources>


### PR DESCRIPTION
### Changes
This change handles exception thrown while launching browser instance for authentication.

One such error we wanted to handle is SecurityException: Permission Denial happening because of using browsers (mostly misconfigured applications) that have not `exported` their activity

### References
https://github.com/auth0/Auth0.Android/issues/663

### Testing
- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not
