### PR TITLE
Add support for Multi-Resource Refresh Token (MRRT)

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -749,13 +749,27 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      * ```
      *
      * @param refreshToken used to fetch the new Credentials.
+     * @param audience Identifier of the API that your application is requesting access to. Defaults to null.
+     * @param scope Space-separated list of scope values to request. Defaults to null.
      * @return a request to start
      */
-    public fun renewAuth(refreshToken: String): Request<Credentials, AuthenticationException> {
+    public fun renewAuth(
+        refreshToken: String,
+        audience: String? = null,
+        scope: String? = null
+    ): Request<Credentials, AuthenticationException> {
         val parameters = ParameterBuilder.newBuilder()
             .setClientId(clientId)
             .setRefreshToken(refreshToken)
             .setGrantType(ParameterBuilder.GRANT_TYPE_REFRESH_TOKEN)
+            .apply {
+                audience?.let {
+                    setAudience(it)
+                }
+                scope?.let {
+                    setScope(it)
+                }
+            }
             .asDictionary()
         val url = auth0.getDomainUrl().toHttpUrl().newBuilder()
             .addPathSegment(OAUTH_PATH)
@@ -942,7 +956,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     /**
      * Helper function to make a request to the /oauth/token endpoint with a custom response type.
      */
-    private inline fun <reified T> loginWithTokenGeneric(parameters: Map<String, String>): Request<T,AuthenticationException> {
+    private inline fun <reified T> loginWithTokenGeneric(parameters: Map<String, String>): Request<T, AuthenticationException> {
         val url = auth0.getDomainUrl().toHttpUrl().newBuilder()
             .addPathSegment(OAUTH_PATH)
             .addPathSegment(TOKEN_PATH)

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -731,7 +731,9 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     }
 
     /**
-     * Requests new Credentials using a valid Refresh Token. The received token will have the same audience and scope as first requested.
+     * Requests new Credentials using a valid Refresh Token. You can request credentials for a specific API by passing its audience value. The default scopes configured for
+     * the API will be granted if you don't request any specific scopes.
+     *
      *
      * This method will use the /oauth/token endpoint with the 'refresh_token' grant, and the response will include an id_token and an access_token if 'openid' scope was requested when the refresh_token was obtained.
      * Additionally, if the application has Refresh Token Rotation configured, a new one-time use refresh token will also be included in the response.
@@ -740,8 +742,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      *
      * Example usage:
      * ```
-     * client.renewAuth("{refresh_token}")
-     *     .addParameter("scope", "openid profile email")
+     * client.renewAuth("{refresh_token}","{audience}","{scope})
      *     .start(object: Callback<Credentials, AuthenticationException> {
      *         override fun onSuccess(result: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -3,6 +3,7 @@ package com.auth0.android.authentication.storage
 import androidx.annotation.VisibleForTesting
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.callback.Callback
+import com.auth0.android.result.APICredentials
 import com.auth0.android.result.Credentials
 import com.auth0.android.result.SSOCredentials
 import com.auth0.android.util.Clock
@@ -30,6 +31,7 @@ public abstract class BaseCredentialsManager internal constructor(
 
     @Throws(CredentialsManagerException::class)
     public abstract fun saveCredentials(credentials: Credentials)
+    public abstract fun saveApiCredentials(apiCredentials: APICredentials, audience: String)
     public abstract fun saveSsoCredentials(ssoCredentials: SSOCredentials)
     public abstract fun getCredentials(callback: Callback<Credentials, CredentialsManagerException>)
     public abstract fun getSsoCredentials(callback: Callback<SSOCredentials, CredentialsManagerException>)
@@ -61,6 +63,15 @@ public abstract class BaseCredentialsManager internal constructor(
         headers: Map<String, String>,
         forceRefresh: Boolean,
         callback: Callback<Credentials, CredentialsManagerException>
+    )
+
+    public abstract fun getApiCredentials(
+        audience: String,
+        scope: String? = null,
+        minTtl: Int = 0,
+        parameters: Map<String, String> = emptyMap(),
+        headers: Map<String, String> = emptyMap(),
+        callback: Callback<APICredentials, CredentialsManagerException>
     )
 
     @JvmSynthetic
@@ -102,7 +113,18 @@ public abstract class BaseCredentialsManager internal constructor(
         forceRefresh: Boolean
     ): Credentials
 
+    @JvmSynthetic
+    @Throws(CredentialsManagerException::class)
+    public abstract suspend fun awaitApiCredentials(
+        audience: String,
+        scope: String? = null,
+        minTtl: Int = 0,
+        parameters: Map<String, String> = emptyMap(),
+        headers: Map<String, String> = emptyMap()
+    ): APICredentials
+
     public abstract fun clearCredentials()
+    public abstract fun clearApiCredentials(audience: String)
     public abstract fun hasValidCredentials(): Boolean
     public abstract fun hasValidCredentials(minTtl: Long): Boolean
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -546,13 +546,9 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
                 val updatedRefreshToken =
                     if (TextUtils.isEmpty(newCredentials.refreshToken)) refreshToken else newCredentials.refreshToken
                 val newApiCredentials = newCredentials.toAPICredentials()
-                saveCredentials(
-                    recreateCredentials(
-                        newCredentials.idToken, newCredentials.accessToken, newCredentials.type,
-                        updatedRefreshToken, newCredentials.expiresAt, newCredentials.scope
-                    )
-                )
-                saveCredentials(newApiCredentials, audience)
+                storage.store(KEY_REFRESH_TOKEN, updatedRefreshToken)
+                storage.store(KEY_ID_TOKEN, newCredentials.idToken)
+                saveApiCredentials(newApiCredentials, audience)
                 callback.onSuccess(newApiCredentials)
             } catch (error: AuthenticationException) {
                 val exception = when {

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -11,9 +11,11 @@ import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
 import com.auth0.android.request.internal.GsonProvider
+import com.auth0.android.result.APICredentials
 import com.auth0.android.result.Credentials
 import com.auth0.android.result.OptionalCredentials
 import com.auth0.android.result.SSOCredentials
+import com.auth0.android.result.toAPICredentials
 import com.google.gson.Gson
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.lang.ref.WeakReference
@@ -37,7 +39,6 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     private val localAuthenticationManagerFactory: LocalAuthenticationManagerFactory? = null,
 ) : BaseCredentialsManager(apiClient, storage, jwtDecoder) {
     private val gson: Gson = GsonProvider.gson
-
 
     /**
      * Creates a new SecureCredentialsManager to handle Credentials
@@ -129,6 +130,36 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     }
 
     /**
+     * Stores the given [APICredentials] in the storage for the given audience.
+     * @param apiCredentials the API Credentials to be stored
+     * @param audience the audience for which the credentials are stored
+     */
+    override fun saveApiCredentials(apiCredentials: APICredentials, audience: String) {
+        val json = gson.toJson(apiCredentials)
+        try {
+            val encrypted = crypto.encrypt(json.toByteArray())
+            val encryptedEncoded = Base64.encodeToString(encrypted, Base64.DEFAULT)
+            storage.store(audience, encryptedEncoded)
+        } catch (e: IncompatibleDeviceException) {
+            throw CredentialsManagerException(
+                CredentialsManagerException.Code.INCOMPATIBLE_DEVICE,
+                e
+            )
+        } catch (e: CryptoException) {
+            /*
+             * If the keys were invalidated in the call above a good new pair is going to be available
+             * to use on the next call. We clear any existing credentials so #hasValidCredentials returns
+             * a true value. Retrying this operation will succeed.
+             */
+            clearApiCredentials(audience)
+            throw CredentialsManagerException(
+                CredentialsManagerException.Code.CRYPTO_EXCEPTION,
+                e
+            )
+        }
+    }
+
+    /**
      * Stores the given [SSOCredentials] refresh token in the storage.
      * This method must be called if the SSOCredentials are obtained by directly invoking [AuthenticationAPIClient.fetchSessionToken] api and
      * [rotating refresh token](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation) are enabled for
@@ -143,7 +174,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
             try {
                 existingCredentials = getExistingCredentials()
             } catch (exception: CredentialsManagerException) {
-                Log.e(TAG,"Error while fetching existing credentials", exception)
+                Log.e(TAG, "Error while fetching existing credentials", exception)
                 return@execute
             }
             // Checking if the existing one needs to be replaced with the new one
@@ -162,10 +193,10 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
      */
     override fun getSsoCredentials(callback: Callback<SSOCredentials, CredentialsManagerException>) {
         serialExecutor.execute {
-            lateinit var existingCredentials:Credentials
-            try{
+            lateinit var existingCredentials: Credentials
+            try {
                 existingCredentials = getExistingCredentials()
-            }catch (exception:CredentialsManagerException){
+            } catch (exception: CredentialsManagerException) {
                 callback.onFailure(exception)
                 return@execute
             }
@@ -363,6 +394,48 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     }
 
     /**
+     * Retrieves API credentials from storage and automatically renews them using the refresh token if the access
+     * token is expired. Otherwise, the retrieved API credentials will be returned via the success case as they are still valid.
+     *
+     * If there are no stored API credentials, the refresh token will be exchanged for a new set of API credentials.
+     * New or renewed API credentials will be automatically stored in storage.
+     * This is a Coroutine that is exposed only for Kotlin.
+     *
+     * @param audience Identifier of the API that your application is requesting access to.
+     * @param scope    the scope to request for the access token. If null is passed, the previous scope will be kept.
+     * @param minTtl   the minimum time in seconds that the access token should last before expiration.
+     * @param parameters additional parameters to send in the request to refresh expired credentials.
+     * @param headers additional headers to send in the request to refresh expired credentials.
+     */
+    @JvmSynthetic
+    @Throws(CredentialsManagerException::class)
+    override suspend fun awaitApiCredentials(
+        audience: String,
+        scope: String?,
+        minTtl: Int,
+        parameters: Map<String, String>,
+        headers: Map<String, String>
+    ): APICredentials {
+        return suspendCancellableCoroutine { continuation ->
+            getApiCredentials(
+                audience,
+                scope,
+                minTtl,
+                parameters,
+                headers,
+                object : Callback<APICredentials, CredentialsManagerException> {
+                    override fun onSuccess(result: APICredentials) {
+                        continuation.resume(result)
+                    }
+
+                    override fun onFailure(error: CredentialsManagerException) {
+                        continuation.resumeWithException(error)
+                    }
+                })
+        }
+    }
+
+    /**
      * Tries to obtain the credentials from the Storage. The callback's [Callback.onSuccess] method will be called with the result.
      * If something unexpected happens, the [Callback.onFailure] method will be called with the error. Some devices are not compatible
      * at all with the cryptographic implementation and will have [CredentialsManagerException.isDeviceIncompatible] return true.
@@ -487,20 +560,14 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         }
 
         if (fragmentActivity != null && localAuthenticationOptions != null && localAuthenticationManagerFactory != null) {
+
             fragmentActivity.get()?.let { fragmentActivity ->
-                val localAuthenticationManager = localAuthenticationManagerFactory.create(
-                    activity = fragmentActivity,
-                    authenticationOptions = localAuthenticationOptions,
-                    resultCallback = localAuthenticationResultCallback(
-                        scope,
-                        minTtl,
-                        parameters,
-                        headers,
-                        forceRefresh,
-                        callback
+                startBiometricAuthentication(
+                    fragmentActivity,
+                    biometricAuthenticationCredentialsCallback(
+                        scope, minTtl, parameters, headers, forceRefresh, callback
                     )
                 )
-                localAuthenticationManager.authenticate()
             } ?: run {
                 callback.onFailure(CredentialsManagerException.BIOMETRIC_ERROR_NO_ACTIVITY)
             }
@@ -510,21 +577,47 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         continueGetCredentials(scope, minTtl, parameters, headers, forceRefresh, callback)
     }
 
-    private val localAuthenticationResultCallback =
-        { scope: String?, minTtl: Int, parameters: Map<String, String>, headers: Map<String, String>, forceRefresh: Boolean, callback: Callback<Credentials, CredentialsManagerException> ->
-            object : Callback<Boolean, CredentialsManagerException> {
-                override fun onSuccess(result: Boolean) {
-                    continueGetCredentials(
-                        scope, minTtl, parameters, headers, forceRefresh,
-                        callback
-                    )
-                }
 
-                override fun onFailure(error: CredentialsManagerException) {
-                    callback.onFailure(error)
-                }
+    /**
+     * Retrieves API credentials from storage and automatically renews them using the refresh token if the access
+     * token is expired. Otherwise, the retrieved API credentials will be returned via the success case as they are still valid.
+     *
+     * If there are no stored API credentials, the refresh token will be exchanged for a new set of API credentials.
+     * New or renewed API credentials will be automatically stored in storage.
+     *
+     * @param audience Identifier of the API that your application is requesting access to.
+     * @param scope    the scope to request for the access token. If null is passed, the previous scope will be kept.
+     * @param minTtl   the minimum time in seconds that the access token should last before expiration.
+     * @param parameters additional parameters to send in the request to refresh expired credentials.
+     * @param headers additional headers to send in the request to refresh expired credentials.
+     */
+    override fun getApiCredentials(
+        audience: String,
+        scope: String?,
+        minTtl: Int,
+        parameters: Map<String, String>,
+        headers: Map<String, String>,
+        callback: Callback<APICredentials, CredentialsManagerException>
+    ) {
+
+        if (fragmentActivity != null && localAuthenticationOptions != null && localAuthenticationManagerFactory != null) {
+
+            fragmentActivity.get()?.let { fragmentActivity ->
+                startBiometricAuthentication(
+                    fragmentActivity,
+                    biometricAuthenticationApiCredentialsCallback(
+                        audience, scope, minTtl, parameters, headers, callback
+                    )
+                )
+            } ?: run {
+                callback.onFailure(CredentialsManagerException.BIOMETRIC_ERROR_NO_ACTIVITY)
             }
+            return
         }
+
+        continueGetApiCredentials(audience, scope, minTtl, parameters, headers, callback)
+    }
+
 
     /**
      * Delete the stored credentials
@@ -535,6 +628,13 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         storage.remove(LEGACY_KEY_CACHE_EXPIRES_AT)
         storage.remove(KEY_CAN_REFRESH)
         Log.d(TAG, "Credentials were just removed from the storage")
+    }
+
+    /**
+     * Removes the credentials for the given audience from the storage if present.
+     */
+    override fun clearApiCredentials(audience: String) {
+        storage.remove(audience)
     }
 
     /**
@@ -713,6 +813,129 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         }
     }
 
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun continueGetApiCredentials(
+        audience: String,
+        scope: String?,
+        minTtl: Int = 0,
+        parameters: Map<String, String>,
+        headers: Map<String, String>,
+        callback: Callback<APICredentials, CredentialsManagerException>
+    ) {
+        serialExecutor.execute {
+            val encryptedEncodedJson = storage.retrieveString(audience)
+            //Check if existing api credentials are present and valid
+            encryptedEncodedJson?.let { encryptedEncoded ->
+                val encrypted = Base64.decode(encryptedEncoded, Base64.DEFAULT)
+                val json: String
+                try {
+                    json = String(crypto.decrypt(encrypted))
+                } catch (e: IncompatibleDeviceException) {
+                    callback.onFailure(
+                        CredentialsManagerException(
+                            CredentialsManagerException.Code.INCOMPATIBLE_DEVICE,
+                            e
+                        )
+                    )
+                    return@execute
+                } catch (e: CryptoException) {
+                    //If keys were invalidated, existing credentials will not be recoverable.
+                    clearApiCredentials(audience)
+                    callback.onFailure(
+                        CredentialsManagerException(
+                            CredentialsManagerException.Code.CRYPTO_EXCEPTION,
+                            e
+                        )
+                    )
+                    return@execute
+                }
+
+                val apiCredentials = gson.fromJson(json, APICredentials::class.java)
+
+                val expiresAt = apiCredentials.expiresAt.time
+                val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
+                val scopeChanged = hasScopeChanged(apiCredentials.scope, scope)
+                val hasExpired = hasExpired(apiCredentials.expiresAt.time)
+                if (!hasExpired && !willAccessTokenExpire && !scopeChanged) {
+                    callback.onSuccess(apiCredentials)
+                    return@execute
+                }
+            }
+
+            //Check if refresh token exists or not
+            lateinit var existingCredentials: Credentials
+            try {
+                existingCredentials = getExistingCredentials()
+            } catch (exception: CredentialsManagerException) {
+                callback.onFailure(exception)
+                return@execute
+            }
+            val refreshToken = existingCredentials.refreshToken
+            if (refreshToken == null) {
+                callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
+                return@execute
+            }
+
+            val request = authenticationClient.renewAuth(refreshToken, audience, scope)
+            request.addParameters(parameters)
+            for (header in headers) {
+                request.addHeader(header.key, header.value)
+            }
+
+            try {
+                val newCredentials = request.execute()
+                val expiresAt = newCredentials.expiresAt.time
+                val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
+                if (willAccessTokenExpire) {
+                    val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000
+                    val wrongTtlException = CredentialsManagerException(
+                        CredentialsManagerException.Code.LARGE_MIN_TTL, String.format(
+                            Locale.getDefault(),
+                            "The lifetime of the renewed Access Token (%d) is less than the minTTL requested (%d). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard, or request a lower minTTL.",
+                            tokenLifetime,
+                            minTtl
+                        )
+                    )
+                    callback.onFailure(wrongTtlException)
+                    return@execute
+                }
+
+                // non-empty refresh token for refresh token rotation scenarios
+                val updatedRefreshToken =
+                    if (TextUtils.isEmpty(newCredentials.refreshToken)) refreshToken else newCredentials.refreshToken
+                val newApiCredentials = newCredentials.toAPICredentials()
+                saveCredentials(
+                    existingCredentials.copy(
+                        refreshToken = updatedRefreshToken,
+                        idToken = newCredentials.idToken
+                    )
+                )
+                saveApiCredentials(newApiCredentials, audience)
+                callback.onSuccess(newApiCredentials)
+
+            } catch (error: AuthenticationException) {
+                val exception = when {
+                    error.isRefreshTokenDeleted || error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
+
+                    error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
+                    else -> CredentialsManagerException.Code.API_ERROR
+                }
+                callback.onFailure(
+                    CredentialsManagerException(
+                        exception, error
+                    )
+                )
+            }
+
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun clearFragmentActivity() {
+        fragmentActivity!!.clear()
+    }
+
     /**
      * Helper method to fetch existing credentials from the storage.
      * This method is not thread safe
@@ -751,10 +974,60 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         return existingCredentials
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun clearFragmentActivity() {
-        fragmentActivity!!.clear()
+    /**
+     * Helper method to start the biometric authentication for accessing the credentials
+     */
+    private fun startBiometricAuthentication(
+        fragmentActivity: FragmentActivity,
+        biometricResultCallback: Callback<Boolean, CredentialsManagerException>
+    ) {
+        val localAuthenticationManager = localAuthenticationManagerFactory?.create(
+            activity = fragmentActivity,
+            authenticationOptions = localAuthenticationOptions!!,
+            resultCallback = biometricResultCallback,
+        )
+        localAuthenticationManager?.authenticate()
     }
+
+    /**
+     * Biometric authentication callback for authentication credentials
+     */
+    private val biometricAuthenticationCredentialsCallback =
+        { scope: String?, minTtl: Int, parameters: Map<String, String>, headers: Map<String, String>,
+          forceRefresh: Boolean, callback: Callback<Credentials, CredentialsManagerException> ->
+            object : Callback<Boolean, CredentialsManagerException> {
+                override fun onSuccess(result: Boolean) {
+                    continueGetCredentials(
+                        scope, minTtl, parameters, headers, forceRefresh,
+                        callback
+                    )
+                }
+
+                override fun onFailure(error: CredentialsManagerException) {
+                    callback.onFailure(error)
+                }
+            }
+        }
+
+    /**
+     * Biometric authentication callback for authentication credentials
+     */
+    private val biometricAuthenticationApiCredentialsCallback =
+        { audience: String, scope: String?, minTtl: Int, parameters: Map<String, String>, headers: Map<String, String>,
+          callback: Callback<APICredentials, CredentialsManagerException> ->
+            object : Callback<Boolean, CredentialsManagerException> {
+                override fun onSuccess(result: Boolean) {
+                    continueGetApiCredentials(
+                        audience, scope, minTtl, parameters, headers,
+                        callback
+                    )
+                }
+
+                override fun onFailure(error: CredentialsManagerException) {
+                    callback.onFailure(error)
+                }
+            }
+        }
 
     internal companion object {
         private val TAG = SecureCredentialsManager::class.java.simpleName

--- a/auth0/src/main/java/com/auth0/android/result/APICredentials.kt
+++ b/auth0/src/main/java/com/auth0/android/result/APICredentials.kt
@@ -1,0 +1,57 @@
+package com.auth0.android.result
+
+import com.google.gson.annotations.SerializedName
+import java.util.Date
+
+/**
+ * Holds the user's credentials obtained from Auth0 for a specific API as the result of exchanging a refresh token.
+ *
+ *  * *accessToken*: Access Token for Auth0 API
+ *  * *type*: The type of the received Access Token.
+ *  * *expiresAt*: The token expiration date.
+ *  * *scope*: The token's granted scope.
+ *
+ */
+public data class APICredentials(
+    /**
+     * Getter for the Access Token for Auth0 API.
+     *
+     * @return the Access Token.
+     */
+    @field:SerializedName("access_token")
+    val accessToken: String,
+    /**
+     * Getter for the type of the received Token.
+     *
+     * @return the token type.
+     */
+    @field:SerializedName("token_type")
+    val type: String,
+    /**
+     * Getter for the expiration date of the Access Token.
+     * Once expired, the Access Token can no longer be used to access an API and a new Access Token needs to be obtained.
+     *
+     * @return the expiration date of this Access Token
+     */
+    @field:SerializedName("expires_at")
+    val expiresAt: Date,
+    /**
+     * Getter for the access token's granted scope. Only available if the requested scope differs from the granted one.
+     *
+     * @return the granted scope.
+     */
+    @field:SerializedName("scope")
+    val scope: String?
+) {
+    override fun toString(): String {
+        return "APICredentials( accessToken='xxxxx', type='$type', expiresAt='$expiresAt', scope='$scope')"
+    }
+}
+
+
+/**
+ * Converts a Credentials instance to an APICredentials instance.
+ */
+internal fun Credentials.toAPICredentials(): APICredentials {
+    return APICredentials(accessToken, type, expiresAt, scope)
+}

--- a/auth0/src/main/java/com/auth0/android/result/Credentials.kt
+++ b/auth0/src/main/java/com/auth0/android/result/Credentials.kt
@@ -3,8 +3,7 @@ package com.auth0.android.result
 import com.auth0.android.request.internal.GsonProvider
 import com.auth0.android.request.internal.Jwt
 import com.google.gson.annotations.SerializedName
-
-import java.util.*
+import java.util.Date
 
 /**
  * Holds the user's credentials returned by Auth0.

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -1822,7 +1822,7 @@ public class SecureCredentialsManagerTest {
                 "newScope"
             )
         Mockito.`when`(
-            client.renewAuth("refreshToken")
+            client.renewAuth(refreshToken = "refreshToken")
         ).thenReturn(request)
         Mockito.`when`(request.execute()).thenReturn(renewedCredentials)
         val serialExecutor = Executors.newSingleThreadExecutor()
@@ -1893,7 +1893,9 @@ public class SecureCredentialsManagerTest {
         }
         latch.await() // Wait for all threads to finish
         Mockito.verify(client, Mockito.times(1))
-            .renewAuth(any()) // verify that api client's renewAuth is called only once
+            .renewAuth(
+               refreshToken = "refreshToken"
+            ) // verify that api client's renewAuth is called only once
         Mockito.verify(request, Mockito.times(1)).execute() // Verify single network request
     }
 


### PR DESCRIPTION
### Changes
This PR moves the Credentials Manager from a single credentials model to a multiple credentials one, supporting:

1 set of app credentials (the existing functionality)
N sets of API-specific credentials
To this end, two new public methods were added to the Credentials Manager:
``` kotlin
// And its coroutine counter part
public fun getApiCredentials(
        audience: String,
        scope: String? = null,
        minTtl: Int = 0,
        parameters: Map<String, String> = emptyMap(),
        headers: Map<String, String> = emptyMap(),
        callback: Callback<APICredentials, CredentialsManagerException>
    )
```

```kotlin
public fun clearApiCredentials(audience: String)
```

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
