### PR TITLE
Added Passkey authentication support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1243,3 +1243,4 @@ The rules should be applied automatically if your application is using `minifyEn
 By default you should at least use the following files:
 * `proguard-okio.pro`
 * `proguard-gson.pro`
+* `proguard-jetpack.pro`

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -34,11 +34,11 @@ version = getVersionFromFile()
 logger.lifecycle("Using version ${version} for ${name}")
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 34
         versionCode 1
         versionName project.version
 
@@ -77,13 +77,14 @@ ext {
     powermockVersion = '2.0.9'
     coroutinesVersion = '1.6.2'
     biometricLibraryVersion = '1.1.0'
+    credentialManagerVersion = "1.3.0"
 }
 
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
     implementation 'androidx.browser:browser:1.4.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
@@ -110,6 +111,9 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
 
     testImplementation "androidx.biometric:biometric:$biometricLibraryVersion"
+
+    implementation "androidx.credentials:credentials-play-services-auth:$credentialManagerVersion"
+    implementation "androidx.credentials:credentials:$credentialManagerVersion"
 }
 
 apply from: rootProject.file('gradle/jacoco.gradle')

--- a/auth0/build.gradle
+++ b/auth0/build.gradle
@@ -45,7 +45,7 @@ android {
         buildConfigField "String", "LIBRARY_NAME", "\"$project.rootProject.name\""
         buildConfigField "String", "VERSION_NAME", "\"${project.version}\""
 
-        consumerProguardFiles '../proguard/proguard-gson.pro', '../proguard/proguard-okio.pro'
+        consumerProguardFiles '../proguard/proguard-gson.pro', '../proguard/proguard-okio.pro', '../proguard/proguard-jetpack.pro'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -157,7 +157,8 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     /**
      * Log in a user using passkeys.
      * This should be called after the client has received the Passkey challenge and Auth-session from the server .
-     * Requires the client to have the **Passkey** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
+     * Requires the client to have the **Passkey** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types)
+     * to learn how to enable it.
      *
      * @param authSession the auth session received from the server as part of the public challenge request.
      * @param authResponse the public key credential response to be sent to the server
@@ -185,7 +186,8 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     /**
      *  Register a user and returns a challenge.
-     *  Requires the client to have the **Passkey** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
+     *  Requires the client to have the **Passkey** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types)
+     *  to learn how to enable it.
      *
      *  @param userMetadata user information of the client
      *  @param parameters additional parameter to be sent as part of the request
@@ -220,7 +222,8 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
 
     /**
      * Request for a challenge to initiate a passkey login flow
-     * Requires the client to have the **Passkey** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
+     * Requires the client to have the **Passkey** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types)
+     * to learn how to enable it.
      *
      * @param realm An optional connection name
      * @return a request to configure and start that will yield [PasskeyChallengeResponse]

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -89,7 +89,8 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
             .set(USERNAME_KEY, usernameOrEmail)
             .set(PASSWORD_KEY, password)
             .setGrantType(ParameterBuilder.GRANT_TYPE_PASSWORD_REALM)
-            .setRealm(realmOrConnection).asDictionary()
+            .setRealm(realmOrConnection)
+            .asDictionary()
         return loginWithToken(parameters)
     }
 
@@ -175,7 +176,10 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         }.asDictionary()
 
         return loginWithToken(params)
-            .addParameter(AUTH_RESPONSE_KEY, Gson().toJsonTree(authResponse)) as AuthenticationRequest
+            .addParameter(
+                AUTH_RESPONSE_KEY,
+                Gson().toJsonTree(authResponse)
+            ) as AuthenticationRequest
     }
 
 

--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
@@ -159,6 +159,7 @@ public class ParameterBuilder private constructor(parameters: Map<String, String
             "http://auth0.com/oauth/grant-type/passwordless/otp"
         public const val GRANT_TYPE_TOKEN_EXCHANGE: String =
             "urn:ietf:params:oauth:grant-type:token-exchange"
+        public const val GRANT_TYPE_PASSKEY :String = "urn:okta:params:oauth:grant-type:webauthn"
         public const val SCOPE_OPENID: String = "openid"
         public const val SCOPE_OFFLINE_ACCESS: String = "openid offline_access"
         public const val SCOPE_KEY: String = "scope"

--- a/auth0/src/main/java/com/auth0/android/provider/PasskeyAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/PasskeyAuthProvider.kt
@@ -3,7 +3,9 @@ package com.auth0.android.provider
 import android.content.Context
 import android.os.Build
 import android.util.Log
+import androidx.credentials.CredentialManager
 import com.auth0.android.Auth0
+import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.authentication.ParameterBuilder
 import com.auth0.android.callback.Callback
@@ -96,7 +98,11 @@ public object PasskeyAuthProvider {
                 callback.onFailure(ex)
                 return
             }
-            val passkeyManager = PasskeyManager(auth0)
+            val passkeyManager =
+                PasskeyManager(
+                    AuthenticationAPIClient(auth0),
+                    CredentialManager.create(context)
+                )
             passkeyManager.signin(context, parameters, callback, executor)
         }
     }
@@ -204,7 +210,11 @@ public object PasskeyAuthProvider {
                 callback.onFailure(ex)
                 return
             }
-            val passkeyManager = PasskeyManager(auth0)
+            val passkeyManager =
+                PasskeyManager(
+                    AuthenticationAPIClient(auth0),
+                    CredentialManager.create(context)
+                )
             val userMetadata = UserMetadataRequest(email, phoneNumber, username, name)
             passkeyManager.signup(
                 context, userMetadata, parameters, callback, executor

--- a/auth0/src/main/java/com/auth0/android/provider/PasskeyAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/PasskeyAuthProvider.kt
@@ -1,0 +1,214 @@
+package com.auth0.android.provider
+
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import com.auth0.android.Auth0
+import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.ParameterBuilder
+import com.auth0.android.callback.Callback
+import com.auth0.android.request.UserMetadataRequest
+import com.auth0.android.result.Credentials
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+/**
+ * Passkey authentication provider
+ */
+public object PasskeyAuthProvider {
+
+    private val TAG = PasskeyManager::class.simpleName
+
+    /**
+     * Initialize the PasskeyAuthProvider instance for signing up a user . Additional settings can be configured in the
+     * SignupBuilder.
+     *
+     * @param auth0 [Auth0] instance to be used for authentication
+     * @return a new builder instance to customize
+     */
+    @JvmStatic
+    public fun signUp(auth0: Auth0): SignupBuilder {
+        return SignupBuilder(auth0)
+    }
+
+    /**
+     * Initialize the PasskeyAuthProvider instance for signing in a user. Additional settings can be configured in the
+     * SignInBuilder
+     *
+     * @param auth0 [Auth0] instance to be used for authentication
+     * @return a new builder instance to customize
+     */
+    public fun signIn(auth0: Auth0): SignInBuilder {
+        return SignInBuilder(auth0)
+    }
+
+
+    public class SignInBuilder internal constructor(private val auth0: Auth0) {
+        private val parameters: MutableMap<String, String> = mutableMapOf()
+
+        /**
+         * Specify the scope for this request.
+         *
+         * @param scope to request
+         * @return the current builder instance
+         */
+        public fun setScope(scope: String): SignInBuilder = apply {
+            parameters[ParameterBuilder.SCOPE_KEY] = scope
+        }
+
+        /**
+         * Specify the custom audience for this request.
+         *
+         * @param audience to use in this request
+         * @return the current builder instance
+         */
+        public fun setAudience(audience: String): SignInBuilder = apply {
+            parameters[ParameterBuilder.AUDIENCE_KEY] = audience
+        }
+
+        /**
+         * Specify the realm for this request
+         *
+         * @param realm to use in this request
+         * @return the current builder instance
+         */
+        public fun setRealm(realm: String): SignInBuilder = apply {
+            parameters[ParameterBuilder.REALM_KEY] = realm
+        }
+
+        /**
+         * Request user authentication using passkey. The result will be received in the callback.
+         *
+         * @param context context to run the authentication
+         * @param callback to receive the result
+         * @param executor optional executor to run the public key credential response creation
+         */
+        public fun start(
+            context: Context,
+            callback: Callback<Credentials, AuthenticationException>,
+            executor: Executor = Executors.newSingleThreadExecutor()
+        ) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+                Log.w(TAG, "Requires Android 9 or higher to use passkey authentication ")
+                val ex = AuthenticationException(
+                    "Requires Android 9 or higher"
+                )
+                callback.onFailure(ex)
+                return
+            }
+            val passkeyManager = PasskeyManager(auth0)
+            passkeyManager.signin(context, parameters, callback, executor)
+        }
+    }
+
+
+    public class SignupBuilder internal constructor(private val auth0: Auth0) {
+        private var username: String? = null
+        private var email: String? = null
+        private var name: String? = null
+        private var phoneNumber: String? = null
+
+        private val parameters: MutableMap<String, String> = mutableMapOf()
+
+        /**
+         * Specify the realm for this request
+         *
+         * @param realm to use in this request
+         * @return the current builder instance
+         */
+        public fun setRealm(realm: String): SignupBuilder = apply {
+            parameters[ParameterBuilder.REALM_KEY] = realm
+        }
+
+        /**
+         * Specify the email for the user.
+         * Email can be optional,required or forbidden depending on the attribute configuration for the database
+         *
+         * @param email to be set
+         * @return the current builder instance
+         */
+        public fun setEmail(email: String): SignupBuilder = apply {
+            this.email = email
+        }
+
+        /**
+         * Specify the username for the user.
+         * Username can be optional,required or forbidden depending on the attribute configuration for the database
+         *
+         * @param username to be set
+         * @return the current builder instance
+         */
+        public fun setUserName(username: String): SignupBuilder = apply {
+            this.username = username
+        }
+
+        /**
+         * Specify the name for the user.
+         * Name can be optional,required or forbidden depending on the attribute configuration for the database
+         *
+         * @param name to be set
+         * @return the current builder instance
+         */
+        public fun setName(name: String): SignupBuilder = apply {
+            this.name = name
+        }
+
+        /**
+         * Specify the phone number for the user
+         * Phone number can be optional,required or forbidden depending on the attribute configuration for the database
+         *
+         * @param number to be set
+         * @return the current builder instance
+         */
+        public fun setPhoneNumber(number: String): SignupBuilder = apply {
+            this.phoneNumber = number
+        }
+
+        /**
+         * Specify the scope for this request.
+         *
+         * @param scope to request
+         * @return the current builder instance
+         */
+        public fun setScope(scope: String): SignupBuilder = apply {
+            parameters[ParameterBuilder.SCOPE_KEY] = scope
+        }
+
+        /**
+         * Specify the custom audience for this request.
+         *
+         * @param audience to use in this request
+         * @return the current builder instance
+         */
+        public fun setAudience(audience: String): SignupBuilder = apply {
+            parameters[ParameterBuilder.AUDIENCE_KEY] = audience
+        }
+
+        /**
+         * Request user signup and authentication using passkey. The result will be received in the callback.
+         *
+         * @param context context to run the authentication
+         * @param callback to receive the result
+         * @param executor optional executor to run the public key credential response creation
+         */
+        public fun start(
+            context: Context,
+            callback: Callback<Credentials, AuthenticationException>,
+            executor: Executor = Executors.newSingleThreadExecutor()
+        ) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+                Log.w(TAG, "Requires Android 9 or higher to use passkey authentication ")
+                val ex = AuthenticationException(
+                    "Requires Android 9 or higher"
+                )
+                callback.onFailure(ex)
+                return
+            }
+            val passkeyManager = PasskeyManager(auth0)
+            val userMetadata = UserMetadataRequest(email, phoneNumber, username, name)
+            passkeyManager.signup(
+                context, userMetadata, parameters, callback, executor
+            )
+        }
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/provider/PasskeyManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/PasskeyManager.kt
@@ -127,7 +127,7 @@ internal class PasskeyManager(
                             CredentialManagerCallback<GetCredentialResponse, GetCredentialException> {
                             override fun onError(e: GetCredentialException) {
                                 Log.w(TAG, "Error while fetching public key credential")
-                                handleGetCredentialFailure(e)
+                                callback.onFailure(handleGetCredentialFailure(e))
                             }
 
                             override fun onResult(result: GetCredentialResponse) {

--- a/auth0/src/main/java/com/auth0/android/provider/PasskeyManager.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/PasskeyManager.kt
@@ -1,0 +1,242 @@
+package com.auth0.android.provider
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Build
+import android.os.CancellationSignal
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.credentials.CreateCredentialResponse
+import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.CreatePublicKeyCredentialResponse
+import androidx.credentials.CredentialManager
+import androidx.credentials.CredentialManagerCallback
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.PublicKeyCredential
+import androidx.credentials.exceptions.CreateCredentialCancellationException
+import androidx.credentials.exceptions.CreateCredentialException
+import androidx.credentials.exceptions.CreateCredentialInterruptedException
+import androidx.credentials.exceptions.CreateCredentialProviderConfigurationException
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.GetCredentialInterruptedException
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException
+import androidx.credentials.exceptions.GetCredentialUnknownException
+import androidx.credentials.exceptions.GetCredentialUnsupportedException
+import androidx.credentials.exceptions.NoCredentialException
+import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
+import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialDomException
+import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialException
+import com.auth0.android.Auth0
+import com.auth0.android.authentication.AuthenticationAPIClient
+import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.ParameterBuilder
+import com.auth0.android.callback.Callback
+import com.auth0.android.request.PublicKeyCredentialResponse
+import com.auth0.android.request.UserMetadataRequest
+import com.auth0.android.result.Credentials
+import com.auth0.android.result.PasskeyChallengeResponse
+import com.auth0.android.result.PasskeyRegistrationResponse
+import com.google.gson.Gson
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+
+internal class PasskeyManager(auth0: Auth0) {
+    private val TAG = PasskeyManager::class.simpleName
+    private val authenticationAPIClient: AuthenticationAPIClient = AuthenticationAPIClient(auth0)
+
+    @RequiresApi(api = Build.VERSION_CODES.P)
+    @SuppressLint("PublicKeyCredential")
+    fun signup(
+        context: Context,
+        userMetadata: UserMetadataRequest,
+        parameters: Map<String, String>,
+        callback: Callback<Credentials, AuthenticationException>,
+        executor: Executor = Executors.newSingleThreadExecutor()
+    ) {
+        val credentialManager = CredentialManager.create(context)
+
+        authenticationAPIClient.signupWithPasskey(userMetadata, parameters)
+            .start(object : Callback<PasskeyRegistrationResponse, AuthenticationException> {
+                override fun onSuccess(result: PasskeyRegistrationResponse) {
+                    val pasKeyRegistrationResponse = result
+                    val request = CreatePublicKeyCredentialRequest(
+                        Gson().toJson(
+                            pasKeyRegistrationResponse.authParamsPublicKey
+                        )
+                    )
+                    var response: CreatePublicKeyCredentialResponse?
+
+                    credentialManager.createCredentialAsync(context,
+                        request,
+                        CancellationSignal(),
+                        executor,
+                        object :
+                            CredentialManagerCallback<CreateCredentialResponse, CreateCredentialException> {
+
+                            override fun onError(e: CreateCredentialException) {
+                                Log.w(TAG, "Error while creating passkey")
+                                callback.onFailure(handleCreationFailure(e))
+                            }
+
+                            override fun onResult(result: CreateCredentialResponse) {
+
+                                response = result as CreatePublicKeyCredentialResponse
+                                val authRequest = Gson().fromJson(
+                                    response?.registrationResponseJson,
+                                    PublicKeyCredentialResponse::class.java
+                                )
+                                authenticationAPIClient.signinWithPasskey(
+                                    pasKeyRegistrationResponse.authSession, authRequest, parameters
+                                ).start(callback)
+                            }
+                        })
+
+                }
+
+                override fun onFailure(error: AuthenticationException) {
+                    callback.onFailure(error)
+                }
+            })
+
+    }
+
+
+    @RequiresApi(api = Build.VERSION_CODES.P)
+    fun signin(
+        context: Context,
+        parameters: Map<String, String>,
+        callback: Callback<Credentials, AuthenticationException>,
+        executor: Executor = Executors.newSingleThreadExecutor()
+    ) {
+        val credentialManager = CredentialManager.create(context)
+        authenticationAPIClient.passkeyChallenge(parameters[ParameterBuilder.REALM_KEY])
+            .start(object : Callback<PasskeyChallengeResponse, AuthenticationException> {
+                override fun onSuccess(result: PasskeyChallengeResponse) {
+                    val passkeyChallengeResponse = result
+                    val request =
+                        GetPublicKeyCredentialOption(Gson().toJson(passkeyChallengeResponse.authParamsPublicKey))
+                    val getCredRequest = GetCredentialRequest(
+                        listOf(request)
+                    )
+                    credentialManager.getCredentialAsync(context,
+                        getCredRequest,
+                        CancellationSignal(),
+                        executor,
+                        object :
+                            CredentialManagerCallback<GetCredentialResponse, GetCredentialException> {
+                            override fun onError(e: GetCredentialException) {
+                                Log.w(TAG, "Error while fetching public key credential")
+                                handleGetCredentialFailure(e)
+                            }
+
+                            override fun onResult(result: GetCredentialResponse) {
+                                when (val credential = result.credential) {
+                                    is PublicKeyCredential -> {
+                                        val authRequest = Gson().fromJson(
+                                            credential.authenticationResponseJson,
+                                            PublicKeyCredentialResponse::class.java
+                                        )
+                                        authenticationAPIClient.signinWithPasskey(
+                                            passkeyChallengeResponse.authSession,
+                                            authRequest,
+                                            parameters
+                                        )
+                                            .validateClaims()
+                                            .start(callback)
+                                    }
+
+                                    else -> {
+                                        Log.w(
+                                            TAG,
+                                            "Received unrecognized credential type ${credential.type}.This shouldn't happen"
+                                        )
+                                        callback.onFailure(AuthenticationException("Received unrecognized credential type ${credential.type}"))
+                                    }
+                                }
+                            }
+                        })
+
+                }
+
+                override fun onFailure(error: AuthenticationException) {
+                    callback.onFailure(error)
+                }
+            })
+
+    }
+
+    private fun handleCreationFailure(exception: CreateCredentialException): AuthenticationException {
+        return when (exception) {
+
+            is CreateCredentialCancellationException -> {
+                AuthenticationException(
+                    AuthenticationException.ERROR_VALUE_AUTHENTICATION_CANCELED,
+                    "The user cancelled passkey authentication operation."
+                )
+            }
+
+            is CreateCredentialInterruptedException -> {
+                AuthenticationException(
+                    "Passkey authentication was interrupted. Please retry the call."
+                )
+            }
+
+            is CreateCredentialProviderConfigurationException -> {
+                AuthenticationException(
+                    "Provider configuration dependency is missing. Ensure credentials-play-services-auth dependency is added."
+                )
+            }
+
+            else -> {
+                Log.w(TAG, "Unexpected exception type ${exception::class.java.name}")
+                AuthenticationException(
+                    "An error occurred when trying to authenticate with passkey"
+                )
+            }
+        }
+    }
+
+    private fun handleGetCredentialFailure(exception: GetCredentialException): AuthenticationException {
+
+        return when (exception) {
+            is GetCredentialCancellationException -> {
+                AuthenticationException(
+                    AuthenticationException.ERROR_VALUE_AUTHENTICATION_CANCELED,
+                    "The user cancelled passkey authentication operation."
+                )
+            }
+
+            is GetCredentialInterruptedException -> {
+                AuthenticationException(
+                    "Passkey authentication was interrupted. Please retry the call."
+                )
+            }
+
+            is GetCredentialUnsupportedException -> {
+                AuthenticationException(
+                    "Credential manager is unsupported. Please update the device."
+                )
+            }
+
+
+            is NoCredentialException -> {
+                AuthenticationException(
+                    "No viable credential is available for the user"
+                )
+            }
+
+
+            else -> {
+                Log.w(TAG, "Unexpected exception type ${exception::class.java.name}")
+                AuthenticationException(
+                    "An error occurred when trying to authenticate with passkey"
+                )
+            }
+        }
+    }
+
+}

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -8,15 +8,15 @@ import androidx.annotation.VisibleForTesting
 import com.auth0.android.Auth0
 import com.auth0.android.annotation.ExperimentalAuth0Api
 import com.auth0.android.authentication.AuthenticationException
-import com.auth0.android.authentication.storage.CredentialsManagerException
 import com.auth0.android.callback.Callback
 import com.auth0.android.result.Credentials
-import kotlinx.coroutines.*
-import java.util.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.util.Locale
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlin.jvm.Throws
 
 /**
  * OAuth2 Web Authentication Provider.

--- a/auth0/src/main/java/com/auth0/android/request/PublicKeyCredentialRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/PublicKeyCredentialRequest.kt
@@ -1,0 +1,45 @@
+package com.auth0.android.request
+
+
+import com.google.gson.annotations.SerializedName
+
+internal data class PublicKeyCredentialResponse(
+    @SerializedName("authenticatorAttachment")
+    val authenticatorAttachment: String,
+    @SerializedName("clientExtensionResults")
+    val clientExtensionResults: ClientExtensionResults,
+    @SerializedName("id")
+    val id: String,
+    @SerializedName("rawId")
+    val rawId: String,
+    @SerializedName("response")
+    val response: Response,
+    @SerializedName("type")
+    val type: String
+)
+
+
+public data class Response(
+    @SerializedName("attestationObject")
+    val attestationObject: String,
+    @SerializedName("authenticatorData")
+    val authenticatorData: String,
+    @SerializedName("clientDataJSON")
+    val clientDataJSON: String,
+    @SerializedName("transports")
+    val transports: List<String>,
+    @SerializedName("signature")
+    val signature:String,
+    @SerializedName("userHandle")
+    val userHandle:String
+)
+
+public data class CredProps(
+    @SerializedName("rk")
+    val rk: Boolean
+)
+
+public data class ClientExtensionResults(
+    @SerializedName("credProps")
+    val credProps: CredProps
+)

--- a/auth0/src/main/java/com/auth0/android/request/Request.kt
+++ b/auth0/src/main/java/com/auth0/android/request/Request.kt
@@ -56,6 +56,18 @@ public interface Request<T, U : Auth0Exception> {
      */
     public fun addParameter(name: String, value: String): Request<T, U>
 
+
+    /**
+     * Add parameter of [Any] type to the request with a given name
+     *
+     * @param name  of the parameter
+     * @param value of the parameter
+     * @return itself
+     */
+    public fun addParameter(name: String,value:Any):Request<T,U> {
+        return this
+    }
+
     /**
      * Adds an additional header for the request
      *

--- a/auth0/src/main/java/com/auth0/android/request/UserMetadataRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/UserMetadataRequest.kt
@@ -1,0 +1,13 @@
+package com.auth0.android.request
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ *  User metadata request used in Passkey authentication
+ */
+internal data class UserMetadataRequest(
+    @field:SerializedName("email") val email: String? = null,
+    @field:SerializedName("phone_number") val phoneNumber: String? = null,
+    @field:SerializedName("username") val userName: String? = null,
+    @field:SerializedName("name") val name: String? = null,
+)

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseAuthenticationRequest.kt
@@ -17,7 +17,8 @@ import java.util.*
 
 internal open class BaseAuthenticationRequest(
     private val request: Request<Credentials, AuthenticationException>,
-    private val clientId: String, baseURL: String) : AuthenticationRequest {
+    private val clientId: String, baseURL: String
+) : AuthenticationRequest {
 
     private companion object {
         private val TAG = BaseAuthenticationRequest::class.java.simpleName
@@ -28,8 +29,10 @@ internal open class BaseAuthenticationRequest(
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var validateClaims = false
+
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var idTokenVerificationLeeway: Int? = null
+
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var idTokenVerificationIssuer: String = baseURL
 
@@ -121,6 +124,11 @@ internal open class BaseAuthenticationRequest(
         return this
     }
 
+    override fun addParameter(name: String, value: Any): AuthenticationRequest {
+        request.addParameter(name, value)
+        return this
+    }
+
     override fun addHeader(name: String, value: String): AuthenticationRequest {
         request.addHeader(name, value)
         return this
@@ -130,7 +138,7 @@ internal open class BaseAuthenticationRequest(
         warnClaimValidation()
         request.start(object : Callback<Credentials, AuthenticationException> {
             override fun onSuccess(result: Credentials) {
-                if(validateClaims) {
+                if (validateClaims) {
                     try {
                         verifyClaims(result.idToken)
                     } catch (e: AuthenticationException) {
@@ -151,7 +159,7 @@ internal open class BaseAuthenticationRequest(
     override fun execute(): Credentials {
         warnClaimValidation()
         val credentials = request.execute()
-        if(validateClaims) {
+        if (validateClaims) {
             verifyClaims(credentials.idToken)
         }
         return credentials
@@ -162,7 +170,7 @@ internal open class BaseAuthenticationRequest(
     override suspend fun await(): Credentials {
         warnClaimValidation()
         val credentials = request.await()
-        if(validateClaims) {
+        if (validateClaims) {
             verifyClaims(credentials.idToken)
         }
         return credentials
@@ -199,8 +207,11 @@ internal open class BaseAuthenticationRequest(
     }
 
     private fun warnClaimValidation() {
-        if(!validateClaims) {
-            Log.e(TAG, "The request is made without validating claims. Enable claim validation by calling AuthenticationRequest#validateClaims()")
+        if (!validateClaims) {
+            Log.e(
+                TAG,
+                "The request is made without validating claims. Enable claim validation by calling AuthenticationRequest#validateClaims()"
+            )
         }
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
@@ -55,7 +55,7 @@ internal open class BaseRequest<T, U : Auth0Exception>(
         return addParameter(name, anyValue)
     }
 
-    internal fun addParameter(name: String, value: Any): Request<T, U> {
+    override fun addParameter(name: String, value: Any): Request<T, U> {
         options.parameters[name] = value
         return this
     }

--- a/auth0/src/main/java/com/auth0/android/result/PasskeyChallengeResponse.kt
+++ b/auth0/src/main/java/com/auth0/android/result/PasskeyChallengeResponse.kt
@@ -1,0 +1,22 @@
+package com.auth0.android.result
+
+
+import com.google.gson.annotations.SerializedName
+
+internal data class PasskeyChallengeResponse(
+    @SerializedName("auth_session")
+    val authSession: String,
+    @SerializedName("authn_params_public_key")
+    val authParamsPublicKey: AuthParamsPublicKey
+)
+
+internal data class AuthParamsPublicKey(
+    @SerializedName("challenge")
+    val challenge: String,
+    @SerializedName("rpId")
+    val rpId: String,
+    @SerializedName("timeout")
+    val timeout: Int,
+    @SerializedName("userVerification")
+    val userVerification: String
+)

--- a/auth0/src/main/java/com/auth0/android/result/PasskeyRegistrationResponse.kt
+++ b/auth0/src/main/java/com/auth0/android/result/PasskeyRegistrationResponse.kt
@@ -1,0 +1,56 @@
+package com.auth0.android.result
+
+
+import com.google.gson.annotations.SerializedName
+
+internal data class PasskeyRegistrationResponse(
+    @SerializedName("auth_session")
+    val authSession: String,
+    @SerializedName("authn_params_public_key")
+    val authParamsPublicKey: AuthnParamsPublicKey
+)
+
+internal data class AuthnParamsPublicKey(
+    @SerializedName("authenticatorSelection")
+    val authenticatorSelection: AuthenticatorSelection,
+    @SerializedName("challenge")
+    val challenge: String,
+    @SerializedName("pubKeyCredParams")
+    val pubKeyCredParams: List<PubKeyCredParam>,
+    @SerializedName("rp")
+    val relyingParty: RelyingParty,
+    @SerializedName("timeout")
+    val timeout: Long,
+    @SerializedName("user")
+    val user: PasskeyUser
+)
+
+internal data class AuthenticatorSelection(
+    @SerializedName("residentKey")
+    val residentKey: String,
+    @SerializedName("userVerification")
+    val userVerification: String
+)
+
+internal data class PubKeyCredParam(
+    @SerializedName("alg")
+    val alg: Int,
+    @SerializedName("type")
+    val type: String
+)
+
+internal data class RelyingParty(
+    @SerializedName("id")
+    val id: String,
+    @SerializedName("name")
+    val name: String
+)
+
+internal data class PasskeyUser(
+    @SerializedName("displayName")
+    val displayName: String,
+    @SerializedName("id")
+    val id: String,
+    @SerializedName("name")
+    val name: String
+)

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -9,18 +9,31 @@ import com.auth0.android.request.HttpMethod
 import com.auth0.android.request.NetworkingClient
 import com.auth0.android.request.RequestOptions
 import com.auth0.android.request.ServerResponse
+import com.auth0.android.request.UserMetadataRequest
 import com.auth0.android.request.internal.RequestFactory
 import com.auth0.android.request.internal.ThreadSwitcherShadow
-import com.auth0.android.result.*
+import com.auth0.android.result.Authentication
+import com.auth0.android.result.Challenge
+import com.auth0.android.result.Credentials
+import com.auth0.android.result.DatabaseUser
+import com.auth0.android.result.PasskeyRegistrationResponse
+import com.auth0.android.result.UserProfile
 import com.auth0.android.util.Auth0UserAgent
 import com.auth0.android.util.AuthenticationAPIMockServer
+import com.auth0.android.util.AuthenticationAPIMockServer.Companion.SESSION_ID
 import com.auth0.android.util.AuthenticationCallbackMatcher
 import com.auth0.android.util.MockAuthenticationCallback
 import com.auth0.android.util.SSLTestUtils.testClient
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.google.gson.JsonElement
 import com.google.gson.reflect.TypeToken
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -39,7 +52,7 @@ import java.io.ByteArrayInputStream
 import java.io.FileReader
 import java.io.InputStream
 import java.security.PublicKey
-import java.util.*
+import java.util.Locale
 
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ThreadSwitcherShadow::class])
@@ -173,6 +186,84 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.not(Matchers.hasKey("username")))
         assertThat(body, Matchers.not(Matchers.hasKey("password")))
         assertThat(body, Matchers.not(Matchers.hasKey("connection")))
+    }
+
+    @Test
+    public fun shouldSigninWithPasskey() {
+        mockAPI.willReturnSuccessfulLogin()
+        val callback = MockAuthenticationCallback<Credentials>()
+        val auth0 = auth0
+        val client = AuthenticationAPIClient(auth0)
+        client.signinWithPasskey("auth-session", mock(), emptyMap())
+            .start(callback)
+        ShadowLooper.idleMainLooper()
+        assertThat(
+            callback, AuthenticationCallbackMatcher.hasPayloadOfType(
+                Credentials::class.java
+            )
+        )
+        val request = mockAPI.takeRequest()
+        assertThat(
+            request.getHeader("Accept-Language"), Matchers.`is`(
+                defaultLocale
+            )
+        )
+        val body = bodyFromRequest<String>(request)
+        assertThat(request.path, Matchers.equalTo("/oauth/token"))
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
+        assertThat(
+            body,
+            Matchers.hasEntry("grant_type", "urn:okta:params:oauth:grant-type:webauthn")
+        )
+        assertThat(body, Matchers.hasKey("authn_response"))
+        assertThat(body, Matchers.hasEntry("auth_session", "auth-session"))
+    }
+
+    @Test
+    public fun shouldSignupWithPasskey() {
+        mockAPI.willReturnSuccessfulPasskeyRegistration()
+        val auth0 = auth0
+        val client = AuthenticationAPIClient(auth0)
+        val registrationResponse = client.signupWithPasskey(
+            mock(),
+            mapOf("realm" to MY_CONNECTION)
+        )
+            .execute()
+        val request = mockAPI.takeRequest()
+        assertThat(
+            request.getHeader("Accept-Language"), Matchers.`is`(
+                defaultLocale
+            )
+        )
+        val body = bodyFromRequest<String>(request)
+        assertThat(request.path, Matchers.equalTo("/passkey/register"))
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
+        assertThat(body, Matchers.hasEntry("realm", MY_CONNECTION))
+        assertThat(body, Matchers.hasKey("user_profile"))
+        assertThat(registrationResponse, Matchers.`is`(Matchers.notNullValue()))
+        assertThat(registrationResponse.authSession, Matchers.comparesEqualTo(SESSION_ID))
+    }
+
+    @Test
+    public fun shouldGetPasskeyChallenge() {
+        mockAPI.willReturnSuccessfulPasskeyChallenge()
+        val auth0 = auth0
+        val client = AuthenticationAPIClient(auth0)
+        val challengeResponse = client.passkeyChallenge(MY_CONNECTION)
+            .execute()
+        val request = mockAPI.takeRequest()
+        assertThat(
+            request.getHeader("Accept-Language"), Matchers.`is`(
+                defaultLocale
+            )
+        )
+        val body = bodyFromRequest<String>(request)
+        assertThat(request.path, Matchers.equalTo("/passkey/challenge"))
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
+        assertThat(body, Matchers.hasEntry("realm", MY_CONNECTION))
+        assertThat(challengeResponse, Matchers.`is`(Matchers.notNullValue()))
+        assertThat(challengeResponse.authSession, Matchers.comparesEqualTo(SESSION_ID))
+
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/request/AuthenticationRequestMock.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/AuthenticationRequestMock.java
@@ -6,6 +6,7 @@ import com.auth0.android.Auth0Exception;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.callback.Callback;
 import com.auth0.android.request.AuthenticationRequest;
+import com.auth0.android.request.Request;
 import com.auth0.android.result.Credentials;
 
 import java.util.Map;
@@ -45,6 +46,12 @@ public class AuthenticationRequestMock implements AuthenticationRequest {
     @NonNull
     @Override
     public AuthenticationRequest addParameter(@NonNull String name, @NonNull String value) {
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public Request<Credentials, AuthenticationException> addParameter(@NonNull String name, @NonNull Object value) {
         return this;
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/request/RequestMock.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/request/RequestMock.java
@@ -55,4 +55,10 @@ public class RequestMock<T, U extends Auth0Exception> implements Request<T, U> {
     public T execute() throws Auth0Exception {
         return null;
     }
+
+    @NonNull
+    @Override
+    public Request<T, U> addParameter(@NonNull String name, @NonNull Object value) {
+        return this;
+    }
 }

--- a/auth0/src/test/java/com/auth0/android/provider/PasskeyManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/PasskeyManagerTest.kt
@@ -1,0 +1,362 @@
+package com.auth0.android.provider
+
+import android.content.Context
+import androidx.credentials.CreateCredentialResponse
+import androidx.credentials.CreatePublicKeyCredentialResponse
+import androidx.credentials.CredentialManager
+import androidx.credentials.CredentialManagerCallback
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.PublicKeyCredential
+import androidx.credentials.exceptions.CreateCredentialException
+import androidx.credentials.exceptions.CreateCredentialInterruptedException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.GetCredentialInterruptedException
+import com.auth0.android.authentication.AuthenticationAPIClient
+import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.request.AuthenticationRequestMock
+import com.auth0.android.authentication.request.RequestMock
+import com.auth0.android.callback.Callback
+import com.auth0.android.request.UserMetadataRequest
+import com.auth0.android.result.AuthParamsPublicKey
+import com.auth0.android.result.AuthenticatorSelection
+import com.auth0.android.result.AuthnParamsPublicKey
+import com.auth0.android.result.Credentials
+import com.auth0.android.result.PasskeyChallengeResponse
+import com.auth0.android.result.PasskeyRegistrationResponse
+import com.auth0.android.result.PasskeyUser
+import com.auth0.android.result.PubKeyCredParam
+import com.auth0.android.result.RelyingParty
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import java.util.Date
+import java.util.concurrent.Executor
+
+
+@RunWith(RobolectricTestRunner::class)
+public class PasskeyManagerTest {
+
+    private lateinit var passkeyManager: PasskeyManager
+
+    @Mock
+    private lateinit var callback: Callback<Credentials, AuthenticationException>
+
+    @Mock
+    private lateinit var authenticationAPIClient: AuthenticationAPIClient
+
+    @Mock
+    private lateinit var credentialManager: CredentialManager
+
+    @Mock
+    private lateinit var context: Context
+
+    private val serialExecutor = Executor { runnable -> runnable.run() }
+
+    private val credentialsCaptor: KArgumentCaptor<Credentials> = argumentCaptor()
+    private val exceptionCaptor: KArgumentCaptor<AuthenticationException> = argumentCaptor()
+
+
+    private val passkeyRegistrationResponse = PasskeyRegistrationResponse(
+        authSession = "dummyAuthSession",
+        authParamsPublicKey = AuthnParamsPublicKey(
+            authenticatorSelection = AuthenticatorSelection(
+                residentKey = "required",
+                userVerification = "preferred"
+            ),
+            challenge = "dummyChallenge",
+            pubKeyCredParams = listOf(
+                PubKeyCredParam(
+                    alg = -7,
+                    type = "public-key"
+                )
+            ),
+            relyingParty = RelyingParty(
+                id = "dummyRpId",
+                name = "dummyRpName"
+            ),
+            timeout = 60000L,
+            user = PasskeyUser(
+                displayName = "displayName",
+                id = "userId",
+                name = "userName"
+            )
+        )
+    )
+
+    private val registrationResponseJSON = """
+        {
+            "id": "id",
+            "rawId": "rawId",
+            "response": {
+                "attestationObject": "attnObject",
+                "clientDataJSON": "dataJSON"
+            },
+            "type": "public-key"
+        }
+    """
+
+    private val passkeyChallengeResponse = PasskeyChallengeResponse(
+        authSession = "authSession",
+        authParamsPublicKey = AuthParamsPublicKey(
+            challenge = "challenge",
+            rpId = "RpId",
+            timeout = 60000,
+            userVerification = "preferred"
+        )
+    )
+
+    @Before
+    public fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        passkeyManager = PasskeyManager(authenticationAPIClient, credentialManager)
+    }
+
+
+    @Test
+    public fun shouldSignUpWithPasskeySuccess() {
+        val userMetadata: UserMetadataRequest = mock()
+        val parameters = mapOf("realm" to "testRealm")
+
+        `when`(authenticationAPIClient.signupWithPasskey(userMetadata, parameters)).thenReturn(
+            RequestMock(passkeyRegistrationResponse, null)
+        )
+        `when`(authenticationAPIClient.signinWithPasskey(any(), any(), any())).thenReturn(
+            AuthenticationRequestMock(
+                Credentials(
+                    "expectedIdToken",
+                    "codeAccess",
+                    "codeType",
+                    "codeRefresh",
+                    Date(),
+                    "codeScope"
+                ), null
+            )
+        )
+
+        val createResponse: CreatePublicKeyCredentialResponse = mock()
+        `when`(createResponse.registrationResponseJson).thenReturn(
+            registrationResponseJSON
+        )
+
+        whenever(
+            credentialManager.createCredentialAsync(
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        ).thenAnswer {
+            (it.arguments[4] as CredentialManagerCallback<CreateCredentialResponse, CreateCredentialException>).onResult(
+                createResponse
+            )
+        }
+
+        passkeyManager.signup(context, userMetadata, parameters, callback, serialExecutor)
+
+        verify(authenticationAPIClient).signupWithPasskey(userMetadata, parameters)
+        verify(credentialManager).createCredentialAsync(eq(context), any(), any(), any(), any())
+        verify(authenticationAPIClient).signinWithPasskey(any(), any(), any())
+        verify(callback).onSuccess(credentialsCaptor.capture())
+        Assert.assertEquals("codeAccess", credentialsCaptor.firstValue.accessToken)
+        Assert.assertEquals("codeScope", credentialsCaptor.firstValue.scope)
+
+    }
+
+    @Test
+    public fun shouldSignUpWithPasskeyApiFailure() {
+        val userMetadata: UserMetadataRequest = mock()
+        val parameters = mapOf("realm" to "testRealm")
+        val error = AuthenticationException("Signup failed")
+        `when`(
+            authenticationAPIClient.signupWithPasskey(
+                userMetadata,
+                parameters
+            )
+        ).thenReturn(RequestMock(null, error))
+        passkeyManager.signup(context, userMetadata, parameters, callback, serialExecutor)
+        verify(authenticationAPIClient).signupWithPasskey(userMetadata, parameters)
+        verify(authenticationAPIClient, never()).signinWithPasskey(any(), any(), any())
+        verify(credentialManager, never()).createCredentialAsync(
+            any(),
+            any(),
+            any(),
+            any(),
+            any()
+        )
+        verify(callback).onFailure(error)
+    }
+
+    @Test
+    public fun shouldSignUpWithPasskeyCreateCredentialFailure() {
+        val userMetadata: UserMetadataRequest = mock()
+        val parameters = mapOf("realm" to "testRealm")
+        `when`(
+            authenticationAPIClient.signupWithPasskey(
+                userMetadata,
+                parameters
+            )
+        ).thenReturn(RequestMock(passkeyRegistrationResponse, null))
+
+        whenever(
+            credentialManager.createCredentialAsync(
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        ).thenAnswer {
+            (it.arguments[4] as CredentialManagerCallback<CreateCredentialResponse, CreateCredentialException>).onError(
+                CreateCredentialInterruptedException()
+            )
+        }
+
+        passkeyManager.signup(context, userMetadata, parameters, callback, serialExecutor)
+        verify(authenticationAPIClient).signupWithPasskey(userMetadata, parameters)
+        verify(credentialManager).createCredentialAsync(eq(context), any(), any(), any(), any())
+        verify(authenticationAPIClient, never()).signinWithPasskey(any(), any(), any())
+        verify(callback).onFailure(exceptionCaptor.capture())
+        Assert.assertEquals(
+            AuthenticationException::class.java,
+            exceptionCaptor.firstValue.javaClass
+        )
+        Assert.assertEquals(
+            "Passkey authentication was interrupted. Please retry the call.",
+            exceptionCaptor.firstValue.message
+        )
+    }
+
+
+    @Test
+    public fun shouldSignInWithPasskeySuccess() {
+        val parameters = mapOf("realm" to "testRealm")
+        val credentialResponse: GetCredentialResponse = mock()
+
+        `when`(authenticationAPIClient.passkeyChallenge(parameters["realm"])).thenReturn(
+            RequestMock(passkeyChallengeResponse, null)
+        )
+
+        `when`(credentialResponse.credential).thenReturn(
+            PublicKeyCredential(registrationResponseJSON)
+        )
+
+        `when`(authenticationAPIClient.signinWithPasskey(any(), any(), any())).thenReturn(
+            AuthenticationRequestMock(
+                Credentials(
+                    "expectedIdToken",
+                    "codeAccess",
+                    "codeType",
+                    "codeRefresh",
+                    Date(),
+                    "codeScope"
+                ), null
+            )
+        )
+
+        doAnswer {
+            val callback =
+                it.getArgument<CredentialManagerCallback<GetCredentialResponse, GetCredentialException>>(
+                    4
+                )
+            callback.onResult(credentialResponse)
+        }.`when`(credentialManager)
+            .getCredentialAsync(any(), any<GetCredentialRequest>(), any(), any(), any())
+
+        passkeyManager.signin(context, parameters, callback, serialExecutor)
+
+        verify(authenticationAPIClient).passkeyChallenge(parameters["realm"])
+        verify(credentialManager).getCredentialAsync(
+            any(),
+            any<GetCredentialRequest>(),
+            any(),
+            any(),
+            any()
+        )
+        verify(authenticationAPIClient).signinWithPasskey(any(), any(), any())
+        verify(callback).onSuccess(credentialsCaptor.capture())
+        Assert.assertEquals("codeAccess", credentialsCaptor.firstValue.accessToken)
+        Assert.assertEquals("codeScope", credentialsCaptor.firstValue.scope)
+    }
+
+
+    @Test
+    public fun shouldSignInWithPasskeyApiFailure() {
+        val parameters = mapOf("realm" to "testRealm")
+        val error = AuthenticationException("Signin failed")
+
+        `when`(authenticationAPIClient.passkeyChallenge(parameters["realm"])).thenReturn(
+            RequestMock(null, error)
+        )
+
+        passkeyManager.signin(context, parameters, callback, serialExecutor)
+
+        verify(authenticationAPIClient).passkeyChallenge(any())
+        verify(credentialManager, never()).getCredentialAsync(
+            any(),
+            any<GetCredentialRequest>(),
+            any(),
+            any(),
+            any()
+        )
+        verify(authenticationAPIClient, never()).signinWithPasskey(any(), any(), any())
+        verify(callback).onFailure(error)
+    }
+
+    @Test
+    public fun shouldSignInWithPasskeyGetCredentialFailure() {
+        val parameters = mapOf("realm" to "testRealm")
+        `when`(authenticationAPIClient.passkeyChallenge(parameters["realm"])).thenReturn(
+            RequestMock(passkeyChallengeResponse, null)
+        )
+
+        whenever(
+            credentialManager.getCredentialAsync(
+                any(),
+                any<GetCredentialRequest>(),
+                any(),
+                any(),
+                any()
+            )
+        ).thenAnswer {
+            (it.arguments[4] as CredentialManagerCallback<GetCredentialResponse, GetCredentialException>).onError(
+                GetCredentialInterruptedException()
+            )
+        }
+
+        passkeyManager.signin(context, parameters, callback, serialExecutor)
+        verify(authenticationAPIClient).passkeyChallenge(parameters["realm"])
+        verify(credentialManager).getCredentialAsync(
+            any(),
+            any<GetCredentialRequest>(),
+            any(),
+            any(),
+            any()
+        )
+        verify(authenticationAPIClient, never()).signinWithPasskey(any(), any(), any())
+        verify(callback).onFailure(exceptionCaptor.capture())
+        Assert.assertEquals(
+            AuthenticationException::class.java,
+            exceptionCaptor.firstValue.javaClass
+        )
+        Assert.assertEquals(
+            "Passkey authentication was interrupted. Please retry the call.",
+            exceptionCaptor.firstValue.message
+        )
+    }
+}

--- a/auth0/src/test/java/com/auth0/android/util/AuthenticationAPIMockServer.kt
+++ b/auth0/src/test/java/com/auth0/android/util/AuthenticationAPIMockServer.kt
@@ -47,6 +47,55 @@ internal class AuthenticationAPIMockServer : APIMockServer() {
         return this
     }
 
+    fun willReturnSuccessfulPasskeyRegistration(): AuthenticationAPIMockServer {
+        val json = """{
+            "authn_params_public_key":{
+                "challenge": "$CHALLENGE",
+                "timeout": 6046456,
+                "rp": {
+                    "id": "auth0.passkey.com",
+                    "name": "Passkey Test"
+                },
+                "pubKeyCredParams": [
+                    {
+                        "type": "public-key",
+                        "alg": -7
+                    },
+                    {
+                        "type": "public-key",
+                        "alg": -257
+                    }
+                ],
+                "authenticatorSelection": {
+                    "authenticatorAttachment": "platform",
+                    "residentKey": "required"
+                },
+                "user": {
+                       "id": "53b995f8bce68d9fc900099c",
+                       "name": "p",
+                       "displayName": "d"
+                   }
+                },
+                 "auth_session": "$SESSION_ID"
+            }"""
+        server.enqueue(responseWithJSON(json, 200))
+        return this
+    }
+
+    fun willReturnSuccessfulPasskeyChallenge():AuthenticationAPIMockServer{
+        val json = """{
+            "authn_params_public_key":{
+                "challenge": "$CHALLENGE",
+                "timeout": 604645,
+                "rpId": "domain",
+                "userVerification":"preferred"
+                },
+                 "auth_session": "$SESSION_ID"
+            }"""
+        server.enqueue(responseWithJSON(json, 200))
+        return this
+    }
+
     fun willReturnSuccessfulLoginWithRecoveryCode(): AuthenticationAPIMockServer {
         val json = """{
           "refresh_token": "$REFRESH_TOKEN",
@@ -155,6 +204,8 @@ internal class AuthenticationAPIMockServer : APIMockServer() {
         const val REFRESH_TOKEN = "REFRESH_TOKEN"
         const val ID_TOKEN = "ID_TOKEN"
         const val ACCESS_TOKEN = "ACCESS_TOKEN"
+        const val SESSION_ID = "SESSION_ID"
         private const val BEARER = "BEARER"
+        private const val CHALLENGE = "CHALLENGE"
     }
 }

--- a/proguard/proguard-jetpack.pro
+++ b/proguard/proguard-jetpack.pro
@@ -1,0 +1,6 @@
+# Jetpack libraries
+
+-if class androidx.credentials.CredentialManager
+-keep class androidx.credentials.playservices.** {
+  *;
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
+++ b/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
@@ -17,6 +17,7 @@ import com.auth0.android.authentication.storage.SharedPreferencesStorage
 import com.auth0.android.callback.Callback
 import com.auth0.android.management.ManagementException
 import com.auth0.android.management.UsersAPIClient
+import com.auth0.android.provider.PasskeyAuthProvider
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.request.DefaultClient
 import com.auth0.android.result.Credentials
@@ -91,6 +92,60 @@ class DatabaseLoginFragment : Fragment() {
                 dbLoginAsync(email, password)
             }
         }
+
+        binding.btSignupPasskey.setOnClickListener {
+            PasskeyAuthProvider.signUp(account)
+                .setEmail("username@email.com")
+                .setRealm("Username-Password-Authentication")
+                .start(
+                    requireActivity(),
+                    object : Callback<Credentials, AuthenticationException> {
+                        override fun onSuccess(result: Credentials) {
+                            credentialsManager.saveCredentials(result)
+                            Snackbar.make(
+                                requireView(),
+                                "Hello ${result.user.name}",
+                                Snackbar.LENGTH_LONG
+                            ).show()
+                        }
+
+                        override fun onFailure(error: AuthenticationException) {
+                            Snackbar.make(
+                                requireView(),
+                                error.getDescription(),
+                                Snackbar.LENGTH_LONG
+                            )
+                                .show()
+                        }
+                    })
+        }
+        binding.btSignInPasskey.setOnClickListener {
+            PasskeyAuthProvider
+                .signIn(account)
+                .setRealm("Username-Password-Authentication")
+                .start(requireActivity(), object : Callback<Credentials, AuthenticationException> {
+                    override fun onSuccess(result: Credentials) {
+                        credentialsManager.saveCredentials(result)
+                        Snackbar.make(
+                            requireView(),
+                            "Hello ${result.user.name}",
+                            Snackbar.LENGTH_LONG
+                        ).show()
+                    }
+
+                    override fun onFailure(error: AuthenticationException) {
+                        Snackbar.make(
+                            requireView(),
+                            error.getDescription(),
+                            Snackbar.LENGTH_LONG
+                        )
+                            .show()
+                    }
+
+                })
+
+        }
+
         binding.btWebAuth.setOnClickListener {
             webAuth()
         }

--- a/sample/src/main/res/layout/fragment_database_login.xml
+++ b/sample/src/main/res/layout/fragment_database_login.xml
@@ -20,6 +20,7 @@
             android:autofillHints="emailAddress"
             android:ems="10"
             android:hint="Email"
+            android:isCredential="true"
             android:inputType="textEmailAddress"
             android:text="asd@asd.asd"
             android:textSize="14sp"
@@ -37,6 +38,7 @@
             android:autofillHints="password"
             android:ems="10"
             android:hint="Password"
+            android:isCredential="true"
             android:inputType="textPassword"
             android:text="asdasd"
             android:textSize="14sp"
@@ -67,7 +69,44 @@
             android:textSize="16sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/btSignInPasskey" />
+
+        <TextView
+            android:id="@+id/textViewPasskey"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Authenticate with Passkey"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/btLoginAsync" />
+
+        <Button
+            android:id="@+id/btSignupPasskey"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="4dp"
+            android:text="SignUp with Passkey"
+            android:textSize="12sp"
+            app:layout_constraintEnd_toStartOf="@+id/btSignInPasskey"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textViewPasskey" />
+
+        <Button
+            android:id="@+id/btSignInPasskey"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="4dp"
+            android:text="Signin with Passkey"
+            android:textSize="12sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toEndOf="@+id/btSignupPasskey"
+            app:layout_constraintTop_toBottomOf="@+id/textViewPasskey" />
 
         <TextView
             android:id="@+id/textView4"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Auth0 SDK Sample</string>
-    <string name="com_auth0_domain">poovamraj.eu.auth0.com</string>
-    <string name="com_auth0_client_id">swarLtLAd0aW55ajPUPzYPXjtB3UtZki</string>
+    <string name="com_auth0_domain">passkey.acmetest.org</string>
+    <string name="com_auth0_client_id">gkba7X6OJM2b0cdlUlTCqXD7AwT3FYVV</string>
     <string name="com_auth0_scheme">demo</string>
 </resources>


### PR DESCRIPTION
### Changes

Added support to signup and signin using Passkey. This change introduces a new public class called `PasskeyAuthProvider` . It exposes two apis for the client to initiate the signup and signin flow

1.   `PasskeyAuthProvider.signUp(auth0:Auth0)`
2.   `PasskeyAuthProvider.signIn(auth0:Auth0)`


#References
[Webauthn](https://w3c.github.io/webauthn/)
[Passkeys](https://developers.google.com/identity/passkeys)
[Google Credential Manager](https://developer.android.com/identity/sign-in/credential-manager)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [X] This change adds unit test coverage

- [X] This change adds integration test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
