### PR TITLE
fix: fixed release process to use maven publish plugin directly

### DIFF
--- a/.github/actions/maven-publish/action.yml
+++ b/.github/actions/maven-publish/action.yml
@@ -1,20 +1,19 @@
 name: Publish release to Java
 
 inputs:
+  java-version:
+    required: true
+
+secrets:
   ossr-username:
     required: true
-  ossr-password:
+  ossr-token:
     required: true
   signing-key:
     required: true
   signing-password:
     required: true
-  java-version:
-    required: true
-  is-android:
-    required: true
-  version:
-    required: true
+
 
 runs:
   using: composite
@@ -33,12 +32,11 @@ runs:
 
     - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # pin@1.1.0
 
-    - name: Publish Java
-      shell: bash
-      if: inputs.is-android == 'false'
-      run: ./gradlew clean assemble sign publishMavenJavaPublicationToMavenRepository -PisSnapshot=false -Pversion="${{ inputs.version }}" -PossrhUsername="${{ inputs.ossr-username }}" -PossrhPassword="${{ inputs.ossr-password }}" -PsigningKey="${{ inputs.signing-key }}" -PsigningPassword="${{ inputs.signing-password }}"
+    - name: Publish Android/Java Packages to Maven
+      run: ./gradlew publish -PisSnapshot=false
+      env:
+        MAVEN_USERNAME: ${{ secrets.ossr-username }}
+        MAVEN_PASSWORD: ${{ secrets.ossr-token }}
+        SIGNING_KEY: ${{ secrets.signing-key}}
+        SIGNING_PASSWORD: ${{ secrets.signing-password}}
 
-    - name: Publish Android
-      shell: bash
-      if: inputs.is-android == 'true'
-      run: ./gradlew clean assemble publishAndroidLibraryPublicationToMavenRepository -PisSnapshot=false -Pversion="${{ inputs.version }}" -PossrhUsername="${{ inputs.ossr-username }}" -PossrhPassword="${{ inputs.ossr-password }}" -PsigningKey="${{ inputs.signing-key }}" -PsigningPassword="${{ inputs.signing-password }}"

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -6,13 +6,11 @@ on:
       java-version:
         required: true
         type: string
-      is-android:
-        required: true
-        type: string
+
     secrets:
       ossr-username:
         required: true
-      ossr-password:
+      ossr-token:
         required: true
       signing-key:
         required: true
@@ -68,12 +66,12 @@ jobs:
 
       # Publish the release to Maven
       - name: Publish package to Maven
-        run: ./gradlew publish -PisSnapshot=false
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSR_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSR_TOKEN }}
-          SIGNING_KEY:    ${{ secrets.SIGNING_KEY}}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD}}
+      - uses: ./.github/actions/maven-publish
+        secrets:
+          ossr-username: ${{ secrets.ossr-username }}
+          ossr-token: ${{ secrets.ossr-token }}
+          signing-key:    ${{ secrets.signing-key}}
+          signing-password: ${{ secrets.signing-password}}
 
       # Create a release for the tag
       - uses: ./.github/actions/release-create

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -67,15 +67,13 @@ jobs:
         run: exit 1
 
       # Publish the release to Maven
-      - uses: ./.github/actions/maven-publish
-        with:
-          java-version: ${{ inputs.java-version }}
-          is-android: ${{ inputs.is-android }}
-          version: ${{ steps.get_version.outputs.version }}
-          ossr-username: ${{ secrets.ossr-username }}
-          ossr-password: ${{ secrets.ossr-password }}
-          signing-key: ${{ secrets.signing-key }}
-          signing-password: ${{ secrets.signing-password }}
+      - name: Publish package to Maven
+        run: ./gradlew publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSR_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSR_TOKEN }}
+          SIGNING_KEY:    ${{ secrets.SIGNING_KEY}}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD}}
 
       # Create a release for the tag
       - uses: ./.github/actions/release-create

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -68,7 +68,7 @@ jobs:
 
       # Publish the release to Maven
       - name: Publish package to Maven
-        run: ./gradlew publish
+        run: ./gradlew publish -PisSnapshot=false
         env:
           MAVEN_USERNAME: ${{ secrets.OSSR_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSR_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,9 @@ jobs:
     uses: ./.github/workflows/java-release.yml
     with:
       java-version: 8.0.402-zulu
-      is-android: true
     secrets:
       ossr-username: ${{ secrets.OSSR_USERNAME }}
-      ossr-password: ${{ secrets.OSSR_PASSWORD }}
+      ossr-token: ${{ secrets.OSSR_TOKEN }}
       signing-key: ${{ secrets.SIGNING_KEY }}
       signing-password: ${{ secrets.SIGNING_PASSWORD }}
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-COMFASTERXMLWOODSTOX-3091135:
+    - '*':
+        reason: Latest version of dokka has this vulnerability
+        expires: 2024-06-27T07:00:56.333Z
+        created: 2024-05-28T07:00:56.334Z
+  SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744:
+    - '*':
+        reason: Latest version of dokka has this vulnerability
+        expires: 2024-06-27T07:01:24.820Z
+        created: 2024-05-28T07:01:24.825Z
+patch: {}

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -107,4 +107,5 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
 }
 
+apply from: rootProject.file('gradle/jacoco.gradle')
 apply from: rootProject.file('gradle/maven-publish.gradle')

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -27,6 +27,10 @@ plugins {
     id 'kotlin-android'
 }
 
+apply from: rootProject.file('gradle/versioning.gradle')
+
+version = getVersionFromFile()
+
 logger.lifecycle("Using version ${version} for ${name}")
 
 android {

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -24,37 +24,10 @@
 
 plugins {
     id 'kotlin-android'
-    id "com.auth0.gradle.oss-library.android" version "0.18.0"
     id "org.jetbrains.dokka" version "1.4.20"
 }
 
 logger.lifecycle("Using version ${version} for ${name}")
-
-def signingKey = findProperty('signingKey')
-def signingKeyPwd = findProperty('signingPassword')
-
-oss {
-    name 'Auth0.Android'
-    repository 'Auth0.Android'
-    organization 'auth0'
-    description 'Android toolkit for Auth0 API'
-    skipAssertSigningConfiguration true
-
-    developers {
-        auth0 {
-            displayName = 'Auth0'
-            email = 'oss@auth0.com'
-        }
-        lbalmaceda {
-            displayName = 'Luciano Balmaceda'
-            email = 'luciano.balmaceda@auth0.com'
-        }
-    }
-}
-
-signing {
-    useInMemoryPgpKeys(signingKey, signingKeyPwd)
-}
 
 android {
     compileSdkVersion 31

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -23,8 +23,8 @@
  */
 
 plugins {
+    id 'com.android.library'
     id 'kotlin-android'
-    id "org.jetbrains.dokka" version "1.4.20"
 }
 
 logger.lifecycle("Using version ${version} for ${name}")
@@ -74,12 +74,6 @@ ext {
     coroutinesVersion = '1.6.2'
 }
 
-// Configure javadoc jar to use dokka output
-// TODO update oss-plugin to use dokka instead of doing it here
-javadocJar {
-    dependsOn "dokkaJavadoc"
-    from "$buildDir/dokka/javadoc"
-}
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
@@ -108,3 +102,5 @@ dependencies {
     testImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
 }
+
+apply from: rootProject.file('gradle/maven-publish.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jacoco:org.jacoco.core:0.8.5"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,14 @@ buildscript {
     }
 }
 
+plugins {
+    id 'org.jetbrains.dokka' version '1.9.20'
+}
+
+subprojects {
+    apply plugin: 'org.jetbrains.dokka'
+}
+
 allprojects {
     group = 'com.auth0.android'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 GROUP=com.auth0.android
 POM_ARTIFACT_ID=auth0
-VERSION_NAME=2.11.0
 
 POM_NAME=Auth0.Android
 POM_DESCRIPTION=Android toolkit for Auth0 API

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,19 +1,26 @@
-# Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
+GROUP=com.auth0.android
+POM_ARTIFACT_ID=auth0
+VERSION_NAME=2.11.0
+
+POM_NAME=Auth0.Android
+POM_DESCRIPTION=Android toolkit for Auth0 API
+POM_PACKAGING=aar
+
+POM_URL=https://github.com/auth0/Auth0.Android
+POM_SCM_URL=https://github.com/auth0/Auth0.Android
+POM_SCM_CONNECTION=scm:git@github.com:auth0/Auth0.Android.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:auth0/Auth0.Android.git
+
+POM_LICENCE_NAME=The MIT License (MIT)
+POM_LICENCE_URL=https://raw.githubusercontent.com/auth0/Auth0.Android/master/LICENSE
+POM_LICENCE_DIST=repo
+
+POM_DEVELOPER_ID=auth0
+POM_DEVELOPER_NAME=Auth0
+POM_DEVELOPER_EMAIL=oss@auth0.com
+
+
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app"s APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=false

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,0 +1,54 @@
+apply plugin: 'jacoco'
+
+jacoco {
+    toolVersion = "0.8.5"
+}
+
+android {
+    testOptions {
+        unitTests.all {
+            jacoco {
+                includeNoLocationClasses = true
+            }
+        }
+    }
+}
+
+afterEvaluate {
+    def jacocoTestReportTask = tasks.findByName("jacocoTestReport")
+    if (!jacocoTestReportTask) {
+        jacocoTestReportTask = tasks.create("jacocoTestReport")
+        jacocoTestReportTask.group = "Reporting"
+        jacocoTestReportTask.description = "Generate Jacoco coverage reports for all builds."
+    }
+
+    android.libraryVariants.all { variant ->
+        def name = variant.name
+        def testTaskName = "test${name.capitalize()}UnitTest"
+
+        def reportTask = tasks.create(name: "jacocoTest${name.capitalize()}UnitTestReport", type: JacocoReport, dependsOn: testTaskName) {
+            group = "Reporting"
+            description = "Generate Jacoco coverage reports for the ${name.capitalize()} build."
+
+            classDirectories.from = fileTree(
+                    dir: "${buildDir}/intermediates/javac/${name}",
+                    excludes: ['**/R.class',
+                               '**/R$*.class',
+                               '**/*$ViewInjector*.*',
+                               '**/*$ViewBinder*.*',
+                               '**/BuildConfig.*',
+                               '**/Manifest*.*']
+            )
+
+            sourceDirectories.from = ['src/main/java'].plus(android.sourceSets[name].java.srcDirs)
+            executionData.from = "${buildDir}/jacoco/${testTaskName}.exec"
+
+            reports {
+                xml.enabled = true
+                html.enabled = true
+            }
+        }
+        jacocoTestReportTask.dependsOn reportTask
+    }
+}
+

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -9,6 +9,7 @@ android {
         unitTests.all {
             jacoco {
                 includeNoLocationClasses = true
+                jacoco.excludes = ['jdk.internal.*']
             }
         }
     }

--- a/gradle/maven-publish.gradle
+++ b/gradle/maven-publish.gradle
@@ -1,0 +1,97 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+
+apply from: rootProject.file('gradle/versioning.gradle')
+
+task javadocJar(type: Jar, dependsOn: dokkaHtml) {
+    archiveClassifier = "javadoc"
+    from dokkaHtml.outputDirectory
+}
+
+task sourcesJar(type: Jar) {
+    archiveClassifier = 'sources'
+    from android.sourceSets.main.java.source
+}
+
+final releaseRepositoryUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+final snapshotRepositoryUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+
+publishing {
+    publications {
+        release(MavenPublication) {
+            groupId = GROUP
+            artifactId = POM_ARTIFACT_ID
+            version = getVersionName()
+
+            artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom {
+                name = POM_NAME
+                packaging = POM_PACKAGING
+                description = POM_DESCRIPTION
+                url = POM_URL
+
+                licenses {
+                    license {
+                        name = POM_LICENCE_NAME
+                        url = POM_LICENCE_URL
+                        distribution = POM_LICENCE_DIST
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = POM_DEVELOPER_ID
+                        name = POM_DEVELOPER_NAME
+                        email = POM_DEVELOPER_EMAIL
+                    }
+                }
+
+                scm {
+                    url = POM_SCM_URL
+                    connection = POM_SCM_CONNECTION
+                    developerConnection = POM_SCM_DEV_CONNECTION
+                }
+
+                withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    project.configurations.implementation.allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "sonatype"
+            url = version.endsWith('SNAPSHOT') ? snapshotRepositoryUrl : releaseRepositoryUrl
+            credentials {
+                username = System.getenv("MAVEN_USERNAME")
+                password = System.getenv("MAVEN_PASSWORD")
+            }
+        }
+    }
+}
+
+
+signing {
+    def signingKey = System.getenv("SIGNING_KEY")
+    def signingPassword = System.getenv("SIGNING_PASSWORD")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications
+}
+
+
+publish.dependsOn build
+tasks.named('signReleasePublication').configure {
+    dependsOn 'bundleReleaseAar'
+}
+

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -1,11 +1,17 @@
+def getVersionFromFile() {
+    def versionFile = rootProject.file('.version')
+    return versionFile.text.readLines().first().trim()
+}
+
 def isSnapshot() {
     return hasProperty('isSnapshot') ? isSnapshot.toBoolean() : true
 }
 
 def getVersionName() {
-    return isSnapshot() ? VERSION_NAME+"-SNAPSHOT" : VERSION_NAME
+    return isSnapshot() ? project.version+"-SNAPSHOT" : project.version
 }
 
 ext {
     getVersionName = this.&getVersionName
+    getVersionFromFile = this.&getVersionFromFile
 }

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -1,0 +1,11 @@
+def isSnapshot() {
+    return hasProperty('isSnapshot') ? isSnapshot.toBoolean() : true
+}
+
+def getVersionName() {
+    return isSnapshot() ? VERSION_NAME+"-SNAPSHOT" : VERSION_NAME
+}
+
+ext {
+    getVersionName = this.&getVersionName
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Changes

* Removed usage of oss-gradle-plugin for publishing the package
* updated gradle files to use `maven-publish` plugin for publishing
* updated gradle to version `7.3.3`
* updated release ci actions to use maven publish instead of oss-gradle-plugin
* updated authentication process with maven central to use token instead of passwords

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
