### PR TITLE
Add support for custom token exchange

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,11 +19,15 @@ runs:
   using: composite
 
   steps:
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+
     - run: |
         curl -s "https://get.sdkman.io" | bash
         source "/home/runner/.sdkman/bin/sdkman-init.sh"
-        sdk list java
-        sdk install java ${{ inputs.java }} && sdk default java ${{ inputs.java }}
         sdk install gradle ${{ inputs.gradle }} && sdk default gradle ${{ inputs.gradle }}
         sdk install kotlin ${{ inputs.kotlin }} && sdk default kotlin ${{ inputs.kotlin }}
       shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,12 @@ jobs:
       - if: github.actor == 'dependabot[bot]' || github.event_name == 'merge_group'
         run: exit 0 # Skip unnecessary test runs for dependabot and merge queues. Artifically flag as successful, as this is a required check for branch protection.
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.snyk
+++ b/.snyk
@@ -5,16 +5,16 @@ ignore:
   SNYK-JAVA-COMFASTERXMLWOODSTOX-3091135:
     - '*':
         reason: Latest version of dokka has this vulnerability
-        expires: 2024-12-31T12:54:23.000Z
+        expires: 2025-02-21T12:54:23.000Z
         created: 2024-08-01T12:08:37.770Z
   SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744:
     - '*':
         reason: Latest version of dokka has this vulnerability
-        expires: 2024-12-31T12:54:23.000Z
+        expires: 2025-02-21T12:54:23.000Z
         created: 2024-08-01T12:08:55.927Z
   SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538:
     - '*':
         reason: Latest version of dokka has this vulnerability
-        expires: 2024-12-31T1:54:23.000Z
+        expires: 2025-02-21T1:54:23.000Z
         created: 2024-08-01T12:08:02.973Z
 patch: {}

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -457,13 +457,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @return a request to configure and start that will yield [Credentials]
      */
     public fun loginWithNativeSocialToken(token: String, tokenType: String): AuthenticationRequest {
-        val parameters = ParameterBuilder.newAuthenticationBuilder()
-            .setGrantType(ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
-            .setClientId(clientId)
-            .set(SUBJECT_TOKEN_KEY, token)
-            .set(SUBJECT_TOKEN_TYPE_KEY, tokenType)
-            .asDictionary()
-        return loginWithToken(parameters)
+        return customTokenExchange(tokenType, token)
     }
 
     /**
@@ -732,7 +726,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         subjectTokenType: String,
         subjectToken: String,
     ): AuthenticationRequest {
-        val parameters = ParameterBuilder.newBuilder()
+        val parameters = ParameterBuilder.newAuthenticationBuilder()
             .setGrantType(ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
             .set(SUBJECT_TOKEN_TYPE_KEY, subjectTokenType)
             .set(SUBJECT_TOKEN_KEY, subjectToken)

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -702,7 +702,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     }
 
     /**
-     * The Custom Token Exchange feature allows clients to exchange their existing tokens for Auth0 tokens by calling the /oauth/token endpoint with specific parameters
+     * The Custom Token Exchange feature allows clients to exchange their existing tokens for Auth0 tokens by calling the `/oauth/token` endpoint with specific parameters.
      * The default scope used is 'openid profile email'.
      *
      * Example usage:

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -457,7 +457,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @return a request to configure and start that will yield [Credentials]
      */
     public fun loginWithNativeSocialToken(token: String, tokenType: String): AuthenticationRequest {
-        return customTokenExchange(tokenType, token)
+        return tokenExchange(tokenType, token)
     }
 
     /**
@@ -726,12 +726,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         subjectTokenType: String,
         subjectToken: String,
     ): AuthenticationRequest {
-        val parameters = ParameterBuilder.newAuthenticationBuilder()
-            .setGrantType(ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
-            .set(SUBJECT_TOKEN_TYPE_KEY, subjectTokenType)
-            .set(SUBJECT_TOKEN_KEY, subjectToken)
-            .asDictionary()
-        return loginWithToken(parameters)
+        return tokenExchange(subjectTokenType, subjectToken)
     }
 
     /**
@@ -947,6 +942,21 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         )
         request.addParameters(requestParameters)
         return request
+    }
+
+    /**
+     * Helper function to make a request to the /oauth/token endpoint with the token exchange grant type.
+     */
+    private fun tokenExchange(
+        subjectTokenType: String,
+        subjectToken: String
+    ): AuthenticationRequest {
+        val parameters = ParameterBuilder.newAuthenticationBuilder()
+            .setGrantType(ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
+            .set(SUBJECT_TOKEN_TYPE_KEY, subjectTokenType)
+            .set(SUBJECT_TOKEN_KEY, subjectToken)
+            .asDictionary()
+        return loginWithToken(parameters)
     }
 
     private fun profileRequest(): Request<UserProfile, AuthenticationException> {

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -167,7 +167,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.signinWithPasskey("{authSession}", "{authResponse}","{realm}")
      *       .validateClaims() //mandatory
-     *       .addParameter("scope","scope")
+     *       .setScope("{scope}")
      *       .start(object: Callback<Credentials, AuthenticationException> {
      *           override fun onFailure(error: AuthenticationException) { }
      *           override fun onSuccess(result: Credentials) { }
@@ -211,7 +211,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      * client.signinWithPasskey("{authSession}", "{authResponse}","{realm}")
      *       .validateClaims() //mandatory
-     *       .addParameter("scope","scope")
+     *       .setScope("{scope}")
      *       .start(object: Callback<Credentials, AuthenticationException> {
      *           override fun onFailure(error: AuthenticationException) { }
      *           override fun onSuccess(result: Credentials) { }
@@ -705,6 +705,39 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
             .build()
         return factory.post(url.toString())
             .addParameters(parameters)
+    }
+
+    /**
+     * The Custom Token Exchange feature allows clients to exchange their existing tokens for Auth0 tokens by calling the /oauth/token endpoint with specific parameters
+     * The default scope used is 'openid profile email'.
+     *
+     * Example usage:
+     *
+     * ```
+     * client.callTokenExchange("{subject token type}", "{subject token}")
+     *       .validateClaims() //mandatory
+     *       .setScope("{scope}")
+     *       .setAudience("{audience}")
+     *       .start(object: Callback<Credentials, AuthenticationException> {
+     *       override fun onSuccess(result: Credentials) { }
+     *       override fun onFailure(error: AuthenticationException) { }
+     *  })
+     *  ```
+     *
+     * @param subjectTokenType the subject token type that is associated with the existing Identity Provider. e.g. 'http://acme.com/legacy-token'
+     * @param subjectToken   the subject token, typically obtained through the Identity Provider's SDK
+     * @return a request to configure and start that will yield [Credentials]
+     */
+    public fun callTokenExchange(
+        subjectTokenType: String,
+        subjectToken: String,
+    ): AuthenticationRequest {
+        val parameters = ParameterBuilder.newBuilder()
+            .setGrantType(ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
+            .set(SUBJECT_TOKEN_TYPE_KEY, subjectTokenType)
+            .set(SUBJECT_TOKEN_KEY, subjectToken)
+            .asDictionary()
+        return loginWithToken(parameters)
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -714,7 +714,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * Example usage:
      *
      * ```
-     * client.callTokenExchange("{subject token type}", "{subject token}")
+     * client.customTokenExchange("{subject token type}", "{subject token}")
      *       .validateClaims() //mandatory
      *       .setScope("{scope}")
      *       .setAudience("{audience}")
@@ -728,7 +728,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * @param subjectToken   the subject token, typically obtained through the Identity Provider's SDK
      * @return a request to configure and start that will yield [Credentials]
      */
-    public fun callTokenExchange(
+    public fun customTokenExchange(
         subjectTokenType: String,
         subjectToken: String,
     ): AuthenticationRequest {

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -2277,7 +2277,6 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin()
         val callback = MockAuthenticationCallback<Credentials>()
         client.customTokenExchange( "subject-token-type","subject-token")
-            .setScope("openid profile email")
             .start(callback)
         ShadowLooper.idleMainLooper()
         val request = mockAPI.takeRequest()
@@ -2308,7 +2307,6 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin()
         val credentials = client
             .customTokenExchange("subject-token-type", "subject-token")
-            .setScope("openid profile email")
             .execute()
         val request = mockAPI.takeRequest()
         assertThat(
@@ -2335,7 +2333,6 @@ public class AuthenticationAPIClientTest {
         mockAPI.willReturnSuccessfulLogin()
         val credentials = client
             .customTokenExchange("subject-token-type", "subject-token")
-            .setScope("openid profile email")
             .await()
         val request = mockAPI.takeRequest()
         assertThat(

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -2273,6 +2273,90 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
+    public fun shouldCustomTokenExchange() {
+        mockAPI.willReturnSuccessfulLogin()
+        val callback = MockAuthenticationCallback<Credentials>()
+        client.customTokenExchange( "subject-token-type","subject-token")
+            .setScope("openid profile email")
+            .start(callback)
+        ShadowLooper.idleMainLooper()
+        val request = mockAPI.takeRequest()
+        assertThat(
+            request.getHeader("Accept-Language"), Matchers.`is`(
+                defaultLocale
+            )
+        )
+        assertThat(request.path, Matchers.equalTo("/oauth/token"))
+        val body = bodyFromRequest<String>(request)
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
+        assertThat(
+            body,
+            Matchers.hasEntry("grant_type", ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
+        )
+        assertThat(body, Matchers.hasEntry("subject_token", "subject-token"))
+        assertThat(body, Matchers.hasEntry("subject_token_type", "subject-token-type"))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
+        assertThat(
+            callback, AuthenticationCallbackMatcher.hasPayloadOfType(
+                Credentials::class.java
+            )
+        )
+    }
+
+    @Test
+    public fun shouldCustomTokenExchangeSync() {
+        mockAPI.willReturnSuccessfulLogin()
+        val credentials = client
+            .customTokenExchange("subject-token-type", "subject-token")
+            .setScope("openid profile email")
+            .execute()
+        val request = mockAPI.takeRequest()
+        assertThat(
+            request.getHeader("Accept-Language"), Matchers.`is`(
+                defaultLocale
+            )
+        )
+        assertThat(request.path, Matchers.equalTo("/oauth/token"))
+        val body = bodyFromRequest<String>(request)
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
+        assertThat(
+            body,
+            Matchers.hasEntry("grant_type", ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
+        )
+        assertThat(body, Matchers.hasEntry("subject_token", "subject-token"))
+        assertThat(body, Matchers.hasEntry("subject_token_type", "subject-token-type"))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
+        assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    public fun shouldAwaitCustomTokenExchnage(): Unit = runTest {
+        mockAPI.willReturnSuccessfulLogin()
+        val credentials = client
+            .customTokenExchange("subject-token-type", "subject-token")
+            .setScope("openid profile email")
+            .await()
+        val request = mockAPI.takeRequest()
+        assertThat(
+            request.getHeader("Accept-Language"), Matchers.`is`(
+                defaultLocale
+            )
+        )
+        assertThat(request.path, Matchers.equalTo("/oauth/token"))
+        val body = bodyFromRequest<String>(request)
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
+        assertThat(
+            body,
+            Matchers.hasEntry("grant_type", ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
+        )
+        assertThat(body, Matchers.hasEntry("subject_token", "subject-token"))
+        assertThat(body, Matchers.hasEntry("subject_token_type", "subject-token-type"))
+        assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
+        assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
+    }
+
+    @Test
     public fun shouldRenewAuthWithOAuthToken() {
         val auth0 = auth0
         val client = AuthenticationAPIClient(auth0)

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Auth0 SDK Sample</string>
-    <string name="com_auth0_domain">p-mathew.us.auth0.com</string>
-    <string name="com_auth0_client_id">gkba7X6OJM2b0cdlUlTCqXD7AwT3FYVV</string>
+    <string name="com_auth0_domain">YOUR_DOMAIN</string>
+    <string name="com_auth0_client_id">YOUR_CLIENT_ID</string>
     <string name="com_auth0_scheme">demo</string>
 </resources>


### PR DESCRIPTION
### Changes


- Added `customTokenExchange` method in `AuthenticationAPIClient`  to exchange a users existing identity provider token with an Auth0 token

### References

https://auth0.com/docs/custom-token-exchange-beta

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [X] This change adds unit test coverage

- [X] This change adds integration test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
