### PR TITLE
Added new error types for CredentialsManagerException

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -325,9 +325,15 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
                 saveCredentials(credentials)
                 callback.onSuccess(credentials)
             } catch (error: AuthenticationException) {
+                val exception = when {
+                    error.isRefreshTokenDeleted ||
+                            error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
+                    error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
+                    else -> CredentialsManagerException.Code.SERVER_ERROR
+                }
                 callback.onFailure(
                     CredentialsManagerException(
-                        CredentialsManagerException.Code.RENEW_FAILED,
+                        exception,
                         error
                     )
                 )

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -329,7 +329,7 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
                     error.isRefreshTokenDeleted ||
                             error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
                     error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
-                    else -> CredentialsManagerException.Code.SERVER_ERROR
+                    else -> CredentialsManagerException.Code.API_ERROR
                 }
                 callback.onFailure(
                     CredentialsManagerException(

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.kt
@@ -43,6 +43,8 @@ public class CredentialsManagerException :
         BIOMETRIC_ERROR_UNABLE_TO_PROCESS,
         BIOMETRICS_INVALID_USER,
         BIOMETRIC_AUTHENTICATION_FAILED,
+        NO_NETWORK,
+        SERVER_ERROR
     }
 
     private var code: Code?
@@ -135,6 +137,12 @@ public class CredentialsManagerException :
         public val BIOMETRICS_INVALID_USER: CredentialsManagerException =
             CredentialsManagerException(Code.BIOMETRICS_INVALID_USER)
 
+        //Exceptions thrown when making api calls for access token renewal
+        public val NO_NETWORK: CredentialsManagerException =
+            CredentialsManagerException(Code.NO_NETWORK)
+        public val SERVER_ERROR: CredentialsManagerException =
+            CredentialsManagerException(Code.SERVER_ERROR)
+
 
         private fun getMessage(code: Code): String {
             return when (code) {
@@ -177,6 +185,8 @@ public class CredentialsManagerException :
                 Code.BIOMETRIC_ERROR_UNABLE_TO_PROCESS -> "Failed to authenticate because the sensor was unable to process the current image."
                 Code.BIOMETRICS_INVALID_USER -> "The user didn't pass the authentication challenge."
                 Code.BIOMETRIC_AUTHENTICATION_FAILED -> "Biometric authentication failed."
+                Code.NO_NETWORK -> "Failed to execute the network request."
+                Code.SERVER_ERROR -> "An error occurred when trying to authenticate with the server."
             }
         }
     }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.kt
@@ -44,7 +44,7 @@ public class CredentialsManagerException :
         BIOMETRICS_INVALID_USER,
         BIOMETRIC_AUTHENTICATION_FAILED,
         NO_NETWORK,
-        SERVER_ERROR
+        API_ERROR
     }
 
     private var code: Code?
@@ -140,8 +140,8 @@ public class CredentialsManagerException :
         //Exceptions thrown when making api calls for access token renewal
         public val NO_NETWORK: CredentialsManagerException =
             CredentialsManagerException(Code.NO_NETWORK)
-        public val SERVER_ERROR: CredentialsManagerException =
-            CredentialsManagerException(Code.SERVER_ERROR)
+        public val API_ERROR: CredentialsManagerException =
+            CredentialsManagerException(Code.API_ERROR)
 
 
         private fun getMessage(code: Code): String {
@@ -186,7 +186,7 @@ public class CredentialsManagerException :
                 Code.BIOMETRICS_INVALID_USER -> "The user didn't pass the authentication challenge."
                 Code.BIOMETRIC_AUTHENTICATION_FAILED -> "Biometric authentication failed."
                 Code.NO_NETWORK -> "Failed to execute the network request."
-                Code.SERVER_ERROR -> "An error occurred when trying to authenticate with the server."
+                Code.API_ERROR -> "An error occurred while processing the request."
             }
         }
     }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -590,7 +590,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                     error.isRefreshTokenDeleted ||
                             error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
                     error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
-                    else -> CredentialsManagerException.Code.SERVER_ERROR
+                    else -> CredentialsManagerException.Code.API_ERROR
                 }
                 callback.onFailure(
                     CredentialsManagerException(

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -916,7 +916,7 @@ public class CredentialsManagerTest {
     }
 
     @Test
-    public fun shouldGetAndFailToRenewExpiredCredentialsWhenServerErrorOccurs() {
+    public fun shouldGetAndFailToRenewExpiredCredentialsWhenApiErrorOccurs() {
         Mockito.`when`(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken")
         Mockito.`when`(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken")
         Mockito.`when`(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken")
@@ -950,7 +950,7 @@ public class CredentialsManagerTest {
         MatcherAssert.assertThat(exception.cause, Is.`is`(authenticationException))
         MatcherAssert.assertThat(
             exception.message,
-            Is.`is`("An error occurred when trying to authenticate with the server.")
+            Is.`is`("An error occurred while processing the request.")
         )
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -1,5 +1,6 @@
 package com.auth0.android.authentication.storage
 
+import com.auth0.android.NetworkErrorException
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
@@ -788,7 +789,7 @@ public class CredentialsManagerTest {
     }
 
     @Test
-    public fun shouldGetAndFailToRenewExpiredCredentials() {
+    public fun shouldGetAndFailToRenewExpiredCredentialsWhenRefreshTokenExpired() {
         Mockito.`when`(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken")
         Mockito.`when`(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken")
         Mockito.`when`(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken")
@@ -802,8 +803,9 @@ public class CredentialsManagerTest {
             client.renewAuth("refreshToken")
         ).thenReturn(request)
         //Trigger failure
-        val authenticationException = Mockito.mock(
-            AuthenticationException::class.java
+        val authenticationException = AuthenticationException(
+            "invalid_grant",
+            "Unknown or invalid refresh token."
         )
         Mockito.`when`(request.execute()).thenThrow(authenticationException)
         manager.getCredentials(callback)
@@ -825,6 +827,130 @@ public class CredentialsManagerTest {
         MatcherAssert.assertThat(
             exception.message,
             Is.`is`("An error occurred while trying to use the Refresh Token to renew the Credentials.")
+        )
+    }
+
+    @Test
+    public fun shouldGetAndFailToRenewExpiredCredentialsWhenUserIsDeleted() {
+        Mockito.`when`(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken")
+        Mockito.`when`(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken")
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken")
+        Mockito.`when`(storage.retrieveString("com.auth0.token_type")).thenReturn("type")
+        val expirationTime = CredentialsMock.CURRENT_TIME_MS //Same as current time --> expired
+        Mockito.`when`(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime)
+        Mockito.`when`(storage.retrieveLong("com.auth0.cache_expires_at"))
+            .thenReturn(expirationTime)
+        Mockito.`when`(storage.retrieveString("com.auth0.scope")).thenReturn("scope")
+        Mockito.`when`(
+            client.renewAuth("refreshToken")
+        ).thenReturn(request)
+        //Trigger failure
+        val authenticationException = AuthenticationException(
+            mapOf(
+                "error" to "invalid_grant",
+                "error_description" to "The refresh_token was generated for a user who doesn't exist anymore."
+            ), 403
+        )
+        Mockito.`when`(request.execute()).thenThrow(authenticationException)
+        manager.getCredentials(callback)
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyLong())
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())
+        verify(storage, never()).remove(ArgumentMatchers.anyString())
+        verify(callback).onFailure(
+            exceptionCaptor.capture()
+        )
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(authenticationException))
+        MatcherAssert.assertThat(
+            exception.message,
+            Is.`is`("An error occurred while trying to use the Refresh Token to renew the Credentials.")
+        )
+    }
+
+    @Test
+    public fun shouldGetAndFailToRenewExpiredCredentialsWhenNetworkIsNotAvailable() {
+        Mockito.`when`(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken")
+        Mockito.`when`(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken")
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken")
+        Mockito.`when`(storage.retrieveString("com.auth0.token_type")).thenReturn("type")
+        val expirationTime = CredentialsMock.CURRENT_TIME_MS //Same as current time --> expired
+        Mockito.`when`(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime)
+        Mockito.`when`(storage.retrieveLong("com.auth0.cache_expires_at"))
+            .thenReturn(expirationTime)
+        Mockito.`when`(storage.retrieveString("com.auth0.scope")).thenReturn("scope")
+        Mockito.`when`(
+            client.renewAuth("refreshToken")
+        ).thenReturn(request)
+        //Trigger failure
+        val authenticationException = AuthenticationException(
+            "Failed to execute the network request", NetworkErrorException(mock())
+        )
+        Mockito.`when`(request.execute()).thenThrow(authenticationException)
+        manager.getCredentials(callback)
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyLong())
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())
+        verify(storage, never()).remove(ArgumentMatchers.anyString())
+        verify(callback).onFailure(
+            exceptionCaptor.capture()
+        )
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(authenticationException))
+        MatcherAssert.assertThat(
+            exception.message,
+            Is.`is`("Failed to execute the network request.")
+        )
+    }
+
+    @Test
+    public fun shouldGetAndFailToRenewExpiredCredentialsWhenServerErrorOccurs() {
+        Mockito.`when`(storage.retrieveString("com.auth0.id_token")).thenReturn("idToken")
+        Mockito.`when`(storage.retrieveString("com.auth0.access_token")).thenReturn("accessToken")
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken")
+        Mockito.`when`(storage.retrieveString("com.auth0.token_type")).thenReturn("type")
+        val expirationTime = CredentialsMock.CURRENT_TIME_MS //Same as current time --> expired
+        Mockito.`when`(storage.retrieveLong("com.auth0.expires_at")).thenReturn(expirationTime)
+        Mockito.`when`(storage.retrieveLong("com.auth0.cache_expires_at"))
+            .thenReturn(expirationTime)
+        Mockito.`when`(storage.retrieveString("com.auth0.scope")).thenReturn("scope")
+        Mockito.`when`(
+            client.renewAuth("refreshToken")
+        ).thenReturn(request)
+        //Trigger failure
+        val authenticationException = AuthenticationException("Something went wrong", mock<Exception>())
+        Mockito.`when`(request.execute()).thenThrow(authenticationException)
+        manager.getCredentials(callback)
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyLong())
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())
+        verify(storage, never())
+            .store(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())
+        verify(storage, never()).remove(ArgumentMatchers.anyString())
+        verify(callback).onFailure(
+            exceptionCaptor.capture()
+        )
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(authenticationException))
+        MatcherAssert.assertThat(
+            exception.message,
+            Is.`is`("An error occurred when trying to authenticate with the server.")
         )
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -1375,7 +1375,7 @@ public class SecureCredentialsManagerTest {
     }
 
     @Test
-    public fun shouldGetAndFailToRenewExpiredCredentialsWhenServerErrorOccurs() {
+    public fun shouldGetAndFailToRenewExpiredCredentialsWhenApiErrorOccurs() {
         Mockito.`when`(localAuthenticationManager.authenticate()).then {
             localAuthenticationManager.resultCallback.onSuccess(true)
         }
@@ -1406,7 +1406,7 @@ public class SecureCredentialsManagerTest {
         MatcherAssert.assertThat(exception.cause, Is.`is`(authenticationException))
         MatcherAssert.assertThat(
             exception.message,
-            Is.`is`("An error occurred when trying to authenticate with the server.")
+            Is.`is`("An error occurred while processing the request.")
         )
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.util.Base64
 import androidx.fragment.app.FragmentActivity
 import com.auth0.android.Auth0
+import com.auth0.android.NetworkErrorException
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
@@ -1259,7 +1260,7 @@ public class SecureCredentialsManagerTest {
     }
 
     @Test
-    public fun shouldGetAndFailToRenewExpiredCredentials() {
+    public fun shouldGetAndFailToRenewExpiredCredentialsWhenRefreshTokenExpired() {
         Mockito.`when`(localAuthenticationManager.authenticate()).then {
             localAuthenticationManager.resultCallback.onSuccess(true)
         }
@@ -1269,7 +1270,10 @@ public class SecureCredentialsManagerTest {
             client.renewAuth("refreshToken")
         ).thenReturn(request)
         //Trigger failure
-        val authenticationException = mock<AuthenticationException>()
+        val authenticationException = AuthenticationException(
+            "invalid_grant",
+            "Unknown or invalid refresh token."
+        )
         Mockito.`when`(request.execute()).thenThrow(authenticationException)
         manager.getCredentials(callback)
         verify(callback).onFailure(
@@ -1290,6 +1294,119 @@ public class SecureCredentialsManagerTest {
         MatcherAssert.assertThat(
             exception.message,
             Is.`is`("An error occurred while trying to use the Refresh Token to renew the Credentials.")
+        )
+    }
+
+    @Test
+    public fun shouldGetAndFailToRenewExpiredCredentialsWhenUserIsDeleted() {
+        Mockito.`when`(localAuthenticationManager.authenticate()).then {
+            localAuthenticationManager.resultCallback.onSuccess(true)
+        }
+        val expiresAt = Date(CredentialsMock.CURRENT_TIME_MS)
+        insertTestCredentials(false, true, true, expiresAt, "scope")
+        Mockito.`when`(
+            client.renewAuth("refreshToken")
+        ).thenReturn(request)
+        //Trigger failure
+        val authenticationException = AuthenticationException(
+            mapOf(
+                "error" to "invalid_grant",
+                "error_description" to "The refresh_token was generated for a user who doesn't exist anymore."
+            ), 403
+        )
+        Mockito.`when`(request.execute()).thenThrow(authenticationException)
+        manager.getCredentials(callback)
+        verify(callback).onFailure(
+            exceptionCaptor.capture()
+        )
+        verify(storage, never())
+            .store(anyString(), anyLong())
+        verify(storage, never())
+            .store(anyString(), anyInt())
+        verify(storage, never())
+            .store(anyString(), anyString())
+        verify(storage, never())
+            .store(anyString(), anyBoolean())
+        verify(storage, never()).remove(anyString())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(authenticationException))
+        MatcherAssert.assertThat(
+            exception.message,
+            Is.`is`("An error occurred while trying to use the Refresh Token to renew the Credentials.")
+        )
+    }
+
+    @Test
+    public fun shouldGetAndFailToRenewExpiredCredentialsWhenNetworkIsNotAvailable() {
+        Mockito.`when`(localAuthenticationManager.authenticate()).then {
+            localAuthenticationManager.resultCallback.onSuccess(true)
+        }
+        val expiresAt = Date(CredentialsMock.CURRENT_TIME_MS)
+        insertTestCredentials(false, true, true, expiresAt, "scope")
+        Mockito.`when`(
+            client.renewAuth("refreshToken")
+        ).thenReturn(request)
+        //Trigger failure
+        val authenticationException = AuthenticationException(
+            "Failed to execute the network request", NetworkErrorException(mock())
+        )
+        Mockito.`when`(request.execute()).thenThrow(authenticationException)
+        manager.getCredentials(callback)
+        verify(callback).onFailure(
+            exceptionCaptor.capture()
+        )
+        verify(storage, never())
+            .store(anyString(), anyLong())
+        verify(storage, never())
+            .store(anyString(), anyInt())
+        verify(storage, never())
+            .store(anyString(), anyString())
+        verify(storage, never())
+            .store(anyString(), anyBoolean())
+        verify(storage, never()).remove(anyString())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(authenticationException))
+        MatcherAssert.assertThat(
+            exception.message,
+            Is.`is`("Failed to execute the network request.")
+        )
+    }
+
+    @Test
+    public fun shouldGetAndFailToRenewExpiredCredentialsWhenServerErrorOccurs() {
+        Mockito.`when`(localAuthenticationManager.authenticate()).then {
+            localAuthenticationManager.resultCallback.onSuccess(true)
+        }
+        val expiresAt = Date(CredentialsMock.CURRENT_TIME_MS)
+        insertTestCredentials(false, true, true, expiresAt, "scope")
+        Mockito.`when`(
+            client.renewAuth("refreshToken")
+        ).thenReturn(request)
+        //Trigger failure
+        val authenticationException =
+            AuthenticationException("Something went wrong", mock<Exception>())
+        Mockito.`when`(request.execute()).thenThrow(authenticationException)
+        manager.getCredentials(callback)
+        verify(callback).onFailure(
+            exceptionCaptor.capture()
+        )
+        verify(storage, never())
+            .store(anyString(), anyLong())
+        verify(storage, never())
+            .store(anyString(), anyInt())
+        verify(storage, never())
+            .store(anyString(), anyString())
+        verify(storage, never())
+            .store(anyString(), anyBoolean())
+        verify(storage, never()).remove(anyString())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(authenticationException))
+        MatcherAssert.assertThat(
+            exception.message,
+            Is.`is`("An error occurred when trying to authenticate with the server.")
         )
     }
 

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Auth0 SDK Sample</string>
-    <string name="com_auth0_domain">mathewp.acmetest.org</string>
+    <string name="com_auth0_domain">p-mathew.us.auth0.com</string>
     <string name="com_auth0_client_id">gkba7X6OJM2b0cdlUlTCqXD7AwT3FYVV</string>
     <string name="com_auth0_scheme">demo</string>
 </resources>


### PR DESCRIPTION
### Changes

Added two new error types to the `CredentialsManagerException` class .


### Testing


- [X] This change adds unit test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
