### PR TITLE
refactor: Deprecated the PasskeyAuthProvider class

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/PasskeyAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/PasskeyAuthProvider.kt
@@ -17,6 +17,12 @@ import java.util.concurrent.Executors
 /**
  * Passkey authentication provider
  */
+
+@Deprecated(
+    """PasskeyAuthProvider is deprecated and will be removed in the next major version of the SDK.
+        Use API's in [AuthenticationAPIClient] directly to support sign-in/signup with passkeys.""",
+    level = DeprecationLevel.WARNING
+)
 public object PasskeyAuthProvider {
 
     private val TAG = PasskeyManager::class.simpleName


### PR DESCRIPTION
### Changes
This PR deprecates the `PasskeyAuthProvider` class  which will be removed in the next major version of the SDK. Users are recommended to use the  API's in `AuthenticationAPIClient` class directly . 
### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
