### PR TITLE
GH issue Allow accessing credentials without an attempt to refresh #378

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -3,11 +3,16 @@ package com.auth0.android.authentication.storage
 import androidx.annotation.VisibleForTesting
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.callback.Callback
+import com.auth0.android.request.internal.GsonProvider
+import com.auth0.android.request.internal.Jwt
 import com.auth0.android.result.APICredentials
 import com.auth0.android.result.Credentials
 import com.auth0.android.result.SSOCredentials
+import com.auth0.android.result.UserProfile
 import com.auth0.android.util.Clock
 import java.util.*
+import kotlin.collections.component1
+import kotlin.collections.component2
 
 /**
  * Base class meant to abstract common logic across Credentials Manager implementations.
@@ -37,6 +42,7 @@ public abstract class BaseCredentialsManager internal constructor(
         parameters: Map<String, String>,
         callback: Callback<SSOCredentials, CredentialsManagerException>
     )
+
 
     public abstract fun getSsoCredentials(
         callback: Callback<SSOCredentials, CredentialsManagerException>
@@ -135,6 +141,8 @@ public abstract class BaseCredentialsManager internal constructor(
         parameters: Map<String, String> = emptyMap(),
         headers: Map<String, String> = emptyMap()
     ): APICredentials
+
+    public abstract val userProfile: UserProfile?
 
     public abstract fun clearCredentials()
     public abstract fun clearApiCredentials(audience: String)

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -1,21 +1,28 @@
 package com.auth0.android.authentication.storage
 
 import android.text.TextUtils
+import android.util.Base64
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.storage.SecureCredentialsManager.Companion.KEY_CREDENTIALS
 import com.auth0.android.callback.Callback
 import com.auth0.android.request.internal.GsonProvider
+import com.auth0.android.request.internal.Jwt
 import com.auth0.android.result.APICredentials
 import com.auth0.android.result.Credentials
+import com.auth0.android.result.OptionalCredentials
 import com.auth0.android.result.SSOCredentials
+import com.auth0.android.result.UserProfile
 import com.auth0.android.result.toAPICredentials
 import com.google.gson.Gson
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.*
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
+import kotlin.collections.component1
+import kotlin.collections.component2
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -43,6 +50,47 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
         JWTDecoder(),
         Executors.newSingleThreadExecutor()
     )
+
+    private fun retrieveCredentials() : Credentials? {
+        val encryptedEncoded = storage.retrieveString(KEY_CREDENTIALS)
+        if (encryptedEncoded.isNullOrBlank()) {
+            return null
+        }
+        val encrypted = android.util.Base64.decode(encryptedEncoded, Base64.DEFAULT)
+        val json: String
+        try {
+            json = String(crypto.decrypt(encrypted))
+        } catch (e: IncompatibleDeviceException) {
+            return null
+        } catch (e: CryptoException) {
+            return null
+        }
+        val bridgeCredentials = gson.fromJson(json, OptionalCredentials::class.java)/* OPTIONAL CREDENTIALS
+             * This bridge is required to prevent users from being logged out when
+             * migrating from Credentials with optional Access Token and ID token
+             */
+        val credentials = Credentials(
+            bridgeCredentials.idToken.orEmpty(),
+            bridgeCredentials.accessToken.orEmpty(),
+            bridgeCredentials.type.orEmpty(),
+            bridgeCredentials.refreshToken,
+            bridgeCredentials.expiresAt ?: Date(),
+            bridgeCredentials.scope
+        )
+        return credentials
+    }
+
+    public override val userProfile: UserProfile?
+        get() {
+            val credentials: Credentials? = retrieveCredentials()
+            // Handle null credentials gracefully
+            if (credentials == null) {
+                return null
+            }
+            val (_, payload) = Jwt.splitToken(credentials.idToken)
+            val gson = GsonProvider.gson
+            return gson.fromJson(Jwt.decodeBase64(payload), UserProfile::class.java)
+        }
 
     /**
      * Stores the given credentials in the storage. Must have an access_token or id_token and a expires_in value.

--- a/gradle/maven-publish.gradle
+++ b/gradle/maven-publish.gradle
@@ -50,11 +50,6 @@ publishing {
                     }
                 }
 
-                scm {
-                    url = POM_SCM_URL
-                    connection = POM_SCM_CONNECTION
-                    developerConnection = POM_SCM_DEV_CONNECTION
-                }
 
                 withXml {
                     def dependenciesNode = asNode().appendNode('dependencies')

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Auth0 SDK Sample</string>
-    <string name="com_auth0_domain">YOUR_DOMAIN</string>
-    <string name="com_auth0_client_id">YOUR_CLIENT_ID</string>
+    <string name="com_auth0_domain">int-dx-enterprise-test.us.auth0.com</string>
+    <string name="com_auth0_client_id">GGUVoHL5nseaacSzqB810HWYGHZI34m8</string>
     <string name="com_auth0_scheme">demo</string>
 </resources>


### PR DESCRIPTION
### Changes
This PR covers addressing a github issue requesting a feature to allow accessing credentials without refresh.
Both SecureCredentialsManager and CredentialManager returns credentials directly from storage. In case of SecureCredentialsManager, it takes care of fetching from storage and decrypting as well.

### References

https://github.com/auth0/auth0-flutter/issues/378

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
