### PR TITLE
refactor : Made the updateAuthenticationMethodById public

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -43,6 +43,7 @@
     - [Enroll a Recovery Code](#enroll-a-recovery-code)
     - [Verify an Enrollment](#verify-an-enrollment)
     - [Delete an Authentication Method](#delete-an-authentication-method)
+    - [Update an Authentication Method](#update-an-authentication-method)
   - [Credentials Manager](#credentials-manager)
     - [Secure Credentials Manager](#secure-credentials-manager)
       - [Usage](#usage)
@@ -2227,6 +2228,42 @@ myAccountClient.deleteAuthenticationMethod("phone|dev_...")
 
 ```java
 myAccountClient.deleteAuthenticationMethod("phone|dev_...")
+    .start(new Callback<Void, MyAccountException>() {
+        @Override
+        public void onSuccess(Void result) {
+            // Deletion successful
+        }
+        @Override
+        public void onFailure(@NonNull MyAccountException error) { }
+    });
+```
+</details>
+
+
+
+### Update an Authentication Method
+**Scopes required:** `update:me:authentication_methods`
+
+Updates a single authentication method.
+
+**Prerequisites:**
+
+The user must have the specific authentication method (identified by its ID) already enrolled.
+
+```kotlin
+myAccountClient.updateAuthenticationMethodById("{Authentication_Id}", "{Name}")
+    .start(object : Callback<Unit, MyAccountException> {
+        override fun onSuccess(result: Unit) {
+            // Deletion successful
+        }
+        override fun onFailure(error: MyAccountException) { }
+    })
+```
+<details>
+    <summary>Using Java</summary>
+
+```java
+myAccountClient.updateAuthenticationMethodById("{Authentication_Id}", "{Name}")
     .start(new Callback<Void, MyAccountException>() {
         @Override
         public void onSuccess(Void result) {

--- a/auth0/src/main/java/com/auth0/android/myaccount/MyAccountAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/myaccount/MyAccountAPIClient.kt
@@ -364,7 +364,7 @@ public class MyAccountAPIClient @VisibleForTesting(otherwise = VisibleForTesting
      *     })
      * ```
      *
-     * @param authenticationMethodId  Id of the authentication method to be retrieved
+     * @param authenticationMethodId  Id of the authentication method to be updated
      * @param authenticationMethodName  The friendly name of the authentication method
      * @param preferredAuthenticationMethod The preferred authentication method for the user. (for phone authenticators)
      *

--- a/auth0/src/main/java/com/auth0/android/myaccount/MyAccountAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/myaccount/MyAccountAPIClient.kt
@@ -370,7 +370,7 @@ public class MyAccountAPIClient @VisibleForTesting(otherwise = VisibleForTesting
      *
      */
     @JvmOverloads
-    internal fun updateAuthenticationMethodById(
+    public fun updateAuthenticationMethodById(
         authenticationMethodId: String,
         authenticationMethodName: String? = null,
         preferredAuthenticationMethod: PhoneAuthenticationMethodType? = null


### PR DESCRIPTION
### Changes

This PR makes `updateAuthenticationMethodById` in the `MyAccountAPIClient` class public. This API was earlier marked as internal which made it impossible for consuming clients to use this API


### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
