### PR TITLE
Added support to enroll passkeys with My Account API 

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -1088,7 +1088,7 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
                 override fun fromJsonResponse(
                     statusCode: Int, reader: Reader
                 ): AuthenticationException {
-                    val values = mapAdapter.fromJson(reader)
+                    val values = mapAdapter.fromJson(reader, emptyMap())
                     return AuthenticationException(values, statusCode)
                 }
 

--- a/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/management/UsersAPIClient.kt
@@ -216,7 +216,7 @@ public class UsersAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRI
                     statusCode: Int,
                     reader: Reader
                 ): ManagementException {
-                    val values = mapAdapter.fromJson(reader)
+                    val values = mapAdapter.fromJson(reader, emptyMap())
                     return ManagementException(values)
                 }
 

--- a/auth0/src/main/java/com/auth0/android/myaccount/MyAccountAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/myaccount/MyAccountAPIClient.kt
@@ -1,0 +1,315 @@
+package com.auth0.android.myaccount
+
+import androidx.annotation.VisibleForTesting
+import com.auth0.android.Auth0
+import com.auth0.android.Auth0Exception
+import com.auth0.android.NetworkErrorException
+import com.auth0.android.authentication.ParameterBuilder
+import com.auth0.android.request.ErrorAdapter
+import com.auth0.android.request.JsonAdapter
+import com.auth0.android.request.PublicKeyCredentials
+import com.auth0.android.request.Request
+import com.auth0.android.request.internal.GsonAdapter
+import com.auth0.android.request.internal.GsonAdapter.Companion.forMap
+import com.auth0.android.request.internal.GsonProvider
+import com.auth0.android.request.internal.RequestFactory
+import com.auth0.android.request.internal.ResponseUtils.isNetworkError
+import com.auth0.android.result.PasskeyAuthenticationMethod
+import com.auth0.android.result.PasskeyEnrollmentChallenge
+import com.auth0.android.result.PasskeyRegistrationChallenge
+import com.google.gson.Gson
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import java.io.IOException
+import java.io.Reader
+import java.net.URLDecoder
+
+
+/**
+ * Auth0 My Account API client for managing the current user's account.
+ *
+ * You can use the refresh token to get an access token for the My Account API. Refer to [com.auth0.android.authentication.storage.CredentialsManager.getApiCredentials]
+ *  , or alternatively [com.auth0.android.authentication.AuthenticationAPIClient.renewAuth] if you are not using CredentialsManager.
+ *
+ * ## Usage
+ * ```kotlin
+ * val auth0 = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN")
+ * val client = MyAccountAPIClient(auth0,accessToken)
+ * ```
+ *
+ *
+ */
+public class MyAccountAPIClient @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) internal constructor(
+    private val auth0: Auth0,
+    private val accessToken: String,
+    private val factory: RequestFactory<MyAccountException>,
+    private val gson: Gson
+) {
+
+    public val clientId: String
+        get() = auth0.clientId
+
+    public val baseURL: String
+        get() = auth0.getDomainUrl()
+
+    /**
+     * Creates a new MyAccountAPI client instance.
+     *
+     * Example usage:
+     *
+     * ```
+     * val auth0 = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN")
+     * val client = MyAccountAPIClient(auth0, accessToken)
+     * ```
+     * @param auth0 account information
+     */
+    public constructor(
+        auth0: Auth0,
+        accessToken: String
+    ) : this(
+        auth0,
+        accessToken,
+        RequestFactory<MyAccountException>(auth0.networkingClient, createErrorAdapter()),
+        Gson()
+    )
+
+
+    /**
+     * Requests a challenge for enrolling a new passkey. This is the first part of the enrollment flow.
+     *
+     * You can specify an optional user identity identifier and an optional database connection name.
+     * If a connection name is not specified, your tenant's default directory will be used.
+     *
+     * ## Availability
+     *
+     * This feature is currently available in
+     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
+     * Please reach out to Auth0 support to get it enabled for your tenant.
+     *
+     * ## Scopes Required
+     *
+     * `create:me:authentication_methods`
+     *
+     * ## Usage
+     *
+     * ```kotlin
+     * val auth0 = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN")
+     * val apiClient = MyAccountAPIClient(auth0, accessToken)
+     *
+     * apiClient.passkeyEnrollmentChallenge()
+     *     .start(object : Callback<PasskeyEnrollmentChallenge, MyAccountException> {
+     *         override fun onSuccess(result: PasskeyEnrollmentChallenge) {
+     *             // Use the challenge with Credential Manager API to generate a new passkey credential
+     *             Log.d("MyApp", "Obtained enrollment challenge: $result")
+     *         }
+     *
+     *         override fun onFailure(error: MyAccountException) {
+     *             Log.e("MyApp", "Failed with: ${error.message}")
+     *         }
+     *     })
+     * ```
+     * Use the challenge with [Google Credential Manager API](https://developer.android.com/identity/sign-in/credential-manager) to generate a new passkey credential.
+     *
+     * ``` kotlin
+     *  CreatePublicKeyCredentialRequest( Gson().
+     *      toJson( passkeyEnrollmentChallenge.authParamsPublicKey ))
+     *            var response: CreatePublicKeyCredentialResponse?
+     *            credentialManager.createCredentialAsync(
+     *               requireContext(),
+     *               request,
+     *               CancellationSignal(),
+     *               Executors.newSingleThreadExecutor(),
+     *               object :
+     *                    CredentialManagerCallback<CreateCredentialResponse, CreateCredentialException> {
+     *                        override fun onError(e: CreateCredentialException) {
+     *                        }
+     *
+     *                        override fun onResult(result: CreateCredentialResponse) {
+     *                           response = result as CreatePublicKeyCredentialResponse
+     *                           val credentials = Gson().fromJson(
+     *                               response?.registrationResponseJson, PublicKeyCredentials::class.java
+     *                             )
+     *                        }
+     * ```
+     *
+     * Then, call ``enroll()`` with the created passkey credential and the challenge to complete
+     * the enrollment
+     *
+     * @param userIdentity Unique identifier of the current user's identity. Needed if the user logged in with a [linked account](https://auth0.com/docs/manage-users/user-accounts/user-account-linking)
+     * @param connection Name of the database connection where the user is stored
+     * @return A request to obtain a passkey enrollment challenge
+     *
+     * */
+    public fun passkeyEnrollmentChallenge(
+        userIdentity: String? = null, connection: String? = null
+    ): Request<PasskeyEnrollmentChallenge, MyAccountException> {
+
+        val url = getDomainUrlBuilder()
+            .addPathSegment(AUTHENTICATION_METHODS)
+            .build()
+
+        val params = ParameterBuilder.newBuilder().apply {
+            set(TYPE_KEY, "passkey")
+            userIdentity?.let {
+                set(USER_IDENTITY_ID_KEY, userIdentity)
+            }
+            connection?.let {
+                set(CONNECTION_KEY, connection)
+            }
+        }.asDictionary()
+
+        val passkeyEnrollmentAdapter: JsonAdapter<PasskeyEnrollmentChallenge> =
+            object : JsonAdapter<PasskeyEnrollmentChallenge> {
+                override fun fromJson(
+                    reader: Reader, headers: Map<String, List<String>>
+                ): PasskeyEnrollmentChallenge {
+                    val authenticationId =
+                        URLDecoder.decode(
+                            headers[LOCATION_KEY]?.get(0)?.split("/")?.lastOrNull(),
+                            "UTF-8"
+                        )
+
+                    authenticationId ?: throw MyAccountException("Authentication ID not found")
+
+                    val passkeyRegistrationChallenge = gson.fromJson<PasskeyRegistrationChallenge>(
+                        reader, PasskeyRegistrationChallenge::class.java
+                    )
+                    return PasskeyEnrollmentChallenge(
+                        authenticationId,
+                        passkeyRegistrationChallenge.authSession,
+                        passkeyRegistrationChallenge.authParamsPublicKey
+                    )
+                }
+            }
+        val post = factory.post(url.toString(), passkeyEnrollmentAdapter)
+            .addParameters(params)
+            .addHeader(AUTHORIZATION_KEY, "Bearer $accessToken")
+
+        return post
+    }
+
+    /**
+     * Enrolls a new passkey credential. This is the last part of the enrollment flow.
+     *
+     * ## Availability
+     *
+     * This feature is currently available in
+     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
+     * Please reach out to Auth0 support to get it enabled for your tenant.
+     *
+     * ## Scopes Required
+     *
+     * `create:me:authentication_methods`
+     *
+     * ## Usage
+     *
+     * ```kotlin
+     * val auth0 = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN")
+     * val apiClient = MyAccountAPIClient(auth0, accessToken)
+     *
+     * // After obtaining the passkey credential from the [Credential Manager API](https://developer.android.com/identity/sign-in/credential-manager)
+     * apiClient.enroll(publicKeyCredentials, enrollmentChallenge)
+     *     .start(object : Callback<PasskeyAuthenticationMethod, MyAccountException> {
+     *         override fun onSuccess(result: AuthenticationMethodVerified) {
+     *             Log.d("MyApp", "Enrolled passkey: $result")
+     *         }
+     *
+     *         override fun onFailure(error: MyAccountException) {
+     *             Log.e("MyApp", "Failed with: ${error.message}")
+     *         }
+     *     })
+     * ```
+     *
+     * @param credentials The passkey credentials obtained from the [Credential Manager API](https://developer.android.com/identity/sign-in/credential-manager).
+     * @param challenge The enrollment challenge obtained from the `passkeyEnrollmentChallenge()` method.
+     * @return A request to enroll the passkey credential.
+     */
+    public fun enroll(
+        credentials: PublicKeyCredentials, challenge: PasskeyEnrollmentChallenge
+    ): Request<PasskeyAuthenticationMethod, MyAccountException> {
+        val authMethodId = challenge.authenticationMethodId
+        val url =
+            getDomainUrlBuilder()
+                .addPathSegment(AUTHENTICATION_METHODS)
+                .addPathSegment(authMethodId)
+                .addPathSegment(VERIFY)
+                .build()
+
+        val authenticatorResponse = mapOf(
+            "authenticatorAttachment" to "platform",
+            "clientExtensionResults" to credentials.clientExtensionResults,
+            "id" to credentials.id,
+            "rawId" to credentials.rawId,
+            "type" to "public-key",
+            "response" to mapOf(
+                "clientDataJSON" to credentials.response.clientDataJSON,
+                "attestationObject" to credentials.response.attestationObject
+            )
+        )
+
+        val params = ParameterBuilder.newBuilder().apply {
+            set(AUTH_SESSION_KEY, challenge.authSession)
+        }.asDictionary()
+
+        val passkeyAuthenticationAdapter = GsonAdapter(
+            PasskeyAuthenticationMethod::class.java
+        )
+
+        val request = factory.post(
+            url.toString(), passkeyAuthenticationAdapter
+        ).addParameters(params)
+            .addParameter(AUTHN_RESPONSE_KEY, authenticatorResponse)
+            .addHeader(AUTHORIZATION_KEY, "Bearer $accessToken")
+        return request
+    }
+
+    private fun getDomainUrlBuilder(): HttpUrl.Builder {
+        return auth0.getDomainUrl().toHttpUrl().newBuilder()
+            .addPathSegment(ME_PATH)
+            .addPathSegment(API_VERSION)
+    }
+
+
+    private companion object {
+        private const val AUTHENTICATION_METHODS = "authentication-methods"
+        private const val VERIFY = "verify"
+        private const val API_VERSION = "v1"
+        private const val ME_PATH = "me"
+        private const val TYPE_KEY = "type"
+        private const val USER_IDENTITY_ID_KEY = "identity_user_id"
+        private const val CONNECTION_KEY = "connection"
+        private const val AUTHORIZATION_KEY = "Authorization"
+        private const val LOCATION_KEY = "Location"
+        private const val AUTH_SESSION_KEY = "auth_session"
+        private const val AUTHN_RESPONSE_KEY = "authn_response"
+        private fun createErrorAdapter(): ErrorAdapter<MyAccountException> {
+            val mapAdapter = forMap(GsonProvider.gson)
+            return object : ErrorAdapter<MyAccountException> {
+                override fun fromRawResponse(
+                    statusCode: Int, bodyText: String, headers: Map<String, List<String>>
+                ): MyAccountException {
+                    return MyAccountException(bodyText, statusCode)
+                }
+
+                @Throws(IOException::class)
+                override fun fromJsonResponse(
+                    statusCode: Int, reader: Reader
+                ): MyAccountException {
+                    val values = mapAdapter.fromJson(reader, emptyMap())
+                    return MyAccountException(values)
+                }
+
+                override fun fromException(cause: Throwable): MyAccountException {
+                    if (isNetworkError(cause)) {
+                        return MyAccountException(
+                            "Failed to execute the network request", NetworkErrorException(cause)
+                        )
+                    }
+                    return MyAccountException(
+                        "Something went wrong", Auth0Exception("Something went wrong", cause)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/myaccount/MyAccountException.kt
+++ b/auth0/src/main/java/com/auth0/android/myaccount/MyAccountException.kt
@@ -1,0 +1,115 @@
+package com.auth0.android.myaccount
+
+import com.auth0.android.Auth0Exception
+import com.auth0.android.NetworkErrorException
+
+public class MyAccountException @JvmOverloads constructor(
+    message: String,
+    exception: Auth0Exception? = null
+) : Auth0Exception(message, exception) {
+
+    private var code: String? = null
+    private var description: String? = null
+
+
+    /**
+     * Http Response status code. Can have value of 0 if not set.
+     *
+     * @return the status code.
+     */
+    public var statusCode: Int = 0
+        private set
+    private var values: Map<String, Any>? = null
+
+
+    public val type: String?
+        get() = values?.get("type") as? String
+    public var status: Int = 0
+        private set
+    public val title: String?
+        get() = values?.get("title") as? String
+    public val detail: String?
+        get() = values?.get("detail") as? String
+    public val validationErrors: List<ValidationError>?
+        get() = (values?.get("validation_errors") as? List<Map<String, String>>)?.map {
+            ValidationError(
+                it["detail"],
+                it["field"],
+                it["pointer"],
+                it["source"]
+            )
+        }
+
+    public constructor(payload: String?, statusCode: Int) : this(DEFAULT_MESSAGE) {
+        code = if (payload != null) NON_JSON_ERROR else EMPTY_BODY_ERROR
+        description = payload ?: EMPTY_RESPONSE_BODY_DESCRIPTION
+        this.statusCode = statusCode
+    }
+
+    public constructor(values: Map<String, Any>) : this(DEFAULT_MESSAGE) {
+        this.values = values
+        val codeValue =
+            (if (values.containsKey(ERROR_KEY)) values[ERROR_KEY] else values[CODE_KEY]) as String?
+        code = codeValue ?: UNKNOWN_ERROR
+        description =
+            (if (values.containsKey(DESCRIPTION_KEY)) values[DESCRIPTION_KEY] else values[ERROR_DESCRIPTION_KEY]) as String?
+    }
+
+    /**
+     * Auth0 error code if the server returned one or an internal library code (e.g.: when the server could not be reached)
+     *
+     * @return the error code.
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    public fun getCode(): String {
+        return if (code != null) code!! else UNKNOWN_ERROR
+    }
+
+    /**
+     * Description of the error.
+     * important: You should avoid displaying description to the user, it's meant for debugging only.
+     *
+     * @return the error description.
+     */
+    @Suppress("unused")
+    public fun getDescription(): String {
+        if (description != null) {
+            return description!!
+        }
+        return if (UNKNOWN_ERROR == getCode()) {
+            String.format("Received error with code %s", getCode())
+        } else "Failed with unknown error"
+    }
+
+    /**
+     * Returns a value from the error map, if any.
+     *
+     * @param key key of the value to return
+     * @return the value if found or null
+     */
+    public fun getValue(key: String): Any? {
+        return values?.get(key)
+    }
+
+    // When the request failed due to network issues
+    public val isNetworkError: Boolean
+        get() = cause is NetworkErrorException
+
+
+    public data class ValidationError(
+        val detail: String?,
+        val field: String?,
+        val pointer: String?,
+        val source: String?
+    )
+
+    private companion object {
+        private const val ERROR_KEY = "error"
+        private const val CODE_KEY = "code"
+        private const val DESCRIPTION_KEY = "description"
+        private const val ERROR_DESCRIPTION_KEY = "error_description"
+        private const val DEFAULT_MESSAGE =
+            "An error occurred when trying to authenticate with the server."
+    }
+
+}

--- a/auth0/src/main/java/com/auth0/android/request/JsonAdapter.kt
+++ b/auth0/src/main/java/com/auth0/android/request/JsonAdapter.kt
@@ -11,10 +11,11 @@ public interface JsonAdapter<T> {
     /**
      * Converts the JSON input given in the Reader to the <T> instance.
      * @param reader the reader that contains the JSON encoded string.
+     * @param headers the headers that were received with the response.
      * @throws IOException could be thrown to signal that the input was invalid.
      * @return the parsed <T> result
      */
     @Throws(IOException::class)
-    public fun fromJson(reader: Reader): T
+    public fun fromJson(reader: Reader, headers: Map<String, List<String>>): T
 
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt
@@ -129,7 +129,7 @@ internal open class BaseRequest<T, U : Auth0Exception>(
             if (response.isSuccess()) {
                 //2. Successful scenario. Response of type T
                 return try {
-                    resultAdapter.fromJson(reader)
+                    resultAdapter.fromJson(reader,response.headers)
                 } catch (exception: Exception) {
                     //multi catch IOException and JsonParseException (including JsonIOException)
                     //3. Network exceptions, timeouts, etc reading response body

--- a/auth0/src/main/java/com/auth0/android/request/internal/GsonAdapter.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/GsonAdapter.kt
@@ -4,6 +4,7 @@ import com.auth0.android.request.JsonAdapter
 import com.google.gson.Gson
 import com.google.gson.TypeAdapter
 import com.google.gson.reflect.TypeToken
+import okhttp3.Headers
 import java.io.Reader
 
 /**
@@ -54,7 +55,7 @@ internal class GsonAdapter<T> private constructor(private val adapter: TypeAdapt
         gson: Gson = supplyDefaultGson()
     ) : this(gson.getAdapter(tTypeToken))
 
-    override fun fromJson(reader: Reader): T {
+    override fun fromJson(reader: Reader,headers: Map<String,List<String>>): T {
         return adapter.fromJson(reader)
     }
 }

--- a/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
+++ b/auth0/src/main/java/com/auth0/android/request/internal/RequestFactory.kt
@@ -33,7 +33,7 @@ internal class RequestFactory<U : Auth0Exception> internal constructor(
 
     fun post(url: String): Request<Void?, U> =
         this.post(url, object : JsonAdapter<Void?> {
-            override fun fromJson(reader: Reader): Void? {
+            override fun fromJson(reader: Reader, headers: Map<String, List<String>>): Void? {
                 return null
             }
         })

--- a/auth0/src/main/java/com/auth0/android/result/PasskeyAuthenticationMethod.kt
+++ b/auth0/src/main/java/com/auth0/android/result/PasskeyAuthenticationMethod.kt
@@ -1,0 +1,34 @@
+package com.auth0.android.result
+
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * A passkey authentication method.
+ */
+public data class PasskeyAuthenticationMethod(
+    @SerializedName("created_at")
+    val createdAt: String,
+    @SerializedName("credential_backed_up")
+    val credentialBackedUp: Boolean,
+    @SerializedName("credential_device_type")
+    val credentialDeviceType: String,
+    @SerializedName("id")
+    val id: String,
+    @SerializedName("identity_user_id")
+    val identityUserId: String,
+    @SerializedName("key_id")
+    val keyId: String,
+    @SerializedName("public_key")
+    val publicKey: String,
+    @SerializedName("transports")
+    val transports: List<String>,
+    @SerializedName("type")
+    val type: String,
+    @SerializedName("usage")
+    val usage: String,
+    @SerializedName("user_agent")
+    val userAgent: String,
+    @SerializedName("user_handle")
+    val userHandle: String
+)

--- a/auth0/src/main/java/com/auth0/android/result/PasskeyEnrollmentChallenge.kt
+++ b/auth0/src/main/java/com/auth0/android/result/PasskeyEnrollmentChallenge.kt
@@ -1,0 +1,14 @@
+package com.auth0.android.result
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents the challenge data required for enrolling a passkey.
+ */
+public data class PasskeyEnrollmentChallenge(
+    val authenticationMethodId: String,
+    @SerializedName("auth_session")
+    val authSession: String,
+    @SerializedName("authn_params_public_key")
+    val authParamsPublicKey: AuthnParamsPublicKey
+)


### PR DESCRIPTION
### Changes

This PR adds:

- A new API client for the My Account API, including its own exception type MyAccountException.
- A sub-client for the authentication methods endpoints.
     - A method for requesting a passkey enrollment challenge.
     - A method for enrolling a newly created passkey.


### Testing

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
