### PR TITLE
BREAKING CHANGE: updated description of AuthenticationException in case of empty description

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
@@ -86,7 +86,7 @@ public class AuthenticationException : Auth0Exception {
         if (!TextUtils.isEmpty(description)) {
             return description!!
         }
-        return if (UNKNOWN_ERROR == getCode()) {
+        return if (UNKNOWN_ERROR != getCode()) {
             String.format("Received error with code %s", getCode())
         } else "Failed with unknown error"
     }

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationExceptionTest.kt
@@ -134,8 +134,7 @@ public class AuthenticationExceptionTest {
             CoreMatchers.`is`(
                 CoreMatchers.equalTo(
                     String.format(
-                        "Received error with code %s",
-                        Auth0Exception.UNKNOWN_ERROR
+                        "Failed with unknown error"
                     )
                 )
             )
@@ -150,7 +149,7 @@ public class AuthenticationExceptionTest {
         )
         MatcherAssert.assertThat(
             ex.getDescription(),
-            CoreMatchers.`is`(CoreMatchers.equalTo("Failed with unknown error"))
+            CoreMatchers.`is`(CoreMatchers.equalTo("Received error with code a_valid_code"))
         )
     }
 


### PR DESCRIPTION
### BREAKING CHANGE: updated description of AuthenticationException in case of empty description

Previously the `getException()` of `AuthenticationException` object is returning a string with value `Received error with code a0.sdk.internal_error.unknown` instead of `Failed with unknown error` due to an in-correct branching logic when the code of the exception is `a0.sdk.internal_error.unknown`.

We are fixing it as part of this to return the description as `Failed with unknown error`.



### References

https://github.com/auth0/Auth0.Android/issues/755

### Testing

All the existing unit tests are passing after updating them accordingly as per the code changes in this PR

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
