### PR TITLE
chore(dependencies): Update OkHttp to 4.12.0

### DIFF
--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -88,7 +88,7 @@ android {
 }
 
 ext {
-    okhttpVersion = '4.11.0'
+    okhttpVersion = '4.12.0'
     powermockVersion = '2.0.9'
     coroutinesVersion = '1.6.2'
 }
@@ -106,12 +106,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.browser:browser:1.4.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
-
-    // TODO remove direct dependency when OkHttp 4.12.0 is released
-    implementation ("com.squareup.okhttp3:okhttp:${okhttpVersion}") {
-        exclude group: 'com.squareup.okhttp3', module: 'okio'
-    }
-    implementation "com.squareup.okio:okio:3.5.0"
+    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
 
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"
     implementation 'com.google.code.gson:gson:2.8.9'


### PR DESCRIPTION
### Changes

This PR follows up on #687 and bumps the OkHttp dependency to 4.12, now that it's been released. It removes the temporary workaround for forcing okio 3.5 with 4.11, as this is now included in 4.12.

### References

This also resolves [CVE-2020-29582](https://www.cve.org/CVERecord?id=CVE-2020-29582), a vulnerability in OkHttp 4.11.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
