### PR TITLE
feat: Add clearAll() API to credentials manager

### DIFF
--- a/V4_MIGRATION_GUIDE.md
+++ b/V4_MIGRATION_GUIDE.md
@@ -22,6 +22,8 @@ v4 of the Auth0 Android SDK includes significant build toolchain updates, update
 - [**Behavior Changes**](#behavior-changes)
   + [clearCredentials() Now Clears All Storage](#clearCredentials-now-clears-all-storage)
   + [Storage Interface: New removeAll() Method](#storage-interface-new-removeall-method)
+- [**New APIs**](#new-apis)
+  + [clearAll() — Full Credential and Key Cleanup](#clearall--full-credential-and-key-cleanup)
 - [**Dependency Changes**](#dependency-changes)
   + [Gson 2.8.9 → 2.11.0](#️-gson-289--2110-transitive-dependency)
   + [DefaultClient.Builder](#defaultclientbuilder)
@@ -225,6 +227,26 @@ In v4, `clearCredentials()` calls `Storage.removeAll()`, which clears **all** va
 **Change:** The `Storage` interface now includes a `removeAll()` method with a default empty implementation.
 
 **Impact:** Existing custom `Storage` implementations will continue to compile and work without changes. Override `removeAll()` to provide the actual clearing behavior if your custom storage is used with `clearCredentials()`.
+
+## New APIs
+
+### `clearAll()` — Full Credential and Key Cleanup
+
+v4 introduces a new `clearAll()` method on `CredentialsManager` and `SecureCredentialsManager` that performs a complete cleanup of all stored credentials **and** cryptographic key pairs.
+
+**Usage:**
+
+```kotlin
+// Clear everything on logout — credentials, DPoP keys, and encryption keys
+credentialsManager.clearAll()
+```
+
+**When to use `clearAll()` vs `clearCredentials()`:**
+
+- Use **`clearCredentials()`** when you only need to remove stored tokens (e.g., forcing a re-login) but want to preserve cryptographic keys for future sessions.
+- Use **`clearAll()`** on full logout or account removal, when you want to ensure no credentials or key material remain on the device.
+
+> **Note:** `clearAll()` catches any errors from DPoP key pair deletion internally, so it will not throw even if the DPoP key pair was never created or has already been removed.
 
 ## Dependency Changes
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -159,6 +159,7 @@ public abstract class BaseCredentialsManager internal constructor(
 
     public abstract fun clearCredentials()
     public abstract fun clearApiCredentials(audience: String, scope: String? = null)
+    public abstract fun clearAll()
     public abstract fun hasValidCredentials(): Boolean
     public abstract fun hasValidCredentials(minTtl: Long): Boolean
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -6,6 +6,8 @@ import androidx.annotation.VisibleForTesting
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
+import com.auth0.android.dpop.DPoP
+import com.auth0.android.dpop.DPoPException
 import com.auth0.android.request.internal.GsonProvider
 import com.auth0.android.request.internal.Jwt
 import com.auth0.android.result.APICredentials
@@ -528,7 +530,8 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
                     callback.onFailure(
                         CredentialsManagerException(
                             CredentialsManagerException.Code.MFA_REQUIRED,
-                            error.message ?: "Multi-factor authentication is required to complete the credential renewal.",
+                            error.message
+                                ?: "Multi-factor authentication is required to complete the credential renewal.",
                             error,
                             error.mfaRequiredErrorPayload
                         )
@@ -654,7 +657,8 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
                     callback.onFailure(
                         CredentialsManagerException(
                             CredentialsManagerException.Code.MFA_REQUIRED,
-                            error.message ?: "Multi-factor authentication is required to complete the credential renewal.",
+                            error.message
+                                ?: "Multi-factor authentication is required to complete the credential renewal.",
                             error,
                             error.mfaRequiredErrorPayload
                         )
@@ -708,6 +712,19 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
      */
     override fun clearCredentials() {
         storage.removeAll()
+    }
+
+    /**
+     * Removes all credentials, API credentials, and cryptographic key pairs.
+     * This calls [Storage.removeAll] to clear all stored data
+     */
+    override fun clearAll() {
+        storage.removeAll()
+        try {
+            DPoP.clearKeyPair()
+        } catch (e: DPoPException) {
+            Log.e(TAG, "Failed to clear DPoP key pair ${e.stackTraceToString()}")
+        }
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CryptoUtil.java
@@ -328,6 +328,14 @@ class CryptoUtil {
     }
 
     /**
+     * Removes all cryptographic keys (both RSA and AES) used by this instance.
+     */
+    public void deleteAllKeys() {
+        deleteRSAKeys();
+        deleteAESKeys();
+    }
+
+    /**
      * Decrypts the given input using a generated RSA Private Key.
      * Used to decrypt the AES key for later usage.
      *

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -10,6 +10,8 @@ import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
+import com.auth0.android.dpop.DPoP
+import com.auth0.android.dpop.DPoPException
 import com.auth0.android.request.internal.GsonProvider
 import com.auth0.android.result.APICredentials
 import com.auth0.android.result.Credentials
@@ -737,6 +739,22 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     }
 
     /**
+     * Removes all credentials, API credentials, and cryptographic key pairs.
+     * This calls [Storage.removeAll] to clear all stored data
+     */
+    override fun clearAll() {
+        storage.removeAll()
+        crypto.deleteAllKeys()
+        clearBiometricSession()
+        try {
+            DPoP.clearKeyPair()
+        } catch (e: DPoPException) {
+            Log.e(TAG, "Failed to clear DPoP key pair ${e.stackTraceToString()}")
+        }
+        Log.d(TAG, "All credentials and key pairs were removed")
+    }
+
+    /**
      * Removes the credentials for the given audience from the storage if present.
      * @param audience Audience for which the [APICredentials] are stored
      * @param scope Optional scope for which the [APICredentials] are stored. If the credentials were initially fetched/stored with scope,
@@ -890,7 +908,8 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                     callback.onFailure(
                         CredentialsManagerException(
                             CredentialsManagerException.Code.MFA_REQUIRED,
-                            error.message ?: "Multi-factor authentication is required to complete the credential renewal.",
+                            error.message
+                                ?: "Multi-factor authentication is required to complete the credential renewal.",
                             error,
                             error.mfaRequiredErrorPayload
                         )
@@ -1048,7 +1067,8 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                     callback.onFailure(
                         CredentialsManagerException(
                             CredentialsManagerException.Code.MFA_REQUIRED,
-                            error.message ?: "Multi-factor authentication is required to complete the credential renewal.",
+                            error.message
+                                ?: "Multi-factor authentication is required to complete the credential renewal.",
                             error,
                             error.mfaRequiredErrorPayload
                         )

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -1496,6 +1496,12 @@ public class CredentialsManagerTest {
     }
 
     @Test
+    public fun shouldClearAllCredentialsAndDPoPKeyPair() {
+        manager.clearAll()
+        verify(storage).removeAll()
+    }
+
+    @Test
     public fun shouldSaveApiCredentialsWithScopeAsKey() {
         val expirationTime = CredentialsMock.ONE_HOUR_AHEAD_MS
         val apiCredentials = APICredentials(

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -1496,7 +1496,7 @@ public class CredentialsManagerTest {
     }
 
     @Test
-    public fun shouldClearAllCredentialsAndDPoPKeyPair() {
+    public fun shouldClearAllCredentials() {
         manager.clearAll()
         verify(storage).removeAll()
     }

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CryptoUtilTest.java
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CryptoUtilTest.java
@@ -2087,6 +2087,41 @@ public class CryptoUtilTest {
     }
 
     /*
+     * deleteAllKeys() tests
+     */
+
+    @Test
+    public void shouldDeleteBothRSAAndAESKeysWhenDeleteAllKeysIsCalled() throws Exception {
+        cryptoUtil.deleteAllKeys();
+
+        // Verify RSA keys deleted from KeyStore
+        Mockito.verify(keyStore).deleteEntry(KEY_ALIAS);
+        Mockito.verify(keyStore).deleteEntry(OLD_KEY_ALIAS);
+
+        // Verify AES keys deleted from Storage
+        Mockito.verify(storage).remove(KEY_ALIAS);
+        Mockito.verify(storage).remove(KEY_ALIAS + "_iv");
+        Mockito.verify(storage).remove(OLD_KEY_ALIAS);
+        Mockito.verify(storage).remove(OLD_KEY_ALIAS + "_iv");
+    }
+
+    @Test
+    public void shouldDeleteAESKeysEvenIfRSAKeyDeletionFails() throws Exception {
+        doThrow(new KeyStoreException("KeyStore error")).when(keyStore).deleteEntry(anyString());
+
+        cryptoUtil.deleteAllKeys();
+
+        // RSA deletion was attempted (first deleteEntry throws, second is never reached)
+        Mockito.verify(keyStore).deleteEntry(KEY_ALIAS);
+
+        // AES keys should still be deleted from Storage
+        Mockito.verify(storage).remove(KEY_ALIAS);
+        Mockito.verify(storage).remove(KEY_ALIAS + "_iv");
+        Mockito.verify(storage).remove(OLD_KEY_ALIAS);
+        Mockito.verify(storage).remove(OLD_KEY_ALIAS + "_iv");
+    }
+
+    /*
      * Helper methods
      */
     private CryptoUtil newCryptoUtilSpy() throws Exception {

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -2165,10 +2165,11 @@ public class SecureCredentialsManagerTest {
     }
 
     @Test
-    public fun shouldClearAllCredentialsKeyPairsAndDPoPKeyPair() {
+    public fun shouldClearAllCredentialsKeyPairsAndBiometricSession() {
         manager.clearAll()
         verify(storage).removeAll()
         verify(crypto).deleteAllKeys()
+        Assert.assertFalse(manager.isBiometricSessionValid())
     }
 
     @Test

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -2165,6 +2165,13 @@ public class SecureCredentialsManagerTest {
     }
 
     @Test
+    public fun shouldClearAllCredentialsKeyPairsAndDPoPKeyPair() {
+        manager.clearAll()
+        verify(storage).removeAll()
+        verify(crypto).deleteAllKeys()
+    }
+
+    @Test
     public fun shouldSaveEncryptedApiCredentialsWithScopeAsKey() {
         val expirationTime = CredentialsMock.ONE_HOUR_AHEAD_MS
         val apiCredentials = APICredentials(


### PR DESCRIPTION
### Changes

Adds a new `clearAll()` method to `BaseCredentialsManager` , `CredentialsManager`, and `SecureCredentialsManager` that performs a complete cleanup of all stored credentials and cryptographic key pairs.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [X] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
