### PR TITLE
API support for fetching session token

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/ParameterBuilder.kt
@@ -160,6 +160,8 @@ public class ParameterBuilder private constructor(parameters: Map<String, String
         public const val GRANT_TYPE_TOKEN_EXCHANGE: String =
             "urn:ietf:params:oauth:grant-type:token-exchange"
         public const val GRANT_TYPE_PASSKEY :String = "urn:okta:params:oauth:grant-type:webauthn"
+        public const val TOKEN_TYPE_REFRESH_TOKEN :String = "urn:ietf:params:oauth:token-type:refresh_token"
+        public const val TOKEN_TYPE_SESSION_TOKEN :String = "urn:auth0:params:oauth:token-type:session_token"
         public const val SCOPE_OPENID: String = "openid"
         public const val SCOPE_OFFLINE_ACCESS: String = "openid offline_access"
         public const val SCOPE_KEY: String = "scope"

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -65,6 +65,10 @@ public abstract class BaseCredentialsManager internal constructor(
 
     @JvmSynthetic
     @Throws(CredentialsManagerException::class)
+    public abstract suspend fun awaitSsoCredentials(): SSOCredentials
+
+    @JvmSynthetic
+    @Throws(CredentialsManagerException::class)
     public abstract suspend fun awaitCredentials(): Credentials
 
     @JvmSynthetic

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -4,6 +4,7 @@ import androidx.annotation.VisibleForTesting
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.callback.Callback
 import com.auth0.android.result.Credentials
+import com.auth0.android.result.SSOCredentials
 import com.auth0.android.util.Clock
 import java.util.*
 
@@ -29,7 +30,9 @@ public abstract class BaseCredentialsManager internal constructor(
 
     @Throws(CredentialsManagerException::class)
     public abstract fun saveCredentials(credentials: Credentials)
+    public abstract fun saveSsoCredentials(ssoCredentials: SSOCredentials)
     public abstract fun getCredentials(callback: Callback<Credentials, CredentialsManagerException>)
+    public abstract fun getSsoCredentials(callback: Callback<SSOCredentials, CredentialsManagerException>)
     public abstract fun getCredentials(
         scope: String?,
         minTtl: Int,

--- a/auth0/src/main/java/com/auth0/android/result/SSOCredentials.kt
+++ b/auth0/src/main/java/com/auth0/android/result/SSOCredentials.kt
@@ -1,0 +1,54 @@
+package com.auth0.android.result
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Holds the session token credentials required for SSO .
+ *
+ *  * *sessionToken*: Session Token for SSO
+ *  * *refreshToken*: Refresh Token that can be used to request new tokens without signing in again
+ *  * *tokenType*: Contains information about how the token should be used.
+ *  * *expiresIn*: The token expiration duration.
+ *  * *issuedTokenType*: Type of the token issued.
+ *
+ */
+public data class SSOCredentials(
+    /**
+     * The Session Token used for SSO .
+     *
+     * @return the Session Token.
+     */
+    @field:SerializedName("access_token") public val sessionToken: String,
+
+    /**
+     * Type of the token issued.In this case, an Auth0 session token
+     *
+     * @return the issued token type.
+     */
+    @field:SerializedName("issued_token_type") public val issuedTokenType: String,
+
+    /**
+     * Contains information about how the token should be used.
+     * If the issued token is not an access token or usable as an access token, then the token_type
+     * value N_A is used to indicate that an OAuth 2.0 token_type identifier is not applicable in that context
+     *
+     * @return the token type.
+     */
+    @field:SerializedName("token_type") public val tokenType: String,
+
+    /**
+     * Expiration duration of the session token in seconds. Session tokens are short-lived and expire after a few minutes.
+     * Once expired, the Session Token can no longer be used for SSO.
+     *
+     * @return the expiration duration of this Session Token
+     */
+    @field:SerializedName("expires_in") public val expiresIn: Int,
+
+
+    /**
+     *  Refresh Token that can be used to request new tokens without signing in again.
+     *
+     * @return the Refresh Token.
+     */
+    @field:SerializedName("refresh_token") public val refreshToken: String? = null
+)

--- a/auth0/src/main/java/com/auth0/android/result/SSOCredentials.kt
+++ b/auth0/src/main/java/com/auth0/android/result/SSOCredentials.kt
@@ -3,9 +3,9 @@ package com.auth0.android.result
 import com.google.gson.annotations.SerializedName
 
 /**
- * Holds the session token credentials required for SSO .
+ * Holds the session token credentials required for web SSO .
  *
- *  * *sessionToken*: Session Token for SSO
+ *  * *sessionToken*: Session Token for web SSO
  *  * *refreshToken*: Refresh Token that can be used to request new tokens without signing in again
  *  * *tokenType*: Contains information about how the token should be used.
  *  * *expiresIn*: The token expiration duration.
@@ -14,7 +14,7 @@ import com.google.gson.annotations.SerializedName
  */
 public data class SSOCredentials(
     /**
-     * The Session Token used for SSO .
+     * The Session Token used for web SSO .
      *
      * @return the Session Token.
      */

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -16,6 +16,7 @@ import com.auth0.android.result.Authentication
 import com.auth0.android.result.Challenge
 import com.auth0.android.result.Credentials
 import com.auth0.android.result.DatabaseUser
+import com.auth0.android.result.SSOCredentials
 import com.auth0.android.result.UserProfile
 import com.auth0.android.util.Auth0UserAgent
 import com.auth0.android.util.AuthenticationAPIMockServer
@@ -2351,6 +2352,86 @@ public class AuthenticationAPIClientTest {
         assertThat(body, Matchers.hasEntry("subject_token_type", "subject-token-type"))
         assertThat(body, Matchers.hasEntry("scope", "openid profile email"))
         assertThat(credentials, Matchers.`is`(Matchers.notNullValue()))
+    }
+
+    @Test
+    public fun shouldFetchSessionToken(){
+        mockAPI.willReturnSuccessfulLogin()
+        val callback = MockAuthenticationCallback<SSOCredentials>()
+        client.fetchSessionToken( "refresh-token")
+            .start(callback)
+        ShadowLooper.idleMainLooper()
+        val request = mockAPI.takeRequest()
+        assertThat(
+            request.getHeader("Accept-Language"), Matchers.`is`(
+                defaultLocale
+            )
+        )
+        assertThat(request.path, Matchers.equalTo("/oauth/token"))
+        val body = bodyFromRequest<String>(request)
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
+        assertThat(
+            body,
+            Matchers.hasEntry("grant_type", ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
+        )
+        assertThat(body, Matchers.hasEntry("subject_token", "refresh-token"))
+        assertThat(body, Matchers.hasEntry("subject_token_type", ParameterBuilder.TOKEN_TYPE_REFRESH_TOKEN))
+        assertThat(body, Matchers.hasEntry("requested_token_type", ParameterBuilder.TOKEN_TYPE_SESSION_TOKEN))
+        assertThat(
+            callback, AuthenticationCallbackMatcher.hasPayloadOfType(
+                SSOCredentials::class.java
+            )
+        )
+    }
+
+    @Test
+    public fun shouldFetchSessionTokenSync(){
+        mockAPI.willReturnSuccessfulLogin()
+       val ssoCredentials= client.fetchSessionToken( "refresh-token")
+            .execute()
+        val request = mockAPI.takeRequest()
+        assertThat(
+            request.getHeader("Accept-Language"), Matchers.`is`(
+                defaultLocale
+            )
+        )
+        assertThat(request.path, Matchers.equalTo("/oauth/token"))
+        val body = bodyFromRequest<String>(request)
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
+        assertThat(
+            body,
+            Matchers.hasEntry("grant_type", ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
+        )
+        assertThat(body, Matchers.hasEntry("subject_token", "refresh-token"))
+        assertThat(body, Matchers.hasEntry("subject_token_type", ParameterBuilder.TOKEN_TYPE_REFRESH_TOKEN))
+        assertThat(body, Matchers.hasEntry("requested_token_type", ParameterBuilder.TOKEN_TYPE_SESSION_TOKEN))
+        assertThat(ssoCredentials, Matchers.`is`(Matchers.notNullValue()))
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    public fun shouldAwaitFetchSessionToken(): Unit = runTest {
+        mockAPI.willReturnSuccessfulLogin()
+        val ssoCredentials = client
+            .fetchSessionToken("refresh-token")
+            .await()
+        val request = mockAPI.takeRequest()
+        assertThat(
+            request.getHeader("Accept-Language"), Matchers.`is`(
+                defaultLocale
+            )
+        )
+        assertThat(request.path, Matchers.equalTo("/oauth/token"))
+        val body = bodyFromRequest<String>(request)
+        assertThat(body, Matchers.hasEntry("client_id", CLIENT_ID))
+        assertThat(
+            body,
+            Matchers.hasEntry("grant_type", ParameterBuilder.GRANT_TYPE_TOKEN_EXCHANGE)
+        )
+        assertThat(body, Matchers.hasEntry("subject_token", "refresh-token"))
+        assertThat(body, Matchers.hasEntry("subject_token_type", ParameterBuilder.TOKEN_TYPE_REFRESH_TOKEN))
+        assertThat(body, Matchers.hasEntry("requested_token_type", ParameterBuilder.TOKEN_TYPE_SESSION_TOKEN))
+        assertThat(ssoCredentials, Matchers.`is`(Matchers.notNullValue()))
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -223,9 +223,9 @@ public class CredentialsManagerTest {
 
     @Test
     public fun shouldNotSaveIfTheSsoCredentialsHasNoRefreshToken() {
-        val ssoCredentials = SSOCredentials(
+        val ssoCredentials = SsoCredentialsMock.create(
             "accessToken",
-            "issuedTokenType", "tokenType", 60, null
+            "issuedTokenType", "tokenType",  null,60
         )
         manager.saveSsoCredentials(ssoCredentials)
         verifyZeroInteractions(storage)
@@ -234,9 +234,9 @@ public class CredentialsManagerTest {
     @Test
     public fun shouldNotSaveIfTheNewSsoCredentialRefreshTokenIsSameAsTheExistingOne() {
         verifyNoMoreInteractions(storage)
-        val ssoCredentials = SSOCredentials(
+        val ssoCredentials = SsoCredentialsMock.create(
             "accessToken",
-            "issuedTokenType", "tokenType", 60, "refresh_token"
+            "issuedTokenType", "tokenType", "refresh_token",60
         )
         Mockito.`when`(storage.retrieveString("com.auth0.refresh_token"))
             .thenReturn("refresh_token")
@@ -247,9 +247,9 @@ public class CredentialsManagerTest {
     @Test
     public fun shouldSaveTheRefreshTokenIfTheNewSsoRefreshTokenIsNotSameAsTheOldOne() {
         verifyNoMoreInteractions(storage)
-        val ssoCredentials = SSOCredentials(
+        val ssoCredentials = SsoCredentialsMock.create(
             "accessToken",
-            "issuedTokenType", "tokenType", 60, "refresh_token"
+            "issuedTokenType", "tokenType",  "refresh_token",60
         )
         Mockito.`when`(storage.retrieveString("com.auth0.refresh_token"))
             .thenReturn("refresh-token")
@@ -299,7 +299,7 @@ public class CredentialsManagerTest {
     }
 
     @Test
-    public fun shouldGetAndFailToGetNewSSOCredentialsWhenRefreshTokenExpired() {
+    public fun shouldFailOnGetNewSSOCredentialsWhenRefreshTokenExpired() {
         Mockito.`when`(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken")
         Mockito.`when`(
             client.fetchSessionToken("refreshToken")
@@ -359,7 +359,6 @@ public class CredentialsManagerTest {
         MatcherAssert.assertThat(credentials.expiresIn, Is.`is`(60))
         verify(storage).store("com.auth0.refresh_token", credentials.refreshToken)
     }
-
 
     @Test
     public fun shouldFailOnGetCredentialsWhenNoAccessTokenOrIdTokenWasSaved() {

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -8,8 +8,19 @@ import com.auth0.android.request.Request
 import com.auth0.android.request.internal.Jwt
 import com.auth0.android.result.Credentials
 import com.auth0.android.result.CredentialsMock
+import com.auth0.android.result.SSOCredentials
+import com.auth0.android.result.SsoCredentialsMock
 import com.auth0.android.util.Clock
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -28,9 +39,7 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import java.lang.Exception
-import java.lang.IllegalArgumentException
-import java.util.*
+import java.util.Date
 import java.util.concurrent.Executor
 
 @RunWith(RobolectricTestRunner::class)
@@ -48,6 +57,12 @@ public class CredentialsManagerTest {
     private lateinit var request: Request<Credentials, AuthenticationException>
 
     @Mock
+    private lateinit var ssoCredentialsRequest: Request<SSOCredentials, AuthenticationException>
+
+    @Mock
+    private lateinit var ssoCallback: Callback<SSOCredentials, CredentialsManagerException>
+
+    @Mock
     private lateinit var jwtDecoder: JWTDecoder
 
     private val serialExecutor = Executor { runnable -> runnable.run() }
@@ -55,6 +70,8 @@ public class CredentialsManagerTest {
     private val credentialsCaptor: KArgumentCaptor<Credentials> = argumentCaptor()
 
     private val exceptionCaptor: KArgumentCaptor<CredentialsManagerException> = argumentCaptor()
+
+    private val ssoCredentialsCaptor: KArgumentCaptor<SSOCredentials> = argumentCaptor()
 
     @get:Rule
     public var exception: ExpectedException = ExpectedException.none()
@@ -197,11 +214,152 @@ public class CredentialsManagerTest {
 
     @Test
     public fun shouldNotThrowOnSetIfCredentialsHasIdTokenAndExpiresAt() {
+        verifyNoMoreInteractions(storage)
         val credentials: Credentials =
             CredentialsMock.create("idToken", "", "type", "refreshToken", Date(), null)
         prepareJwtDecoderMock(Date())
         manager.saveCredentials(credentials)
     }
+
+    @Test
+    public fun shouldNotSaveIfTheSsoCredentialsHasNoRefreshToken() {
+        val ssoCredentials = SSOCredentials(
+            "accessToken",
+            "issuedTokenType", "tokenType", 60, null
+        )
+        manager.saveSsoCredentials(ssoCredentials)
+        verifyZeroInteractions(storage)
+    }
+
+    @Test
+    public fun shouldNotSaveIfTheNewSsoCredentialRefreshTokenIsSameAsTheExistingOne() {
+        verifyNoMoreInteractions(storage)
+        val ssoCredentials = SSOCredentials(
+            "accessToken",
+            "issuedTokenType", "tokenType", 60, "refresh_token"
+        )
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token"))
+            .thenReturn("refresh_token")
+        manager.saveSsoCredentials(ssoCredentials)
+        verify(storage, times(0)).store("com.auth0.refresh_token", "refresh_token")
+    }
+
+    @Test
+    public fun shouldSaveTheRefreshTokenIfTheNewSsoRefreshTokenIsNotSameAsTheOldOne() {
+        verifyNoMoreInteractions(storage)
+        val ssoCredentials = SSOCredentials(
+            "accessToken",
+            "issuedTokenType", "tokenType", 60, "refresh_token"
+        )
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token"))
+            .thenReturn("refresh-token")
+        manager.saveSsoCredentials(ssoCredentials)
+        verify(storage).store("com.auth0.refresh_token", "refresh_token")
+    }
+
+    @Test
+    public fun shouldThrowExceptionIfNoExistingRefreshTokenExistWhenGettingSSOCredentials() {
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token"))
+            .thenReturn(null)
+        manager.getSsoCredentials(ssoCallback)
+        verify(ssoCallback).onFailure(
+            exceptionCaptor.capture()
+        )
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(
+            exception.message,
+            Is.`is`("Credentials need to be renewed but no Refresh Token is available to renew them.")
+        )
+    }
+
+    @Test
+    public fun shouldSaveTheNewRefreshTokenWhenGettingTheSSOCredentials() {
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token"))
+            .thenReturn("refresh_token_old")
+        Mockito.`when`(client.fetchSessionToken("refresh_token_old"))
+            .thenReturn(ssoCredentialsRequest)
+        Mockito.`when`(ssoCredentialsRequest.execute()).thenReturn(
+            SsoCredentialsMock.create(
+                "session-token", "issued-token-type", "token-type", "refresh-token", 60
+            )
+        )
+        manager.getSsoCredentials(ssoCallback)
+        verify(ssoCallback).onSuccess(
+            ssoCredentialsCaptor.capture()
+        )
+        val credentials = ssoCredentialsCaptor.firstValue
+        MatcherAssert.assertThat(credentials.sessionToken, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(credentials.sessionToken, Is.`is`("session-token"))
+        MatcherAssert.assertThat(credentials.tokenType, Is.`is`("token-type"))
+        MatcherAssert.assertThat(credentials.issuedTokenType, Is.`is`("issued-token-type"))
+        MatcherAssert.assertThat(credentials.refreshToken, Is.`is`("refresh-token"))
+        MatcherAssert.assertThat(credentials.expiresIn, Is.`is`(60))
+        verify(storage).store("com.auth0.refresh_token", credentials.refreshToken)
+    }
+
+    @Test
+    public fun shouldGetAndFailToGetNewSSOCredentialsWhenRefreshTokenExpired() {
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken")
+        Mockito.`when`(
+            client.fetchSessionToken("refreshToken")
+        ).thenReturn(ssoCredentialsRequest)
+        //Trigger failure
+        val authenticationException = AuthenticationException(
+            "invalid_grant",
+            "Unknown or invalid refresh token."
+        )
+        Mockito.`when`(ssoCredentialsRequest.execute()).thenThrow(authenticationException)
+        manager.getSsoCredentials(ssoCallback)
+        verify(ssoCallback).onFailure(
+            exceptionCaptor.capture()
+        )
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(authenticationException))
+        MatcherAssert.assertThat(
+            exception.message,
+            Is.`is`("An error occurred while trying to use the Refresh Token to renew the Credentials.")
+        )
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    public fun shouldFailOnAwaitSsoCredentialsWhenNoRefreshTokenWasSaved(): Unit = runTest {
+        verifyNoMoreInteractions(client)
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token")).thenReturn(null)
+        val exception = assertThrows(CredentialsManagerException::class.java) {
+            runBlocking { manager.awaitSsoCredentials() }
+        }
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(
+            exception.message,
+            Is.`is`("Credentials need to be renewed but no Refresh Token is available to renew them.")
+        )
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    public fun shouldSaveNewRefreshingTokenOnAwaitSsoCredentials(): Unit = runTest {
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token"))
+            .thenReturn("refresh_token_old")
+        Mockito.`when`(client.fetchSessionToken("refresh_token_old"))
+            .thenReturn(ssoCredentialsRequest)
+        Mockito.`when`(ssoCredentialsRequest.execute()).thenReturn(
+            SsoCredentialsMock.create(
+                "session-token", "issued-token-type", "token-type", "refresh-token", 60
+            )
+        )
+        val credentials = manager.awaitSsoCredentials()
+        MatcherAssert.assertThat(credentials.sessionToken, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(credentials.sessionToken, Is.`is`("session-token"))
+        MatcherAssert.assertThat(credentials.tokenType, Is.`is`("token-type"))
+        MatcherAssert.assertThat(credentials.issuedTokenType, Is.`is`("issued-token-type"))
+        MatcherAssert.assertThat(credentials.refreshToken, Is.`is`("refresh-token"))
+        MatcherAssert.assertThat(credentials.expiresIn, Is.`is`(60))
+        verify(storage).store("com.auth0.refresh_token", credentials.refreshToken)
+    }
+
 
     @Test
     public fun shouldFailOnGetCredentialsWhenNoAccessTokenOrIdTokenWasSaved() {
@@ -930,7 +1088,8 @@ public class CredentialsManagerTest {
             client.renewAuth("refreshToken")
         ).thenReturn(request)
         //Trigger failure
-        val authenticationException = AuthenticationException("Something went wrong", mock<Exception>())
+        val authenticationException =
+            AuthenticationException("Something went wrong", mock<Exception>())
         Mockito.`when`(request.execute()).thenThrow(authenticationException)
         manager.getCredentials(callback)
         verify(storage, never())

--- a/auth0/src/test/java/com/auth0/android/result/SsoCredentialsMock.kt
+++ b/auth0/src/test/java/com/auth0/android/result/SsoCredentialsMock.kt
@@ -1,0 +1,19 @@
+package com.auth0.android.result
+
+public class SsoCredentialsMock {
+
+    public companion object {
+
+        public fun create(
+            accessToken: String,
+            issuedTokenType: String,
+            type: String,
+            refreshToken: String?,
+            expiresIn: Int
+        ): SSOCredentials {
+            return SSOCredentials(
+                accessToken, issuedTokenType, type, expiresIn, refreshToken
+            )
+        }
+    }
+}


### PR DESCRIPTION
### Changes

This PR adds support to fetch a session token, in exchange for a refresh token, to be used for SSO

### Testing

- [x] This change adds unit test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
