### PR TITLE
Release 2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.10.1](https://github.com/auth0/Auth0.Android/tree/2.10.1) (2023-08-01)
+[Full Changelog](https://github.com/auth0/Auth0.Android/compare/2.10.0...2.10.1)
+
+**Fixed**
+- Handle SecurityException thrown while launching the browser [\#677](https://github.com/auth0/Auth0.Android/pull/677) ([poovamraj](https://github.com/poovamraj))
+
 ## [2.10.0](https://github.com/auth0/Auth0.Android/tree/2.10.0) (2023-07-18)
 [Full Changelog](https://github.com/auth0/Auth0.Android/compare/2.9.3...2.10.0)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To install Auth0.Android with [Gradle](https://gradle.org/), simply add the foll
 
 ```gradle
 dependencies {
-    implementation 'com.auth0.android:auth0:2.10.0'
+    implementation 'com.auth0.android:auth0:2.10.1'
 }
 ```
 


### PR DESCRIPTION
## [2.10.1](https://github.com/auth0/Auth0.Android/tree/2.10.1) (2023-08-01)
[Full Changelog](https://github.com/auth0/Auth0.Android/compare/2.10.0...2.10.1)

**Fixed**
- Handle SecurityException thrown while launching the browser [\#677](https://github.com/auth0/Auth0.Android/pull/677) ([poovamraj](https://github.com/poovamraj))