### PR TITLE
Added support for My Account API [DO NOT MERGE]

### DIFF
--- a/auth0/src/main/java/com/auth0/android/result/AuthenticationMethod.kt
+++ b/auth0/src/main/java/com/auth0/android/result/AuthenticationMethod.kt
@@ -28,9 +28,18 @@ public data class AuthenticationMethod(
     @SerializedName("type")
     val type: String,
     @SerializedName("usage")
-    val usage: String,
+    val usage: List<String>,
     @SerializedName("user_agent")
     val userAgent: String?,
     @SerializedName("user_handle")
     val userHandle: String?
+)
+
+
+/**
+ * List of Authentication Methods
+ */
+public data class AuthenticationMethods(
+    @SerializedName("authentication_methods")
+    val authenticationMethods: List<AuthenticationMethod>
 )


### PR DESCRIPTION
This PR introduces new sets of API for the MyAccount feature . These new set of APIs allows user to get the existing list of authentication methods as well as delete them.



### Testing

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
