### PR TITLE
breaking : Remove redundant constructors from SecureCredentialsManager

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1768,7 +1768,7 @@ To use DPoP with `SecureCredentialsManager` you need to pass an instance of the 
 val auth0 = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN")
 val apiClient = AuthenticationAPIClient(auth0).useDPoP(this)
 val storage = SharedPreferencesStorage(this)
-val manager = SecureCredentialsManager(apiClient, this, auth0, storage)
+val manager = SecureCredentialsManager(apiClient, this, storage)
 ```
 
 Similarly, for `CredentialsManager`:
@@ -2400,31 +2400,34 @@ myAccountClient.updateAuthenticationMethodById("{Authentication_Id}", "{Name}")
 This version adds encryption to the data storage. Additionally, in those devices where a Secure Lock Screen has been configured it can require the user to authenticate before letting them obtain the stored credentials. The class is called `SecureCredentialsManager`.
 
 #### Usage
-The usage is similar to the previous version, with the slight difference that the manager now requires a valid android `Context` as shown below:
+
+`SecureCredentialsManager` requires an `AuthenticationAPIClient` instance. The manager uses the supplied client for all token renewals and DPoP-bound refreshes, so configure that client first and then pass the same instance into `SecureCredentialsManager`. Create one from your `Auth0` configuration object and pass it to the manager:
 
 ```kotlin
+val account = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN")
+val apiClient = AuthenticationAPIClient(account)
 val storage = SharedPreferencesStorage(this)
-val manager = SecureCredentialsManager(this, account, storage)
+val manager = SecureCredentialsManager(apiClient, this, storage)
 ```
 
 <details>
   <summary>Using Java</summary>
 
 ```java
+Auth0 account = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN");
+AuthenticationAPIClient apiClient = new AuthenticationAPIClient(account);
 Storage storage = new SharedPreferencesStorage(this);
-SecureCredentialsManager manager = new SecureCredentialsManager(this, account, storage);
+SecureCredentialsManager manager = new SecureCredentialsManager(apiClient, this, storage);
 ```
 </details>
 
-#### Using a Custom AuthenticationAPIClient
-
-If you need to configure the `AuthenticationAPIClient` with advanced features (such as DPoP), you can pass your own configured instance to `SecureCredentialsManager`:
+To configure the `AuthenticationAPIClient` with advanced features such as DPoP, set them up on the client before passing it in:
 
 ```kotlin
 val auth0 = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN")
 val apiClient = AuthenticationAPIClient(auth0).useDPoP(this)
 val storage = SharedPreferencesStorage(this)
-val manager = SecureCredentialsManager(apiClient, this, auth0, storage)
+val manager = SecureCredentialsManager(apiClient, this, storage)
 ```
 
 <details>
@@ -2434,7 +2437,7 @@ val manager = SecureCredentialsManager(apiClient, this, auth0, storage)
 Auth0 auth0 = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN");
 AuthenticationAPIClient apiClient = new AuthenticationAPIClient(auth0).useDPoP(this);
 Storage storage = new SharedPreferencesStorage(this);
-SecureCredentialsManager manager = new SecureCredentialsManager(apiClient, this, auth0, storage);
+SecureCredentialsManager manager = new SecureCredentialsManager(apiClient, this, storage);
 ```
 </details>
 
@@ -2451,9 +2454,11 @@ val localAuthenticationOptions =
         .setDeviceCredentialFallback(true)
         .setPolicy(BiometricPolicy.Session(300)) // Optional: Use session-based policy (5 minutes)
         .build()
+val account = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN")
+val apiClient = AuthenticationAPIClient(account)
 val storage = SharedPreferencesStorage(this)
 val manager = SecureCredentialsManager(
-    this, account, storage, fragmentActivity,
+    apiClient, this, storage, fragmentActivity,
     localAuthenticationOptions
 )
 ```
@@ -2468,9 +2473,11 @@ LocalAuthenticationOptions localAuthenticationOptions =
                 .setDeviceCredentialFallback(true)
                 .setPolicy(new BiometricPolicy.Session(300)) // Optional: Use session-based policy (5 minutes)
                 .build();
+Auth0 account = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN");
+AuthenticationAPIClient apiClient = new AuthenticationAPIClient(account);
 Storage storage = new SharedPreferencesStorage(context);
 SecureCredentialsManager secureCredentialsManager = new SecureCredentialsManager(
-        context, auth0, storage, fragmentActivity,
+        apiClient, context, storage, fragmentActivity,
         localAuthenticationOptions);
 ```
 </details>
@@ -2491,7 +2498,7 @@ val localAuthenticationOptions =
         .build()
 val storage = SharedPreferencesStorage(this)
 val manager = SecureCredentialsManager(
-    apiClient, this, auth0, storage, fragmentActivity,
+    apiClient, this, storage, fragmentActivity,
     localAuthenticationOptions
 )
 ```
@@ -2513,7 +2520,7 @@ LocalAuthenticationOptions localAuthenticationOptions =
                 .build();
 Storage storage = new SharedPreferencesStorage(this);
 SecureCredentialsManager secureCredentialsManager = new SecureCredentialsManager(
-        apiClient, this, auth0, storage, fragmentActivity,
+        apiClient, this, storage, fragmentActivity,
         localAuthenticationOptions);
 ```
 </details>

--- a/V4_MIGRATION_GUIDE.md
+++ b/V4_MIGRATION_GUIDE.md
@@ -23,6 +23,7 @@ v4 of the Auth0 Android SDK includes significant build toolchain updates, update
 - [**Default Values Changed**](#default-values-changed)
   + [Credentials Manager minTTL](#credentials-manager-minttl)
 - [**Behavior Changes**](#behavior-changes)
+  + [CredentialsManager Now Uses the Global Executor](#credentialsmanager-now-uses-the-global-executor)
   + [clearCredentials() Now Clears All Storage](#clearCredentials-now-clears-all-storage)
   + [Storage Interface: New removeAll() Method](#storage-interface-new-removeall-method)
 - [**New APIs**](#new-apis)
@@ -303,6 +304,20 @@ credentialsManager.getCredentials(scope = null, minTtl = 0, callback = callback)
 **Reason:** A `minTtl` of `0` meant credentials were not renewed until expired, which could result in delivering access tokens that expire immediately after retrieval, causing subsequent API requests to fail. Setting a default value of `60` seconds ensures the access token remains valid for a reasonable period.
 
 ## Behavior Changes
+
+### `CredentialsManager` Now Uses the Global Executor
+
+**Change:** `CredentialsManager` no longer creates a per-instance `Executor`. It now uses the same process-wide single-thread executor already used by `SecureCredentialsManager` .
+
+In v3, each `CredentialsManager` instance created its own `Executors.newSingleThreadExecutor()`. Two `CredentialsManager` instances could therefore run `getCredentials` concurrently, racing to exchange the same refresh token and potentially triggering duplicate `invalid_grant` errors on token rotation. `SecureCredentialsManager` was already on the global executor — this was an inconsistency between the two manager types.
+
+In v4, `getCredentials` and `getApiCredentials` calls from any manager instance backed by the same `Auth0` object are queued on one global single-thread executor. The first caller renews the token, saves the updated credentials, and returns. Subsequent callers find the already-refreshed credentials in storage and return without making a network request.
+
+**Impact:** If your app creates multiple `CredentialsManager` instances backed by the same `Auth0` object, their renewal operations are now serialized rather than concurrent. In practice this eliminates duplicate refresh-token exchanges. The only observable downside is that a slow renewal blocks other callers until it completes.
+
+No code changes are required. This is a runtime-only behavior change.
+
+---
 
 ### `clearCredentials()` Now Clears All Storage
 

--- a/V4_MIGRATION_GUIDE.md
+++ b/V4_MIGRATION_GUIDE.md
@@ -19,6 +19,7 @@ v4 of the Auth0 Android SDK includes significant build toolchain updates, update
   + [DPoP Configuration Moved to Builder](#dpop-configuration-moved-to-builder)
   + [DPoPException.UNSUPPORTED_ERROR Removed](#dpopexceptionunsupported_error-removed)
   + [SSOCredentials.expiresIn Renamed to expiresAt](#ssocredentialsexpiresin-renamed-to-expiresat)
+  + [SecureCredentialsManager Auth0 Constructors Removed](#securecredentialsmanager-auth0-constructors-removed)
 - [**Default Values Changed**](#default-values-changed)
   + [Credentials Manager minTTL](#credentials-manager-minttl)
 - [**Behavior Changes**](#behavior-changes)
@@ -199,6 +200,73 @@ val expirationDate: Date = ssoCredentials.expiresAt
 ```
 
 **Impact:** If your code references `ssoCredentials.expiresIn`, rename it to `ssoCredentials.expiresAt`. The value is now an absolute `Date` instead of a duration in seconds.
+
+### SecureCredentialsManager Auth0 Constructors Removed
+
+**Change:** The two `SecureCredentialsManager` constructors that accepted an `Auth0` instance as their first parameter have been removed. Only the `AuthenticationAPIClient`-based constructors remain.
+
+In v3, `SecureCredentialsManager` offered four public constructors — two that accepted an `Auth0` object (which the manager used internally to create an `AuthenticationAPIClient`) and two that accepted a pre-built `AuthenticationAPIClient` directly. In v4 the `Auth0`-based constructors are gone, leaving two constructors that both require an `AuthenticationAPIClient`.
+
+**v3 (removed):**
+
+```kotlin
+// ❌ Auth0-based constructor — no longer exists
+val manager = SecureCredentialsManager(
+    auth0,    // Auth0 instance
+    context,
+    storage
+)
+
+// ❌ Auth0-based biometric constructor — no longer exists
+val manager = SecureCredentialsManager(
+    auth0,    // Auth0 instance
+    context,
+    storage,
+    fragmentActivity,
+    localAuthenticationOptions
+)
+```
+
+**v4 (required):**
+
+The manager uses the supplied `AuthenticationAPIClient` for all token renewals and DPoP-bound refreshes, so configure that client first and then pass the same instance into `SecureCredentialsManager`.
+
+```kotlin
+// ✅ Create the AuthenticationAPIClient first, then pass it in
+val apiClient = AuthenticationAPIClient(auth0)
+val manager = SecureCredentialsManager(apiClient, context, storage)
+
+// ✅ Biometric variant
+val apiClient = AuthenticationAPIClient(auth0)
+val manager = SecureCredentialsManager(
+    apiClient,
+    context,
+    storage,
+    fragmentActivity,
+    localAuthenticationOptions
+)
+```
+
+<details>
+  <summary>Using Java</summary>
+
+```java
+// ✅ Standard
+AuthenticationAPIClient apiClient = new AuthenticationAPIClient(auth0);
+SecureCredentialsManager manager = new SecureCredentialsManager(apiClient, context, storage);
+
+// ✅ Biometric variant
+AuthenticationAPIClient apiClient = new AuthenticationAPIClient(auth0);
+SecureCredentialsManager manager = new SecureCredentialsManager(
+    apiClient, context, storage, fragmentActivity, localAuthenticationOptions);
+```
+</details>
+
+**Impact:** Any code that constructs `SecureCredentialsManager` with an `Auth0` instance as the first argument will no longer compile. Create an `AuthenticationAPIClient(auth0)` first and pass that instead. The same change applies to Java — there is no Java-specific overload.
+
+**Reason:** The `Auth0` parameter was redundant — `AuthenticationAPIClient` already holds a reference to the `Auth0` configuration object. Removing it eliminates the duplication, makes DPoP opt-in configuration (via `AuthenticationAPIClient.useDPoP(context)`) a natural part of construction, and reduces the public API surface.
+
+---
 
 ## Default Values Changed
 

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -2,7 +2,6 @@ package com.auth0.android.authentication
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
-import java.util.concurrent.Executor
 import com.auth0.android.Auth0
 import com.auth0.android.Auth0Exception
 import com.auth0.android.NetworkErrorException
@@ -37,6 +36,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.io.IOException
 import java.io.Reader
 import java.security.PublicKey
+import java.util.concurrent.Executor
 
 /**
  * API client for Auth0 Authentication API.

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -84,7 +84,8 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
     public val baseURL: String
         get() = auth0.getDomainUrl()
 
-    public val executor: Executor
+
+    internal val executor: Executor
         get() = auth0.executor
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -2,6 +2,7 @@ package com.auth0.android.authentication
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
+import java.util.concurrent.Executor
 import com.auth0.android.Auth0
 import com.auth0.android.Auth0Exception
 import com.auth0.android.NetworkErrorException
@@ -82,6 +83,9 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
         get() = auth0.clientId
     public val baseURL: String
         get() = auth0.getDomainUrl()
+
+    public val executor: Executor
+        get() = auth0.executor
 
     /**
      * Enable DPoP for this client.

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
-import com.auth0.android.authentication.storage.BaseCredentialsManager.Companion.DEFAULT_MIN_TTL
 import com.auth0.android.callback.Callback
 import com.auth0.android.dpop.DPoP
 import com.auth0.android.dpop.DPoPException
@@ -21,7 +20,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.Executor
-import java.util.concurrent.Executors
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -47,7 +45,7 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
         authenticationClient,
         storage,
         JWTDecoder(),
-        Executors.newSingleThreadExecutor()
+        authenticationClient.executor
     )
 
     public override val userProfile: UserProfile?

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -115,7 +115,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     /**
      * Saves the given credentials in the Storage.
      *
-     * ** Imp:** This method is not thread safe
+     * **Important:** This method is not thread safe
      *
      * @param credentials the credentials to save.
      * @throws CredentialsManagerException if the credentials couldn't be encrypted. Some devices are not compatible at all with the cryptographic
@@ -160,7 +160,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     /**
      * Stores the given [APICredentials] in the storage for the given audience.
      *
-     * ** Imp:** This method is not thread safe
+     * **Important:** This method is not thread safe
      * @param apiCredentials the API Credentials to be stored
      * @param audience the audience for which the credentials are stored
      * @param scope the scope for which the credentials are stored

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -6,7 +6,6 @@ import android.util.Base64
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.FragmentActivity
-import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
@@ -49,92 +48,39 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     private val lastBiometricAuthTime = AtomicLong(NO_SESSION)
 
     /**
-     * Creates a new SecureCredentialsManager to handle Credentials
+     * Creates a new SecureCredentialsManager to handle Credentials.
      *
-     * @param context   a valid context
-     * @param auth0     the Auth0 account information to use
-     * @param storage   the storage implementation to use
-     */
-    public constructor(
-        context: Context,
-        auth0: Auth0,
-        storage: Storage,
-    ) : this(
-        AuthenticationAPIClient(auth0),
-        context,
-        auth0,
-        storage
-    )
-
-    /**
-     * Creates a new SecureCredentialsManager to handle Credentials with a custom AuthenticationAPIClient instance.
-     * Use this constructor when you need to configure the API client with advanced features like DPoP.
-     *
-     * Example usage:
+     * To enable DPoP, configure the [apiClient] before passing it in:
      * ```
-     * val auth0 = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN")
      * val apiClient = AuthenticationAPIClient(auth0).useDPoP(context)
-     * val manager = SecureCredentialsManager(apiClient, context, auth0, storage)
+     * val manager = SecureCredentialsManager(apiClient, context, storage)
      * ```
      *
      * @param apiClient a configured AuthenticationAPIClient instance
      * @param context   a valid context
-     * @param auth0     the Auth0 account information to use
      * @param storage   the storage implementation to use
      */
     public constructor(
         apiClient: AuthenticationAPIClient,
         context: Context,
-        auth0: Auth0,
-        storage: Storage
+        storage: Storage,
     ) : this(
         apiClient,
         storage,
         CryptoUtil(context, storage, KEY_ALIAS),
         JWTDecoder(),
-        auth0.executor
+        apiClient.executor
     )
 
-
     /**
-     * Creates a new SecureCredentialsManager to handle Credentials with biometrics Authentication
+     * Creates a new SecureCredentialsManager to handle Credentials with biometric authentication.
      *
-     * @param context   a valid context
-     * @param auth0     the Auth0 account information to use
-     * @param storage   the storage implementation to use
-     * @param fragmentActivity the FragmentActivity to use for the biometric authentication
-     * @param localAuthenticationOptions the options of type [LocalAuthenticationOptions] to use for the biometric authentication
-     */
-    public constructor(
-        context: Context,
-        auth0: Auth0,
-        storage: Storage,
-        fragmentActivity: FragmentActivity,
-        localAuthenticationOptions: LocalAuthenticationOptions
-    ) : this(
-        AuthenticationAPIClient(auth0),
-        context,
-        auth0,
-        storage,
-        fragmentActivity,
-        localAuthenticationOptions
-    )
-
-
-    /**
-     * Creates a new SecureCredentialsManager to handle Credentials with biometrics Authentication
-     * and a custom AuthenticationAPIClient instance.
-     * Use this constructor when you need to configure the API client with advanced features like DPoP
-     * along with biometric authentication.
-     *
-     * Example usage:
+     * To enable DPoP, configure the [apiClient] before passing it in:
      * ```
-     * val auth0 = Auth0.getInstance("YOUR_CLIENT_ID", "YOUR_DOMAIN")
      * val apiClient = AuthenticationAPIClient(auth0).useDPoP(context)
      * val manager = SecureCredentialsManager(
      *     apiClient,
      *     context,
-     *     auth0,
      *     storage,
      *     fragmentActivity,
      *     localAuthenticationOptions
@@ -143,7 +89,6 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
      *
      * @param apiClient a configured AuthenticationAPIClient instance
      * @param context   a valid context
-     * @param auth0     the Auth0 account information to use
      * @param storage   the storage implementation to use
      * @param fragmentActivity the FragmentActivity to use for the biometric authentication
      * @param localAuthenticationOptions the options of type [LocalAuthenticationOptions] to use for the biometric authentication
@@ -151,7 +96,6 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     public constructor(
         apiClient: AuthenticationAPIClient,
         context: Context,
-        auth0: Auth0,
         storage: Storage,
         fragmentActivity: FragmentActivity,
         localAuthenticationOptions: LocalAuthenticationOptions
@@ -160,7 +104,7 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         storage,
         CryptoUtil(context, storage, KEY_ALIAS),
         JWTDecoder(),
-        auth0.executor,
+        apiClient.executor,
         WeakReference(fragmentActivity),
         localAuthenticationOptions,
         DefaultLocalAuthenticationManagerFactory()
@@ -170,9 +114,12 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
     /**
      * Saves the given credentials in the Storage.
      *
+     * ** Imp:** This method is not thread safe
+     *
      * @param credentials the credentials to save.
      * @throws CredentialsManagerException if the credentials couldn't be encrypted. Some devices are not compatible at all with the cryptographic
      * implementation and will have [CredentialsManagerException.isDeviceIncompatible] return true.
+     *
      */
     @Throws(CredentialsManagerException::class)
     override fun saveCredentials(credentials: Credentials) {
@@ -211,10 +158,13 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
 
     /**
      * Stores the given [APICredentials] in the storage for the given audience.
+     *
+     * ** Imp:** This method is not thread safe
      * @param apiCredentials the API Credentials to be stored
      * @param audience the audience for which the credentials are stored
      * @param scope the scope for which the credentials are stored
      */
+    @Throws(CredentialsManagerException::class)
     override fun saveApiCredentials(
         apiCredentials: APICredentials,
         audience: String,
@@ -1040,7 +990,8 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
                 return@execute
             }
 
-            val tokenType = apiCredentialType ?: storage.retrieveString(KEY_TOKEN_TYPE) ?: existingCredentials.type
+            val tokenType = apiCredentialType ?: storage.retrieveString(KEY_TOKEN_TYPE)
+            ?: existingCredentials.type
             validateDPoPState(tokenType)?.let { dpopError ->
                 callback.onFailure(dpopError)
                 return@execute

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -29,8 +29,9 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 /**
- * A safer alternative to the [CredentialsManager] class. A combination of RSA and AES keys is used to keep the values secure.
- * On devices with a Secure LockScreen configured (PIN, Pattern, Password or Fingerprint) an extra authentication step can be required.
+ * A safer alternative to the [CredentialsManager] class. A combination of RSA and AES keys is used
+ * to keep the values secure. On devices with a Secure LockScreen configured (PIN, Pattern, Password
+ * or Fingerprint) an extra authentication step can be required.
  */
 public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) internal constructor(
     apiClient: AuthenticationAPIClient,

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -105,6 +105,7 @@ public class CredentialsManagerTest {
         mockDPoPKeyStore = mock()
         DPoPUtil.keyStore = mockDPoPKeyStore
         whenever(mockDPoPKeyStore.hasKeyPair()).thenReturn(false)
+        Mockito.`when`(client.executor).thenReturn(serialExecutor)
 
         val credentialsManager = CredentialsManager(client, storage, jwtDecoder, serialExecutor)
         manager = Mockito.spy(credentialsManager)

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -5,7 +5,6 @@ import android.app.KeyguardManager
 import android.content.Context
 import android.util.Base64
 import androidx.fragment.app.FragmentActivity
-import com.auth0.android.Auth0
 import com.auth0.android.NetworkErrorException
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
@@ -51,6 +50,7 @@ import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -128,7 +128,6 @@ public class SecureCredentialsManagerTest {
     public val exception: ExpectedException = ExpectedException.none()
     private lateinit var manager: SecureCredentialsManager
     private lateinit var gson: Gson
-    private lateinit var auth0: Auth0
 
     @Before
     public fun setUp() {
@@ -154,8 +153,6 @@ public class SecureCredentialsManagerTest {
                     .get()
             )
         weakFragmentActivity = WeakReference(fragmentActivity)
-        auth0 = Mockito.spy(Auth0.getInstance("clientId", "domain"))
-        Mockito.`when`(auth0.executor).thenReturn(serialExecutor)
         Mockito.`when`(client.executor).thenReturn(serialExecutor)
 
         val secureCredentialsManager =
@@ -164,7 +161,7 @@ public class SecureCredentialsManagerTest {
                 storage,
                 crypto,
                 jwtDecoder,
-                auth0.executor,
+                serialExecutor,
                 weakFragmentActivity,
                 getAuthenticationOptions(),
                 factory
@@ -2102,11 +2099,10 @@ public class SecureCredentialsManagerTest {
     }
 
     /**
-     * Testing that getCredentials execution from multiple threads via multiple instances of SecureCredentialsManager should trigger only one network request.
+     *  Testing that getCredentials execution from multiple threads via multiple instances of SecureCredentialsManager should trigger only one network request.
      */
     @Test
     public fun shouldSynchronizeGetCredentialsAccessAcrossThreadsAndInstances() {
-
         val expiredCredentials = Credentials(
             "",
             "accessToken",
@@ -2115,22 +2111,19 @@ public class SecureCredentialsManagerTest {
             Date(CredentialsMock.CURRENT_TIME_MS),
             "scope"
         )
-        val renewedCredentials =
-            Credentials(
-                "newId",
-                "newAccess",
-                "newType",
-                "rotatedRefreshToken",
-                Date(CredentialsMock.ONE_HOUR_AHEAD_MS),
-                "newScope"
-            )
-        Mockito.`when`(
-            client.renewAuth(refreshToken = "refreshToken")
-        ).thenReturn(request)
+        val renewedCredentials = Credentials(
+            "newId",
+            "newAccess",
+            "newType",
+            "rotatedRefreshToken",
+            Date(CredentialsMock.ONE_HOUR_AHEAD_MS),
+            "newScope"
+        )
+        Mockito.`when`(client.renewAuth(refreshToken = "refreshToken")).thenReturn(request)
         Mockito.`when`(request.execute()).thenReturn(renewedCredentials)
-        val serialExecutor = Executors.newSingleThreadExecutor()
-        Mockito.`when`(auth0.executor).thenReturn(serialExecutor)
-        val executor: ExecutorService = Executors.newFixedThreadPool(5)
+
+        val sharedExecutor = Executors.newSingleThreadExecutor()
+        val callerPool: ExecutorService = Executors.newFixedThreadPool(5)
         val latch = CountDownLatch(5)
         val context: Context =
             Robolectric.buildActivity(Activity::class.java).create().start().resume().get()
@@ -2139,67 +2132,316 @@ public class SecureCredentialsManagerTest {
             sharedPreferencesName = "com.auth0.android.storage.SecureCredentialsManagerTest"
         )
         val cryptoMock = Mockito.mock(CryptoUtil::class.java)
-        Mockito.`when`(cryptoMock.encrypt(any())).thenAnswer {
-            val input = it.arguments[0] as ByteArray
-            input
-        }
-        Mockito.`when`(cryptoMock.decrypt(any())).thenAnswer {
-            val input = it.arguments[0] as ByteArray
-            input
-        }
-        val secureCredsManager =
-            SecureCredentialsManager(client, storage, cryptoMock, jwtDecoder, auth0.executor)
-        secureCredsManager.saveCredentials(expiredCredentials)
+        Mockito.`when`(cryptoMock.encrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
+        Mockito.`when`(cryptoMock.decrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
+
+        SecureCredentialsManager(
+            client, storage, cryptoMock, jwtDecoder, sharedExecutor
+        ).saveCredentials(expiredCredentials)
+
         repeat(5) {
-            executor.submit {
-                val secureCredsManager =
-                    SecureCredentialsManager(
-                        client,
-                        storage,
-                        cryptoMock,
-                        jwtDecoder,
-                        auth0.executor,
-                    )
-                secureCredsManager.getCredentials(object :
+            callerPool.submit {
+                // All instances share the same executor — operations are globally serialized
+                val instance = SecureCredentialsManager(
+                    client, storage, cryptoMock, jwtDecoder, sharedExecutor
+                )
+                instance.getCredentials(object :
                     Callback<Credentials, CredentialsManagerException> {
                     override fun onFailure(error: CredentialsManagerException) {
                         throw error
                     }
 
                     override fun onSuccess(result: Credentials) {
-                        // Verify all instances retrieved the same credentials
                         MatcherAssert.assertThat(
-                            renewedCredentials.accessToken,
-                            Is.`is`(result.accessToken)
+                            result.accessToken, Is.`is`(renewedCredentials.accessToken)
                         )
                         MatcherAssert.assertThat(
-                            renewedCredentials.idToken,
-                            Is.`is`(result.idToken)
-                        )
-                        MatcherAssert.assertThat(
-                            renewedCredentials.refreshToken,
-                            Is.`is`(result.refreshToken)
-                        )
-                        MatcherAssert.assertThat(renewedCredentials.type, Is.`is`(result.type))
-                        MatcherAssert.assertThat(
-                            renewedCredentials.expiresAt,
-                            Is.`is`(result.expiresAt)
-                        )
-                        MatcherAssert.assertThat(
-                            renewedCredentials.scope,
-                            Is.`is`(result.scope)
+                            result.refreshToken, Is.`is`(renewedCredentials.refreshToken)
                         )
                         latch.countDown()
                     }
                 })
             }
         }
-        latch.await() // Wait for all threads to finish
-        Mockito.verify(client, Mockito.times(1))
-            .renewAuth(
-                refreshToken = "refreshToken"
-            ) // verify that api client's renewAuth is called only once
-        Mockito.verify(request, Mockito.times(1)).execute() // Verify single network request
+
+        latch.await(10, TimeUnit.SECONDS)
+        // Exactly one renewal — the shared executor serialized all 5 instances
+        Mockito.verify(client, Mockito.times(1)).renewAuth(refreshToken = "refreshToken")
+        Mockito.verify(request, Mockito.times(1)).execute()
+    }
+
+    @Test
+    public fun shouldTriggerOnlyOneRenewalWhenMultipleThreadsCallGetCredentialsOnSameInstance() {
+        val expiredCredentials = Credentials(
+            "",
+            "accessToken",
+            "type",
+            "refreshToken",
+            Date(CredentialsMock.CURRENT_TIME_MS),
+            "scope"
+        )
+        val renewedCredentials = Credentials(
+            "newId",
+            "newAccess",
+            "newType",
+            "rotatedRefreshToken",
+            Date(CredentialsMock.ONE_HOUR_AHEAD_MS),
+            "newScope"
+        )
+        Mockito.`when`(client.renewAuth(refreshToken = "refreshToken")).thenReturn(request)
+        Mockito.`when`(request.execute()).thenReturn(renewedCredentials)
+
+        val singleThreadExecutor = Executors.newSingleThreadExecutor()
+        val callerPool = Executors.newFixedThreadPool(10)
+        val latch = CountDownLatch(10)
+        val context: Context =
+            Robolectric.buildActivity(Activity::class.java).create().start().resume().get()
+        val storage = SharedPreferencesStorage(
+            context = context,
+            sharedPreferencesName = "com.auth0.android.storage.SecureCredentialsManagerTest.singleInstance"
+        )
+        val cryptoMock = Mockito.mock(CryptoUtil::class.java)
+        Mockito.`when`(cryptoMock.encrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
+        Mockito.`when`(cryptoMock.decrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
+
+        val singleManager =
+            SecureCredentialsManager(client, storage, cryptoMock, jwtDecoder, singleThreadExecutor)
+        singleManager.saveCredentials(expiredCredentials)
+
+        repeat(10) {
+            callerPool.submit {
+                singleManager.getCredentials(object :
+                    Callback<Credentials, CredentialsManagerException> {
+                    override fun onFailure(error: CredentialsManagerException) {
+                        throw error
+                    }
+
+                    override fun onSuccess(result: Credentials) {
+                        MatcherAssert.assertThat(
+                            result.accessToken,
+                            Is.`is`(renewedCredentials.accessToken)
+                        )
+                        MatcherAssert.assertThat(
+                            result.refreshToken,
+                            Is.`is`(renewedCredentials.refreshToken)
+                        )
+                        latch.countDown()
+                    }
+                })
+            }
+        }
+
+        latch.await(10, TimeUnit.SECONDS)
+        Mockito.verify(client, Mockito.times(1)).renewAuth(refreshToken = "refreshToken")
+        Mockito.verify(request, Mockito.times(1)).execute()
+    }
+
+    @Test
+    public fun shouldNotTriggerRenewalWhenMultipleThreadsAccessValidCredentialsOnSameInstance() {
+        val validCredentials = Credentials(
+            "idToken",
+            "accessToken",
+            "type",
+            "refreshToken",
+            Date(CredentialsMock.ONE_HOUR_AHEAD_MS),
+            "scope"
+        )
+
+        val singleThreadExecutor = Executors.newSingleThreadExecutor()
+        val callerPool = Executors.newFixedThreadPool(10)
+        val latch = CountDownLatch(10)
+        val context: Context =
+            Robolectric.buildActivity(Activity::class.java).create().start().resume().get()
+        val storage = SharedPreferencesStorage(
+            context = context,
+            sharedPreferencesName = "com.auth0.android.storage.SecureCredentialsManagerTest.validCreds"
+        )
+        val cryptoMock = Mockito.mock(CryptoUtil::class.java)
+        Mockito.`when`(cryptoMock.encrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
+        Mockito.`when`(cryptoMock.decrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
+
+        val singleManager =
+            SecureCredentialsManager(client, storage, cryptoMock, jwtDecoder, singleThreadExecutor)
+        singleManager.saveCredentials(validCredentials)
+
+        repeat(10) {
+            callerPool.submit {
+                singleManager.getCredentials(object :
+                    Callback<Credentials, CredentialsManagerException> {
+                    override fun onFailure(error: CredentialsManagerException) {
+                        throw error
+                    }
+
+                    override fun onSuccess(result: Credentials) {
+                        MatcherAssert.assertThat(
+                            result.accessToken,
+                            Is.`is`(validCredentials.accessToken)
+                        )
+                        latch.countDown()
+                    }
+                })
+            }
+        }
+
+        latch.await(10, TimeUnit.SECONDS)
+        Mockito.verify(client, Mockito.never()).renewAuth(any(), anyOrNull(), anyOrNull())
+    }
+
+
+    @Test
+    public fun shouldNotTriggerSecondRenewalForCallerQueuedBehindFirstRenewal() {
+        val expiredCredentials = Credentials(
+            "",
+            "accessToken",
+            "type",
+            "refreshToken",
+            Date(CredentialsMock.CURRENT_TIME_MS),
+            "scope"
+        )
+        val renewedCredentials = Credentials(
+            "newId",
+            "newAccess",
+            "newType",
+            "rotatedRefreshToken",
+            Date(CredentialsMock.ONE_HOUR_AHEAD_MS),
+            "newScope"
+        )
+        Mockito.`when`(client.renewAuth(refreshToken = "refreshToken")).thenReturn(request)
+        Mockito.`when`(request.execute()).thenReturn(renewedCredentials)
+
+        val singleThreadExecutor = Executors.newSingleThreadExecutor()
+        val callerPool = Executors.newFixedThreadPool(2)
+        val latch = CountDownLatch(2)
+        val context: Context =
+            Robolectric.buildActivity(Activity::class.java).create().start().resume().get()
+        val storage = SharedPreferencesStorage(
+            context = context,
+            sharedPreferencesName = "com.auth0.android.storage.SecureCredentialsManagerTest.queuedCaller"
+        )
+        val cryptoMock = Mockito.mock(CryptoUtil::class.java)
+        Mockito.`when`(cryptoMock.encrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
+        Mockito.`when`(cryptoMock.decrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
+
+        val singleManager =
+            SecureCredentialsManager(client, storage, cryptoMock, jwtDecoder, singleThreadExecutor)
+        singleManager.saveCredentials(expiredCredentials)
+
+        repeat(2) {
+            callerPool.submit {
+                singleManager.getCredentials(object :
+                    Callback<Credentials, CredentialsManagerException> {
+                    override fun onFailure(error: CredentialsManagerException) {
+                        throw error
+                    }
+
+                    override fun onSuccess(result: Credentials) {
+                        // Both callers must receive the renewed credentials, not the expired ones.
+                        MatcherAssert.assertThat(
+                            result.accessToken,
+                            Is.`is`(renewedCredentials.accessToken)
+                        )
+                        MatcherAssert.assertThat(
+                            result.refreshToken,
+                            Is.`is`(renewedCredentials.refreshToken)
+                        )
+                        latch.countDown()
+                    }
+                })
+            }
+        }
+
+        latch.await(10, TimeUnit.SECONDS)
+        // Exactly one renewal — the second caller found already-valid credentials in storage.
+        Mockito.verify(client, Mockito.times(1)).renewAuth(refreshToken = "refreshToken")
+        Mockito.verify(request, Mockito.times(1)).execute()
+    }
+
+    @Test
+    public fun shouldSerializeGetCredentialsCallsAcrossCredentialsManagerAndSecureCredentialsManager() {
+        val expiredCredentials = Credentials(
+            "",
+            "accessToken",
+            "type",
+            "refreshToken",
+            Date(CredentialsMock.CURRENT_TIME_MS),
+            "scope"
+        )
+        val renewedCredentials = Credentials(
+            "newId",
+            "newAccess",
+            "newType",
+            "rotatedRefreshToken",
+            Date(CredentialsMock.ONE_HOUR_AHEAD_MS),
+            "newScope"
+        )
+        Mockito.`when`(client.renewAuth(refreshToken = "refreshToken")).thenReturn(request)
+        Mockito.`when`(request.execute()).thenReturn(renewedCredentials)
+
+        val sharedExecutor = Executors.newSingleThreadExecutor()
+        val callerPool = Executors.newFixedThreadPool(4)
+        val latch = CountDownLatch(4)
+        val context: Context =
+            Robolectric.buildActivity(Activity::class.java).create().start().resume().get()
+        val credStorage = SharedPreferencesStorage(
+            context = context,
+            sharedPreferencesName = "com.auth0.android.storage.SecureCredentialsManagerTest.crossManagerCred"
+        )
+        val secureStorage = SharedPreferencesStorage(
+            context = context,
+            sharedPreferencesName = "com.auth0.android.storage.SecureCredentialsManagerTest.crossManagerSecure"
+        )
+        val cryptoMock = Mockito.mock(CryptoUtil::class.java)
+        Mockito.`when`(cryptoMock.encrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
+        Mockito.`when`(cryptoMock.decrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
+
+        val credManager = CredentialsManager(client, credStorage, jwtDecoder, sharedExecutor)
+        val secureManager =
+            SecureCredentialsManager(client, secureStorage, cryptoMock, jwtDecoder, sharedExecutor)
+
+        credManager.saveCredentials(expiredCredentials)
+        secureManager.saveCredentials(expiredCredentials)
+
+        repeat(2) {
+            callerPool.submit {
+                credManager.getCredentials(object :
+                    Callback<Credentials, CredentialsManagerException> {
+                    override fun onFailure(error: CredentialsManagerException) {
+                        throw error
+                    }
+
+                    override fun onSuccess(result: Credentials) {
+                        MatcherAssert.assertThat(
+                            result.accessToken,
+                            Is.`is`(renewedCredentials.accessToken)
+                        )
+                        latch.countDown()
+                    }
+                })
+            }
+        }
+
+        repeat(2) {
+            callerPool.submit {
+                secureManager.getCredentials(object :
+                    Callback<Credentials, CredentialsManagerException> {
+                    override fun onFailure(error: CredentialsManagerException) {
+                        throw error
+                    }
+
+                    override fun onSuccess(result: Credentials) {
+                        MatcherAssert.assertThat(
+                            result.accessToken,
+                            Is.`is`(renewedCredentials.accessToken)
+                        )
+                        latch.countDown()
+                    }
+                })
+            }
+        }
+
+        latch.await(10, TimeUnit.SECONDS)
+        Mockito.verify(client, Mockito.times(2)).renewAuth(refreshToken = "refreshToken")
+        Mockito.verify(request, Mockito.times(2)).execute()
     }
 
     /*
@@ -3475,7 +3717,7 @@ public class SecureCredentialsManagerTest {
             storage,
             crypto,
             jwtDecoder,
-            auth0.executor,
+            serialExecutor,
             weakFragmentActivity,
             getAuthenticationOptions(),
             factory
@@ -3549,13 +3791,12 @@ public class SecureCredentialsManagerTest {
                 throw IllegalArgumentException("Proper Executor Set")
             }
         }
-        Mockito.`when`(auth0.executor).thenReturn(serialExecutor)
         val manager = SecureCredentialsManager(
             client,
             storage,
             crypto,
             jwtDecoder,
-            auth0.executor,
+            serialExecutor,
             weakFragmentActivity,
             getAuthenticationOptions(),
             factory

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -2123,8 +2123,8 @@ public class SecureCredentialsManagerTest {
         Mockito.`when`(request.execute()).thenReturn(renewedCredentials)
 
         val sharedExecutor = Executors.newSingleThreadExecutor()
-        val callerPool: ExecutorService = Executors.newFixedThreadPool(5)
-        val latch = CountDownLatch(5)
+        val callerPool: ExecutorService = Executors.newFixedThreadPool(3)
+        val latch = CountDownLatch(3)
         val context: Context =
             Robolectric.buildActivity(Activity::class.java).create().start().resume().get()
         val storage = SharedPreferencesStorage(
@@ -2139,7 +2139,7 @@ public class SecureCredentialsManagerTest {
             client, storage, cryptoMock, jwtDecoder, sharedExecutor
         ).saveCredentials(expiredCredentials)
 
-        repeat(5) {
+        repeat(3) {
             callerPool.submit {
                 // All instances share the same executor — operations are globally serialized
                 val instance = SecureCredentialsManager(
@@ -2164,7 +2164,7 @@ public class SecureCredentialsManagerTest {
             }
         }
 
-        latch.await(10, TimeUnit.SECONDS)
+        Assert.assertTrue(latch.await(3, TimeUnit.SECONDS))
         // Exactly one renewal — the shared executor serialized all 5 instances
         Mockito.verify(client, Mockito.times(1)).renewAuth(refreshToken = "refreshToken")
         Mockito.verify(request, Mockito.times(1)).execute()
@@ -2192,8 +2192,8 @@ public class SecureCredentialsManagerTest {
         Mockito.`when`(request.execute()).thenReturn(renewedCredentials)
 
         val singleThreadExecutor = Executors.newSingleThreadExecutor()
-        val callerPool = Executors.newFixedThreadPool(10)
-        val latch = CountDownLatch(10)
+        val callerPool = Executors.newFixedThreadPool(3)
+        val latch = CountDownLatch(3)
         val context: Context =
             Robolectric.buildActivity(Activity::class.java).create().start().resume().get()
         val storage = SharedPreferencesStorage(
@@ -2208,7 +2208,7 @@ public class SecureCredentialsManagerTest {
             SecureCredentialsManager(client, storage, cryptoMock, jwtDecoder, singleThreadExecutor)
         singleManager.saveCredentials(expiredCredentials)
 
-        repeat(10) {
+        repeat(3) {
             callerPool.submit {
                 singleManager.getCredentials(object :
                     Callback<Credentials, CredentialsManagerException> {
@@ -2231,7 +2231,7 @@ public class SecureCredentialsManagerTest {
             }
         }
 
-        latch.await(10, TimeUnit.SECONDS)
+        Assert.assertTrue(latch.await(3, TimeUnit.SECONDS))
         Mockito.verify(client, Mockito.times(1)).renewAuth(refreshToken = "refreshToken")
         Mockito.verify(request, Mockito.times(1)).execute()
     }
@@ -2248,8 +2248,8 @@ public class SecureCredentialsManagerTest {
         )
 
         val singleThreadExecutor = Executors.newSingleThreadExecutor()
-        val callerPool = Executors.newFixedThreadPool(10)
-        val latch = CountDownLatch(10)
+        val callerPool = Executors.newFixedThreadPool(3)
+        val latch = CountDownLatch(3)
         val context: Context =
             Robolectric.buildActivity(Activity::class.java).create().start().resume().get()
         val storage = SharedPreferencesStorage(
@@ -2264,7 +2264,7 @@ public class SecureCredentialsManagerTest {
             SecureCredentialsManager(client, storage, cryptoMock, jwtDecoder, singleThreadExecutor)
         singleManager.saveCredentials(validCredentials)
 
-        repeat(10) {
+        repeat(3) {
             callerPool.submit {
                 singleManager.getCredentials(object :
                     Callback<Credentials, CredentialsManagerException> {
@@ -2283,7 +2283,7 @@ public class SecureCredentialsManagerTest {
             }
         }
 
-        latch.await(10, TimeUnit.SECONDS)
+        Assert.assertTrue(latch.await(3, TimeUnit.SECONDS))
         Mockito.verify(client, Mockito.never()).renewAuth(any(), anyOrNull(), anyOrNull())
     }
 
@@ -2350,98 +2350,10 @@ public class SecureCredentialsManagerTest {
             }
         }
 
-        latch.await(10, TimeUnit.SECONDS)
+        Assert.assertTrue(latch.await(2, TimeUnit.SECONDS))
         // Exactly one renewal — the second caller found already-valid credentials in storage.
         Mockito.verify(client, Mockito.times(1)).renewAuth(refreshToken = "refreshToken")
         Mockito.verify(request, Mockito.times(1)).execute()
-    }
-
-    @Test
-    public fun shouldSerializeGetCredentialsCallsAcrossCredentialsManagerAndSecureCredentialsManager() {
-        val expiredCredentials = Credentials(
-            "",
-            "accessToken",
-            "type",
-            "refreshToken",
-            Date(CredentialsMock.CURRENT_TIME_MS),
-            "scope"
-        )
-        val renewedCredentials = Credentials(
-            "newId",
-            "newAccess",
-            "newType",
-            "rotatedRefreshToken",
-            Date(CredentialsMock.ONE_HOUR_AHEAD_MS),
-            "newScope"
-        )
-        Mockito.`when`(client.renewAuth(refreshToken = "refreshToken")).thenReturn(request)
-        Mockito.`when`(request.execute()).thenReturn(renewedCredentials)
-
-        val sharedExecutor = Executors.newSingleThreadExecutor()
-        val callerPool = Executors.newFixedThreadPool(4)
-        val latch = CountDownLatch(4)
-        val context: Context =
-            Robolectric.buildActivity(Activity::class.java).create().start().resume().get()
-        val credStorage = SharedPreferencesStorage(
-            context = context,
-            sharedPreferencesName = "com.auth0.android.storage.SecureCredentialsManagerTest.crossManagerCred"
-        )
-        val secureStorage = SharedPreferencesStorage(
-            context = context,
-            sharedPreferencesName = "com.auth0.android.storage.SecureCredentialsManagerTest.crossManagerSecure"
-        )
-        val cryptoMock = Mockito.mock(CryptoUtil::class.java)
-        Mockito.`when`(cryptoMock.encrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
-        Mockito.`when`(cryptoMock.decrypt(any())).thenAnswer { it.arguments[0] as ByteArray }
-
-        val credManager = CredentialsManager(client, credStorage, jwtDecoder, sharedExecutor)
-        val secureManager =
-            SecureCredentialsManager(client, secureStorage, cryptoMock, jwtDecoder, sharedExecutor)
-
-        credManager.saveCredentials(expiredCredentials)
-        secureManager.saveCredentials(expiredCredentials)
-
-        repeat(2) {
-            callerPool.submit {
-                credManager.getCredentials(object :
-                    Callback<Credentials, CredentialsManagerException> {
-                    override fun onFailure(error: CredentialsManagerException) {
-                        throw error
-                    }
-
-                    override fun onSuccess(result: Credentials) {
-                        MatcherAssert.assertThat(
-                            result.accessToken,
-                            Is.`is`(renewedCredentials.accessToken)
-                        )
-                        latch.countDown()
-                    }
-                })
-            }
-        }
-
-        repeat(2) {
-            callerPool.submit {
-                secureManager.getCredentials(object :
-                    Callback<Credentials, CredentialsManagerException> {
-                    override fun onFailure(error: CredentialsManagerException) {
-                        throw error
-                    }
-
-                    override fun onSuccess(result: Credentials) {
-                        MatcherAssert.assertThat(
-                            result.accessToken,
-                            Is.`is`(renewedCredentials.accessToken)
-                        )
-                        latch.countDown()
-                    }
-                })
-            }
-        }
-
-        latch.await(10, TimeUnit.SECONDS)
-        Mockito.verify(client, Mockito.times(2)).renewAuth(refreshToken = "refreshToken")
-        Mockito.verify(request, Mockito.times(2)).execute()
     }
 
     /*

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -156,6 +156,7 @@ public class SecureCredentialsManagerTest {
         weakFragmentActivity = WeakReference(fragmentActivity)
         auth0 = Mockito.spy(Auth0.getInstance("clientId", "domain"))
         Mockito.`when`(auth0.executor).thenReturn(serialExecutor)
+        Mockito.`when`(client.executor).thenReturn(serialExecutor)
 
         val secureCredentialsManager =
             SecureCredentialsManager(
@@ -179,8 +180,8 @@ public class SecureCredentialsManagerTest {
             Robolectric.buildActivity(Activity::class.java).create().start().resume().get()
         val storage: Storage = SharedPreferencesStorage(context)
         val manager = SecureCredentialsManager(
+            client,
             context,
-            auth0,
             storage,
             fragmentActivity,
             getAuthenticationOptions()

--- a/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
+++ b/sample/src/main/java/com/auth0/sample/DatabaseLoginFragment.kt
@@ -77,8 +77,8 @@ class DatabaseLoginFragment : Fragment() {
     private val secureCredentialsManager: SecureCredentialsManager by lazy {
         val storage = SharedPreferencesStorage(requireContext())
         val manager = SecureCredentialsManager(
+            authenticationApiClient,
             requireContext(),
-            account,
             storage,
             requireActivity(),
             localAuthenticationOptions


### PR DESCRIPTION
### Changes
This PR removes two redundant constructors from `SecureCredentialsManager` class making it less confusing for users while instantiating the class .  
`AuthenticationAPIClient` already holds a reference to the Auth0 object, so passing both was always duplication. 
Removing `Auth0` also makes advanced client configuration like DPoP a natural part of setup: callers configure the client before passing it in, and the manager inherits that configuration automatically.



### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. Since this library has unit testing, tests should be added for new functionality and existing tests should complete without errors.

- [X] This change adds unit test coverage

- [x] This change adds integration test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
