### PR TITLE
docs: mention auth0-android-major-migration skill in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ We'd love for you to try it out and share your feedback! Please [open an issue](
 
 📚 [Migration Guide](https://github.com/auth0/Auth0.Android/blob/v4_development/V4_MIGRATION_GUIDE.md)   📦 [v4 Changelog](https://github.com/auth0/Auth0.Android/blob/v4_development/CHANGELOG.md)
 
+**Skill for Coding Agents:** If you use coding agents such as Claude Code or Cursor, add the Auth0.Android migration skill to automate the upgrade: `npx skills add auth0/agent-skills --skill auth0-android-major-migration`
+
 ## Documentation
 - [Quickstart](https://auth0.com/docs/quickstart/native/android/interactive)
 - [Sample App](https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt)


### PR DESCRIPTION
### Changes

dds a "Skill for Coding Agents" section near the top of V3_MIGRATION_GUIDE.md and a one-liner in README.md, both pointing to the auth0-android-major-migration skill.
  


### Testing

Tried installing the skill using the command locally it works fine 


## Summary by CodeRabbit

* **Documentation**
  * Enhanced migration documentation with a new section for coding agent users, including instructions to add the Auth0.Android migration skill to automate project upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * README updated with automation instructions for the Auth0.Android v3-to-v4 migration. Developers using coding agents like Claude Code or Cursor can now run a single command to automate the upgrade process, eliminating manual setup steps, reducing configuration complexity, and accelerating the transition to the latest authentication system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->