### PR TITLE
docs: Add Ask DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![CircleCI](https://img.shields.io/circleci/project/github/auth0/Auth0.Android.svg?style=flat-square)](https://circleci.com/gh/auth0/Auth0.Android/tree/master)
 [![License](https://img.shields.io/:license-mit-blue.svg?style=flat-square)](https://doge.mit-license.org/)
 [![javadoc](https://javadoc.io/badge2/com.auth0.android/auth0/javadoc.svg)](https://javadoc.io/doc/com.auth0.android/auth0)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/Auth0.Android)
 
 📚 [Documentation](#documentation) • 🚀 [Getting Started](#getting-started) • 💬 [Feedback](#feedback)
 


### PR DESCRIPTION

This pull request adds the 'Ask DeepWiki' badge to the repository's README file.

### Purpose
The badge provides a direct and convenient link for users and contributors to ask questions and get information about this codebase via DeepWiki, improving the repository's overall supportability and accessibility.

### Automation Context
This change was applied via an automated script to ensure consistency across multiple repositories. No other files or functional code have been modified.
