### PR TITLE
build(dependencies): Update OkHttp to 4.11.0 [SDK-4501]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Change Log
 
-## [Unreleased]
-
-**Security**
-- Updated OkHttp to 4.11.0
-
 ## [2.10.1](https://github.com/auth0/Auth0.Android/tree/2.10.1) (2023-08-01)
 [Full Changelog](https://github.com/auth0/Auth0.Android/compare/2.10.0...2.10.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [Unreleased]
+
+**Security**
+- Updated OkHttp to 4.11.0
+
 ## [2.10.1](https://github.com/auth0/Auth0.Android/tree/2.10.1) (2023-08-01)
 [Full Changelog](https://github.com/auth0/Auth0.Android/compare/2.10.0...2.10.1)
 

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -88,7 +88,7 @@ android {
 }
 
 ext {
-    okhttpVersion = '4.10.0'
+    okhttpVersion = '4.11.0'
     powermockVersion = '2.0.9'
     coroutinesVersion = '1.6.2'
 }


### PR DESCRIPTION
### Changes

This pull request updates the OkHttp dependency to address a moderate security vulnerability in the imported version. This bumps the included release to 4.11.0 to address [CVE-2023-3635](https://www.cve.org/CVERecord?id=CVE-2023-3635).

### References

Please see internal ticket SDK-4501.

### Testing

No added tests were necessary.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
