### PR TITLE
fix: Fixing the memory leak introduced in the DPoP flow

### DIFF
--- a/auth0/src/main/java/com/auth0/android/dpop/DPoP.kt
+++ b/auth0/src/main/java/com/auth0/android/dpop/DPoP.kt
@@ -22,7 +22,9 @@ public data class HeaderData(val authorizationHeader: String, val dpopProof: Str
  * Class for securing requests with DPoP (Demonstrating Proof of Possession) as described in
  * [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449).
  */
-public class DPoP(private val context: Context) {
+public class DPoP(context: Context) {
+
+    private val applicationContext: Context = context.applicationContext
 
     /**
      * Determines whether a DPoP proof should be generated for the given URL and parameters. The proof should
@@ -79,7 +81,7 @@ public class DPoP(private val context: Context) {
      */
     @Throws(DPoPException::class)
     internal fun generateKeyPair() {
-        DPoPUtil.generateKeyPair(context)
+        DPoPUtil.generateKeyPair(applicationContext)
     }
 
     /**

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -76,6 +76,7 @@ public class AuthenticationAPIClientTest {
         mockAPI = AuthenticationAPIMockServer()
         mockKeyStore = mock()
         mockContext = mock()
+        whenever(mockContext.applicationContext).thenReturn(mockContext)
         val auth0 = auth0
         client = AuthenticationAPIClient(auth0)
         gson = GsonBuilder().serializeNulls().create()

--- a/auth0/src/test/java/com/auth0/android/dpop/DPoPTest.kt
+++ b/auth0/src/test/java/com/auth0/android/dpop/DPoPTest.kt
@@ -47,6 +47,8 @@ public class DPoPTest {
         mockResponse = mock()
         mockKeyStore = mock()
         mockResponseBody = mock()
+
+        whenever(mockContext.applicationContext).thenReturn(mockContext)
         dPoP = DPoP(mockContext)
 
         DPoP._auth0Nonce = null

--- a/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
+++ b/auth0/src/test/java/com/auth0/android/provider/WebAuthProviderTest.kt
@@ -95,6 +95,7 @@ public class WebAuthProviderTest {
 
         mockKeyStore = mock()
         mockContext = mock()
+        Mockito.`when`(mockContext.applicationContext).thenReturn(mockContext)
 
         DPoPUtil.keyStore = mockKeyStore
 


### PR DESCRIPTION
### Changes
This Pr fixes the memory leak introduced as part of the DPoP flow. The `dpop` property in the `WebAuthProvider` class will retain the instance of the activity/fragment context preventing it from being garbage collected. Updated the `context` in the DPoP class to use an `activityContext` instead.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [X] This change adds unit test coverage

- [X] This change adds integration test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
