### PR TITLE
Added new error type to CredentialsManagerException class

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -1,6 +1,7 @@
 package com.auth0.android.authentication.storage
 
 import android.text.TextUtils
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
@@ -442,6 +443,20 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
                         exception, error
                     )
                 )
+            } catch (exception: RuntimeException) {
+                /**
+                 *  Catching any unexpected runtime errors in the token renewal flow
+                 */
+                Log.e(
+                    TAG,
+                    "Caught unexpected exceptions for token renewal ${exception.stackTraceToString()}"
+                )
+                callback.onFailure(
+                    CredentialsManagerException(
+                        CredentialsManagerException.Code.UNKNOWN_ERROR,
+                        exception
+                    )
+                )
             }
         }
     }
@@ -527,5 +542,6 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
         // This is no longer used as we get the credentials expiry from the access token only,
         // but we still store it so users can rollback to versions where it is required.
         private const val LEGACY_KEY_CACHE_EXPIRES_AT = "com.auth0.cache_expires_at"
+        private val TAG = CredentialsManager::class.java.simpleName
     }
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManagerException.kt
@@ -46,6 +46,7 @@ public class CredentialsManagerException :
         NO_NETWORK,
         API_ERROR,
         SSO_EXCHANGE_FAILED,
+        UNKNOWN_ERROR
     }
 
     private var code: Code?
@@ -146,6 +147,8 @@ public class CredentialsManagerException :
         public val SSO_EXCHANGE_FAILED: CredentialsManagerException =
             CredentialsManagerException(Code.SSO_EXCHANGE_FAILED)
 
+        public val UNKNOWN_ERROR: CredentialsManagerException = CredentialsManagerException(Code.UNKNOWN_ERROR)
+
 
         private fun getMessage(code: Code): String {
             return when (code) {
@@ -191,6 +194,7 @@ public class CredentialsManagerException :
                 Code.NO_NETWORK -> "Failed to execute the network request."
                 Code.API_ERROR -> "An error occurred while processing the request."
                 Code.SSO_EXCHANGE_FAILED ->"The exchange of the refresh token for SSO credentials failed."
+                Code.UNKNOWN_ERROR -> "An unknown error has occurred while refreshing the token. Please check the error cause for more details."
             }
         }
     }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -680,6 +680,21 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                     )
                 )
                 return@execute
+            } catch (exception: RuntimeException) {
+                /**
+                 *  Catching any unexpected runtime errors in the token renewal flow
+                 */
+                Log.e(
+                    TAG,
+                    "Caught unexpected exceptions for token renewal ${exception.stackTraceToString()}"
+                )
+                callback.onFailure(
+                    CredentialsManagerException(
+                        CredentialsManagerException.Code.UNKNOWN_ERROR,
+                        exception
+                    )
+                )
+                return@execute
             }
 
             try {


### PR DESCRIPTION

### Changes
This PR adds a new error type `UNKNOWN_ERROR` to the CredentialsManagerException class. This error is triggered during any unexpected error occurs when token refresh happens in the CredentialsManager classes

### Testing

- [X] This change adds unit test coverage

- [X] This change adds integration test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
