### PR TITLE
feat: Add automatic retry mechanism for credential retrieval to improve reliability in unstable network conditions

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt
@@ -209,6 +209,13 @@ public class AuthenticationException : Auth0Exception {
     public val isTooManyAttempts: Boolean
         get() = "too_many_attempts" == code
 
+    /**
+     * Returns true if this error is retryable with exponential backoff.
+     * Retryable errors include network errors, rate limiting (429), and server errors (5xx).
+     */
+    public val isRetryable: Boolean
+        get() = isNetworkError || statusCode == 429 || statusCode in 500..599
+
     internal companion object {
         internal const val ERROR_VALUE_AUTHENTICATION_CANCELED = "a0.authentication_canceled"
         internal const val ERROR_KEY_URI_NULL = "a0.auth.authorize_uri"

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -40,6 +40,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     private val fragmentActivity: WeakReference<FragmentActivity>? = null,
     private val localAuthenticationOptions: LocalAuthenticationOptions? = null,
     private val localAuthenticationManagerFactory: LocalAuthenticationManagerFactory? = null,
+    private val maxRetries: Int = 0
 ) : BaseCredentialsManager(apiClient, storage, jwtDecoder) {
     private val gson: Gson = GsonProvider.gson
 
@@ -52,16 +53,19 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
      * @param context   a valid context
      * @param auth0     the Auth0 account information to use
      * @param storage   the storage implementation to use
+     * @param maxRetries the maximum number of retry attempts for credential renewal when encountering transient errors. Default is 0 (no retries).
      */
     public constructor(
         context: Context,
         auth0: Auth0,
         storage: Storage,
+        maxRetries: Int = 0
     ) : this(
         AuthenticationAPIClient(auth0),
         context,
         auth0,
-        storage
+        storage,
+        maxRetries
     )
 
     /**
@@ -79,18 +83,21 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
      * @param context   a valid context
      * @param auth0     the Auth0 account information to use
      * @param storage   the storage implementation to use
+     * @param maxRetries the maximum number of retry attempts for credential renewal when encountering transient errors. Default is 0 (no retries).
      */
     public constructor(
         apiClient: AuthenticationAPIClient,
         context: Context,
         auth0: Auth0,
-        storage: Storage
+        storage: Storage,
+        maxRetries: Int = 0
     ) : this(
         apiClient,
         storage,
         CryptoUtil(context, storage, KEY_ALIAS),
         JWTDecoder(),
-        auth0.executor
+        auth0.executor,
+        maxRetries = maxRetries
     )
 
 
@@ -102,20 +109,23 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
      * @param storage   the storage implementation to use
      * @param fragmentActivity the FragmentActivity to use for the biometric authentication
      * @param localAuthenticationOptions the options of type [LocalAuthenticationOptions] to use for the biometric authentication
+     * @param maxRetries the maximum number of retry attempts for credential renewal when encountering transient errors. Default is 0 (no retries).
      */
     public constructor(
         context: Context,
         auth0: Auth0,
         storage: Storage,
         fragmentActivity: FragmentActivity,
-        localAuthenticationOptions: LocalAuthenticationOptions
+        localAuthenticationOptions: LocalAuthenticationOptions,
+        maxRetries: Int = 0
     ) : this(
         AuthenticationAPIClient(auth0),
         context,
         auth0,
         storage,
         fragmentActivity,
-        localAuthenticationOptions
+        localAuthenticationOptions,
+        maxRetries
     )
 
 
@@ -145,6 +155,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
      * @param storage   the storage implementation to use
      * @param fragmentActivity the FragmentActivity to use for the biometric authentication
      * @param localAuthenticationOptions the options of type [LocalAuthenticationOptions] to use for the biometric authentication
+     * @param maxRetries the maximum number of retry attempts for credential renewal when encountering transient errors. Default is 0 (no retries).
      */
     public constructor(
         apiClient: AuthenticationAPIClient,
@@ -152,7 +163,8 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         auth0: Auth0,
         storage: Storage,
         fragmentActivity: FragmentActivity,
-        localAuthenticationOptions: LocalAuthenticationOptions
+        localAuthenticationOptions: LocalAuthenticationOptions,
+        maxRetries: Int = 0
     ) : this(
         apiClient,
         storage,
@@ -161,7 +173,8 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         auth0.executor,
         WeakReference(fragmentActivity),
         localAuthenticationOptions,
-        DefaultLocalAuthenticationManagerFactory()
+        DefaultLocalAuthenticationManagerFactory(),
+        maxRetries
     )
 
 


### PR DESCRIPTION
This change addresses [auth0/react-native-auth0#1374](https://github.com/auth0/react-native-auth0/issues/1374) by improving the reliability of credential retrieval in unstable network conditions.

While this update was initially driven by a request from a React Native SDK consumer, reliable credential retrieval is a critical requirement for mobile scenarios in general. As such, this capability is also applicable to Android SDK consumers and can be leveraged to improve the robustness of credential management.

We should recommend this approach to Android SDK developers who encounter similar issues.

### Background / Problem

A scenario highlighted by the community:

1. Request A calls `getCredentials()` and initiates a token refresh.
2. The request successfully reaches Auth0 and a new access token is issued.
3. The response fails to reach the client due to a transient network issue.
4. Later, when the user tries again, the refresh attempt may fail because the refresh token could already be expired by that time.

On mobile networks, which are often unreliable, this scenario is realistic. In such cases, even if the user retries later on a stable network, the refresh attempt may fail because the refresh token could already be expired.

### Proposed Solution

This PR introduces retry support for transient failures to better leverage Auth0's refresh token rotation overlap period, allowing safe retries when the server-side renewal succeeds but the response never reaches the client.

### Outcome

The retry mechanism improves resilience in real-world mobile conditions by safely retrying credential retrieval requests within the refresh token overlap window, reducing unnecessary authentication failures without changing default behavior.

### 📎 References

- Related iOS PR: [Auth0.swift#1063](https://github.com/auth0/Auth0.swift/pull/1063)
- Issue: [react-native-auth0#1374](https://github.com/auth0/react-native-auth0/issues/1374)
