### PR TITLE
Clarify Readme around targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 Android API version 31 or later and Java 8+.
 
-> :warning: Applications targeting Android SDK version 30 and below should use version 2.9.0.
+> :warning: Applications targeting Android SDK version 30 (`targetSdkVersion = 30`) and below should use version 2.9.0.
 
 Here’s what you need in `build.gradle` to target Java 8 byte code for Android and Kotlin plugins respectively.
 


### PR DESCRIPTION
Update readme to make version requirements clearer.

In this context "targeting" may be understood as apps working on given SDK version (`minSdkVersion`)