### PR TITLE
Add to CustomTabsOptions ability to disable opening auth in custom tab

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -149,7 +149,7 @@ class CustomTabsController extends CustomTabsServiceConnection {
         } catch (InterruptedException ignored) {
         }
         Log.d(TAG, "Launching URI. Custom Tabs available: " + available);
-        final Intent intent = customTabsOptions.toIntent(context, session.get());
+        final Intent intent = customTabsOptions.toIntent(context, session.get(), this.preferredPackage);
         intent.setData(uri);
         context.startActivity(intent);
     }

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -149,7 +149,7 @@ class CustomTabsController extends CustomTabsServiceConnection {
         } catch (InterruptedException ignored) {
         }
         Log.d(TAG, "Launching URI. Custom Tabs available: " + available);
-        final Intent intent = customTabsOptions.toIntent(context, session.get(), this.preferredPackage);
+        final Intent intent = customTabsOptions.toIntent(context, session.get());
         intent.setData(uri);
         context.startActivity(intent);
     }

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
@@ -50,6 +50,12 @@ public class CustomTabsOptions implements Parcelable {
         return getPreferredPackage(pm) != null;
     }
 
+    /**
+     * Returns whether the browser preferred package has custom tab disabled or not.
+     *
+     * @param preferredPackage the preferred browser package name.
+     * @return whether the browser preferred package has custom tab disabled or not.
+     */
     boolean isDisabledCustomTabBrowser(@NonNull String preferredPackage) {
         return disabledCustomTabsPackages != null && disabledCustomTabsPackages.contains(preferredPackage);
     }
@@ -193,6 +199,13 @@ public class CustomTabsOptions implements Parcelable {
             return this;
         }
 
+        /**
+         * Define a list of browser packages that disables the launching of authentication on custom tabs.
+         * The authentication url will launch on the preferred package external browser.
+         *
+         * @param disabledCustomTabsPackages list of browser packages.
+         * @return the current builder instance
+         */
         @NonNull
         public Builder withDisabledCustomTabsPackages(List<String> disabledCustomTabsPackages) {
             this.disabledCustomTabsPackages = disabledCustomTabsPackages;

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
@@ -66,7 +66,8 @@ public class CustomTabsOptions implements Parcelable {
 
 
     @SuppressLint("ResourceType")
-    Intent toIntent(@NonNull Context context, @Nullable CustomTabsSession session, @Nullable String preferredPackage) {
+    Intent toIntent(@NonNull Context context, @Nullable CustomTabsSession session) {
+        String preferredPackage = this.getPreferredPackage(context.getPackageManager());
 
         if (preferredPackage != null && this.isDisabledCustomTabBrowser(preferredPackage)) {
             return new Intent(Intent.ACTION_VIEW);

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
@@ -7,17 +7,19 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
+
 import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsSession;
-import androidx.browser.trusted.TrustedWebActivityIntent;
 import androidx.browser.trusted.TrustedWebActivityIntentBuilder;
 import androidx.core.content.ContextCompat;
 
 import com.auth0.android.authentication.AuthenticationException;
+
+import java.util.List;
 
 /**
  * Holder for Custom Tabs customization options. Use {@link CustomTabsOptions#newBuilder()} to begin.
@@ -29,10 +31,14 @@ public class CustomTabsOptions implements Parcelable {
     private final int toolbarColor;
     private final BrowserPicker browserPicker;
 
-    private CustomTabsOptions(boolean showTitle, @ColorRes int toolbarColor, @NonNull BrowserPicker browserPicker) {
+    @Nullable
+    private final List<String> disabledCustomTabsPackages;
+
+    private CustomTabsOptions(boolean showTitle, @ColorRes int toolbarColor, @NonNull BrowserPicker browserPicker, @Nullable List<String> disabledCustomTabsPackages) {
         this.showTitle = showTitle;
         this.toolbarColor = toolbarColor;
         this.browserPicker = browserPicker;
+        this.disabledCustomTabsPackages = disabledCustomTabsPackages;
     }
 
     @Nullable
@@ -42,6 +48,10 @@ public class CustomTabsOptions implements Parcelable {
 
     boolean hasCompatibleBrowser(@NonNull PackageManager pm) {
         return getPreferredPackage(pm) != null;
+    }
+
+    boolean isDisabledCustomTabBrowser(@NonNull String preferredPackage) {
+        return disabledCustomTabsPackages != null && disabledCustomTabsPackages.contains(preferredPackage);
     }
 
     /**
@@ -56,7 +66,12 @@ public class CustomTabsOptions implements Parcelable {
 
 
     @SuppressLint("ResourceType")
-    Intent toIntent(@NonNull Context context, @Nullable CustomTabsSession session) {
+    Intent toIntent(@NonNull Context context, @Nullable CustomTabsSession session, @Nullable String preferredPackage) {
+
+        if (preferredPackage != null && this.isDisabledCustomTabBrowser(preferredPackage)) {
+            return new Intent(Intent.ACTION_VIEW);
+        }
+
         final CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(session)
                 .setShowTitle(showTitle)
                 .setShareState(CustomTabsIntent.SHARE_STATE_OFF);
@@ -85,6 +100,7 @@ public class CustomTabsOptions implements Parcelable {
         showTitle = in.readByte() != 0;
         toolbarColor = in.readInt();
         browserPicker = in.readParcelable(BrowserPicker.class.getClassLoader());
+        disabledCustomTabsPackages = in.createStringArrayList();
     }
 
     @Override
@@ -92,6 +108,7 @@ public class CustomTabsOptions implements Parcelable {
         dest.writeByte((byte) (showTitle ? 1 : 0));
         dest.writeInt(toolbarColor);
         dest.writeParcelable(browserPicker, flags);
+        dest.writeStringList(disabledCustomTabsPackages);
     }
 
     @Override
@@ -120,10 +137,14 @@ public class CustomTabsOptions implements Parcelable {
         @NonNull
         private BrowserPicker browserPicker;
 
+        @Nullable
+        private List<String> disabledCustomTabsPackages;
+
         Builder() {
             this.showTitle = false;
             this.toolbarColor = 0;
             this.browserPicker = BrowserPicker.newBuilder().build();
+            this.disabledCustomTabsPackages = null;
         }
 
         /**
@@ -171,6 +192,12 @@ public class CustomTabsOptions implements Parcelable {
             return this;
         }
 
+        @NonNull
+        public Builder withDisabledCustomTabsPackages(List<String> disabledCustomTabsPackages) {
+            this.disabledCustomTabsPackages = disabledCustomTabsPackages;
+            return this;
+        }
+
         /**
          * Create a new CustomTabsOptions instance with the customization settings.
          *
@@ -178,7 +205,7 @@ public class CustomTabsOptions implements Parcelable {
          */
         @NonNull
         public CustomTabsOptions build() {
-            return new CustomTabsOptions(showTitle, toolbarColor, browserPicker);
+            return new CustomTabsOptions(showTitle, toolbarColor, browserPicker, disabledCustomTabsPackages);
         }
     }
 

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
@@ -14,12 +14,16 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -74,7 +78,7 @@ public class CustomTabsOptionsTest {
         CustomTabsOptions options = CustomTabsOptions.newBuilder().build();
         assertThat(options, is(notNullValue()));
 
-        Intent intent = options.toIntent(context, null);
+        Intent intent = options.toIntent(context, null, null);
 
         assertThat(intent, is(notNullValue()));
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(false));
@@ -89,7 +93,7 @@ public class CustomTabsOptionsTest {
         CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
         assertThat(parceledOptions, is(notNullValue()));
 
-        Intent parceledIntent = parceledOptions.toIntent(context, null);
+        Intent parceledIntent = parceledOptions.toIntent(context, null, null);
         assertThat(parceledIntent, is(notNullValue()));
         assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(false));
         assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
@@ -105,7 +109,7 @@ public class CustomTabsOptionsTest {
                 .build();
         assertThat(options, is(notNullValue()));
 
-        Intent intent = options.toIntent(context, null);
+        Intent intent = options.toIntent(context, null, null);
 
         assertThat(intent, is(notNullValue()));
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
@@ -118,7 +122,7 @@ public class CustomTabsOptionsTest {
         CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
         assertThat(parceledOptions, is(notNullValue()));
 
-        Intent parceledIntent = parceledOptions.toIntent(context, null);
+        Intent parceledIntent = parceledOptions.toIntent(context, null, null);
         assertThat(parceledIntent, is(notNullValue()));
         assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
         assertThat(parceledIntent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.SHOW_PAGE_TITLE));
@@ -131,7 +135,7 @@ public class CustomTabsOptionsTest {
                 .build();
         assertThat(options, is(notNullValue()));
 
-        Intent intent = options.toIntent(context, null);
+        Intent intent = options.toIntent(context, null, null);
 
         assertThat(intent, is(notNullValue()));
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(true));
@@ -145,7 +149,7 @@ public class CustomTabsOptionsTest {
         CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
         assertThat(parceledOptions, is(notNullValue()));
 
-        Intent parceledIntent = parceledOptions.toIntent(context, null);
+        Intent parceledIntent = parceledOptions.toIntent(context, null, null);
         assertThat(parceledIntent, is(notNullValue()));
         assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(true));
         assertThat(parceledIntent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(resolvedColor));
@@ -173,5 +177,37 @@ public class CustomTabsOptionsTest {
 
         String preferredPackageNow = parceledOptions.getPreferredPackage(activity.getPackageManager());
         assertThat(preferredPackageNow, is("com.auth0.browser"));
+    }
+
+    @Test
+    public void shouldSetDisabledCustomTabPackages() {
+        CustomTabsOptions options = CustomTabsOptions.newBuilder()
+                .withDisabledCustomTabsPackages(List.of("com.auth0.browser"))
+                .withToolbarColor(android.R.color.black)
+                .build();
+        assertThat(options, is(notNullValue()));
+
+        Intent intentNoExtras = options.toIntent(context, null, "com.auth0.browser");
+
+        assertThat(intentNoExtras, is(notNullValue()));
+        assertThat(intentNoExtras.getExtras(), is(nullValue()));
+        assertEquals(intentNoExtras.getAction(), "android.intent.action.VIEW");
+
+        Intent intentWithToolbarExtra = options.toIntent(context, null, "com.another.browser");
+        assertThat(intentWithToolbarExtra, is(notNullValue()));
+        assertThat(intentWithToolbarExtra.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(true));
+        int resolvedColor = ContextCompat.getColor(context, android.R.color.black);
+        assertThat(intentWithToolbarExtra.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(resolvedColor));
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
+        assertThat(parceledOptions, is(notNullValue()));
+
+        Intent parceledIntent = parceledOptions.toIntent(context, null, "com.auth0.browser");
+        assertThat(parceledIntent, is(notNullValue()));
+        assertThat(parceledIntent.getExtras(), is(nullValue()));
+        assertEquals(parceledIntent.getAction(), "android.intent.action.VIEW");
     }
 }

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
@@ -78,7 +78,7 @@ public class CustomTabsOptionsTest {
         CustomTabsOptions options = CustomTabsOptions.newBuilder().build();
         assertThat(options, is(notNullValue()));
 
-        Intent intent = options.toIntent(context, null, null);
+        Intent intent = options.toIntent(context, null);
 
         assertThat(intent, is(notNullValue()));
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(false));
@@ -93,7 +93,7 @@ public class CustomTabsOptionsTest {
         CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
         assertThat(parceledOptions, is(notNullValue()));
 
-        Intent parceledIntent = parceledOptions.toIntent(context, null, null);
+        Intent parceledIntent = parceledOptions.toIntent(context, null);
         assertThat(parceledIntent, is(notNullValue()));
         assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(false));
         assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
@@ -109,7 +109,7 @@ public class CustomTabsOptionsTest {
                 .build();
         assertThat(options, is(notNullValue()));
 
-        Intent intent = options.toIntent(context, null, null);
+        Intent intent = options.toIntent(context, null);
 
         assertThat(intent, is(notNullValue()));
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
@@ -122,7 +122,7 @@ public class CustomTabsOptionsTest {
         CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
         assertThat(parceledOptions, is(notNullValue()));
 
-        Intent parceledIntent = parceledOptions.toIntent(context, null, null);
+        Intent parceledIntent = parceledOptions.toIntent(context, null);
         assertThat(parceledIntent, is(notNullValue()));
         assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE), is(true));
         assertThat(parceledIntent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE), is(CustomTabsIntent.SHOW_PAGE_TITLE));
@@ -135,7 +135,7 @@ public class CustomTabsOptionsTest {
                 .build();
         assertThat(options, is(notNullValue()));
 
-        Intent intent = options.toIntent(context, null, null);
+        Intent intent = options.toIntent(context, null);
 
         assertThat(intent, is(notNullValue()));
         assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(true));
@@ -149,7 +149,7 @@ public class CustomTabsOptionsTest {
         CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
         assertThat(parceledOptions, is(notNullValue()));
 
-        Intent parceledIntent = parceledOptions.toIntent(context, null, null);
+        Intent parceledIntent = parceledOptions.toIntent(context, null);
         assertThat(parceledIntent, is(notNullValue()));
         assertThat(parceledIntent.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(true));
         assertThat(parceledIntent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(resolvedColor));
@@ -181,23 +181,22 @@ public class CustomTabsOptionsTest {
 
     @Test
     public void shouldSetDisabledCustomTabPackages() {
+        Activity activity = spy(Robolectric.setupActivity(Activity.class));
+        BrowserPickerTest.setupBrowserContext(activity, Collections.singletonList("com.auth0.browser"), null, null);
+        BrowserPicker browserPicker = BrowserPicker.newBuilder().build();
+
         CustomTabsOptions options = CustomTabsOptions.newBuilder()
+                .withBrowserPicker(browserPicker)
                 .withDisabledCustomTabsPackages(List.of("com.auth0.browser"))
                 .withToolbarColor(android.R.color.black)
                 .build();
         assertThat(options, is(notNullValue()));
 
-        Intent intentNoExtras = options.toIntent(context, null, "com.auth0.browser");
+        Intent intentNoExtras = options.toIntent(activity, null);
 
         assertThat(intentNoExtras, is(notNullValue()));
         assertThat(intentNoExtras.getExtras(), is(nullValue()));
         assertEquals(intentNoExtras.getAction(), "android.intent.action.VIEW");
-
-        Intent intentWithToolbarExtra = options.toIntent(context, null, "com.another.browser");
-        assertThat(intentWithToolbarExtra, is(notNullValue()));
-        assertThat(intentWithToolbarExtra.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(true));
-        int resolvedColor = ContextCompat.getColor(context, android.R.color.black);
-        assertThat(intentWithToolbarExtra.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(resolvedColor));
 
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
@@ -205,9 +204,24 @@ public class CustomTabsOptionsTest {
         CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
         assertThat(parceledOptions, is(notNullValue()));
 
-        Intent parceledIntent = parceledOptions.toIntent(context, null, "com.auth0.browser");
+        Intent parceledIntent = parceledOptions.toIntent(activity, null);
         assertThat(parceledIntent, is(notNullValue()));
         assertThat(parceledIntent.getExtras(), is(nullValue()));
         assertEquals(parceledIntent.getAction(), "android.intent.action.VIEW");
+
+        BrowserPickerTest.setupBrowserContext(activity, Collections.singletonList("com.another.browser"), null, null);
+        BrowserPicker browserPicker2 = BrowserPicker.newBuilder().build();
+
+        CustomTabsOptions options2 = CustomTabsOptions.newBuilder()
+                .withBrowserPicker(browserPicker2)
+                .withDisabledCustomTabsPackages(List.of("com.auth0.browser"))
+                .withToolbarColor(android.R.color.black)
+                .build();
+
+        Intent intentWithToolbarExtra = options2.toIntent(activity, null);
+        assertThat(intentWithToolbarExtra, is(notNullValue()));
+        assertThat(intentWithToolbarExtra.hasExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR), is(true));
+        int resolvedColor = ContextCompat.getColor(activity, android.R.color.black);
+        assertThat(intentWithToolbarExtra.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0), is(resolvedColor));
     }
 }


### PR DESCRIPTION
### Changes

Add option in `CustomTabsOptions` to define a list of browser packages where you do not want to launch the authentication url in custom tab. This adds feature https://github.com/auth0/Auth0.Android/issues/805 to solve incompatible custom tab browser.

Please describe both what is changing and why this is important. Include:

- create new method for CustomTabOptions builder `withDisabledCustomTabsPackages` to define list of custom tab packages to disable which assigns to new instance variable `disabledCustomTabsPackages`
- update `CustomTabOptions.toIntent` to get `preferredPackage` which is the preferred browser package calculated by browser picker.
- update `CustomTabOptions.toIntent` to validate if the `preferredPackage` is in the `disabledCustomTabsPackages` list, and if so, just return `Intent` with action of `Intent.ACTION_VIEW` only


### References

solves feature https://github.com/auth0/Auth0.Android/issues/805

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
