### PR TITLE
Fix: Handle configuration changes correctly to prevent memory leak

### DIFF
--- a/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
+++ b/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
@@ -105,6 +105,7 @@ class DatabaseLoginFragment : Fragment() {
     private val callback = object: Callback<Credentials, AuthenticationException> {
         override fun onSuccess(result: Credentials) {
             credentialsManager.saveCredentials(result)
+            secureCredentialsManager.saveCredentials(result)
             Snackbar.make(
                 requireView(),
                 "Hello ${result.user.name}",
@@ -113,7 +114,12 @@ class DatabaseLoginFragment : Fragment() {
         }
 
         override fun onFailure(error: AuthenticationException) {
-            Snackbar.make(requireView(), error.getDescription(), Snackbar.LENGTH_LONG)
+            val message =
+                if (error.isCanceled)
+                    "Browser was closed"
+                else
+                    error.getDescription()
+            Snackbar.make(requireView(), message, Snackbar.LENGTH_LONG)
                 .show()
         }
     }
@@ -262,27 +268,7 @@ class DatabaseLoginFragment : Fragment() {
             .withScheme(getString(R.string.com_auth0_scheme))
             .withAudience(audience)
             .withScope(scope)
-            .start(requireContext(), object : Callback<Credentials, AuthenticationException> {
-                override fun onSuccess(result: Credentials) {
-                    credentialsManager.saveCredentials(result)
-                    secureCredentialsManager.saveCredentials(result)
-                    Snackbar.make(
-                        requireView(),
-                        "Hello ${result.user.name}",
-                        Snackbar.LENGTH_LONG
-                    ).show()
-                }
-
-                override fun onFailure(error: AuthenticationException) {
-                    val message =
-                        if (error.isCanceled)
-                            "Browser was closed"
-                        else
-                            error.getDescription()
-                    Snackbar.make(requireView(), message, Snackbar.LENGTH_LONG)
-                        .show()
-                }
-            })
+            .start(requireContext(), callback)
     }
 
     private suspend fun webAuthAsync() {


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:
In the SDK (WebAuthProvider.kt): modified the provider to manage a static list of active listeners instead of holding a direct reference to a single callback.
In the sample app (DatabaseLoginFragment.kt): updated the fragment to actively manage its listener status


### References

https://github.com/auth0/Auth0.Android/issues/835

### Testing
All existing Unit tests are passed

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
