### PR TITLE
Removed experimental tag from TWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,11 +290,7 @@ The callback will get invoked when the user returns to your application. There a
 
 If the `returnTo` URL is not found in the **Allowed Logout URLs** of your Auth0 Application, the server will not make the redirection and the browser will remain open.
 
-### Trusted Web Activity (Experimental Release)
-
-> **⚠️ Warning:** Trusted Web Activity support in Auth0.Android is still experimental and can change in the future. 
->
-> Please test it thoroughly in all the targeted browsers and OS variants and let us know your feedback.
+### Trusted Web Activity
 
 Trusted Web Activity is a feature provided by some browsers to provide a native look and feel.
 

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.auth0.android.Auth0
-import com.auth0.android.annotation.ExperimentalAuth0Api
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
 import com.auth0.android.result.Credentials
@@ -210,9 +209,7 @@ public object WebAuthProvider {
          * Launches the Logout experience with a native feel (without address bar). For this to work,
          * you have to setup the app as trusted following the steps mentioned [here](https://github.com/auth0/Auth0.Android/blob/main/EXAMPLES.md#trusted-web-activity-experimental).
          *
-         * This is still an experimental feature, test it thoroughly in the targeted devices and OS variants and let us know your feedback
          */
-        @ExperimentalAuth0Api
         public fun withTrustedWebActivity(): LogoutBuilder {
             launchAsTwa = true
             return this
@@ -504,9 +501,7 @@ public object WebAuthProvider {
          * Launches the Login experience with a native feel (without address bar). For this to work,
          * you have to setup the app as trusted following the steps mentioned [here](https://github.com/auth0/Auth0.Android/blob/main/EXAMPLES.md#trusted-web-activity-experimental).
          *
-         * This is still an experimental feature, test it thoroughly in the targeted devices and OS variants and let us know your feedback
          */
-        @ExperimentalAuth0Api
         public fun withTrustedWebActivity(): Builder {
             launchAsTwa = true
             return this


### PR DESCRIPTION
### Changes

This PR removes the experimental tag from the Trusted Web Activity feature 


### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
