### PR TITLE
doc: Removed EA tag from MyAccount APIs

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1929,12 +1929,9 @@ val manager = CredentialsManager(apiClient, storage)
 
 ## My Account API
 
-> [!NOTE]
-> The My Account API is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). Please reach out to Auth0 support to get it enabled for your tenant.
-
 Use the Auth0 My Account API to manage the current user's account.
 
-To call the My Account API, you need an access token issued specifically for this API, including any required scopes for the operations you want to perform. See [API credentials [EA]](#api-credentials-ea) to learn how to obtain one.
+To call the My Account API, you need an access token issued specifically for this API, including any required scopes for the operations you want to perform. See [API credentials](#api-credentials) to learn how to obtain one.
 
 ```kotlin
 val client = MyAccountAPIClient(auth0, accessToken)
@@ -2809,10 +2806,7 @@ val isValid = secureCredentialsManager.isBiometricSessionValid()
 
 ### Other Credentials
 
-#### API credentials [EA]
-
-> [!NOTE]
-> This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). Please reach out to Auth0 support to get it enabled for your tenant.
+#### API credentials
 
 When the user logs in, you can request an access token for a specific API by passing its API identifier as the [audience](#specify-audience) value. The access token in the resulting credentials can then be used to make authenticated requests to that API.
 

--- a/auth0/src/main/java/com/auth0/android/myaccount/MyAccountAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/myaccount/MyAccountAPIClient.kt
@@ -108,12 +108,6 @@ public class MyAccountAPIClient @VisibleForTesting(otherwise = VisibleForTesting
      * You can specify an optional user identity identifier and an optional database connection name.
      * If a connection name is not specified, your tenant's default directory will be used.
      *
-     * ## Availability
-     *
-     * This feature is currently available in
-     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-     * Please reach out to Auth0 support to get it enabled for your tenant.
-     *
      * ## Scopes Required
      *
      * `create:me:authentication_methods`
@@ -205,12 +199,6 @@ public class MyAccountAPIClient @VisibleForTesting(otherwise = VisibleForTesting
     /**
      * Enrolls a new passkey credential. This is the last part of the enrollment flow.
      *
-     * ## Availability
-     *
-     * This feature is currently available in
-     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-     * Please reach out to Auth0 support to get it enabled for your tenant.
-     *
      * ## Scopes Required
      *
      * `create:me:authentication_methods`
@@ -277,12 +265,6 @@ public class MyAccountAPIClient @VisibleForTesting(otherwise = VisibleForTesting
     /**
      * Retrieves a detailed list of authentication methods belonging to the user.
      *
-     * ## Availability
-     *
-     * This feature is currently available in
-     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-     * Please reach out to Auth0 support to get it enabled for your tenant.
-     *
      * ## Scopes Required
      *
      * `read:me:authentication_methods`
@@ -346,13 +328,6 @@ public class MyAccountAPIClient @VisibleForTesting(otherwise = VisibleForTesting
     /**
      * Retrieves a single authentication method belonging to the user.
      *
-     * ## Availability
-     *
-     * This feature is currently available in
-     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-     * Please reach out to Auth0 support to get it enabled for your tenant.
-     *
-     *
      * ## Usage
      *
      * ```kotlin
@@ -386,13 +361,6 @@ public class MyAccountAPIClient @VisibleForTesting(otherwise = VisibleForTesting
 
     /**
      * Updates a single authentication method belonging to the user.
-     *
-     * ## Availability
-     *
-     * This feature is currently available in
-     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-     * Please reach out to Auth0 support to get it enabled for your tenant.
-     *
      *
      * ## Usage
      *
@@ -447,12 +415,6 @@ public class MyAccountAPIClient @VisibleForTesting(otherwise = VisibleForTesting
 
     /**
      * Deletes an existing authentication method belonging to the user.
-     *
-     * ## Availability
-     *
-     * This feature is currently available in
-     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-     * Please reach out to Auth0 support to get it enabled for your tenant.
      *
      * ## Scopes Required
      * `delete:me:authentication_methods`


### PR DESCRIPTION
### Changes

This PR removes the EA tag from MyAccount API as it is available in GA now

### References
https://auth0.com/docs/api/myaccount



### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Early Access notices from My Account API documentation
  * Updated API credentials reference links in the documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->