### PR TITLE
Remove deprecated jcenter() repository references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,13 +4,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        //noinspection JcenterRepositoryObsolete
-        jcenter() {
-            content {
-                // https://youtrack.jetbrains.com/issue/KT-44730
-                includeModule("org.jetbrains.trove4j", "trove4j")
-            }
-        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.8.2'
@@ -48,14 +41,5 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        //noinspection JcenterRepositoryObsolete
-        jcenter() {
-            content {
-                // https://youtrack.jetbrains.com/issue/KT-44730
-                includeModule("org.jetbrains.trove4j", "trove4j")
-                includeModule("com.soywiz.korlibs.korte", "korte-jvm")
-                includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
-            }
-        }
     }
 }


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

removed jcentre and dependency from build.gradle.

### References
SDK-7722

### Testing

Build Test-->Pass
UT Test-->Pass

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
