### PR TITLE
docs: mention auth0-android-major-migration skill in V4 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@
 - [Docs Site](https://javadoc.io/doc/com.auth0.android/auth0/latest/index.html)
 - [Migration Guide](V4_MIGRATION_GUIDE.md)
 
-**Skill for Coding Agents:** If you use coding agents such as Claude Code or Cursor, add the Auth0.Android migration skill to automate the upgrade: `npx skills add auth0/agent-skills --skill auth0-android-major-migration`
-
-
 ## Getting Started
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
 - [FAQs](https://github.com/auth0/auth0.android/blob/main/FAQ.md)
 - [Examples](https://github.com/auth0/auth0.android/blob/main/EXAMPLES.md)
 - [Docs Site](https://javadoc.io/doc/com.auth0.android/auth0/latest/index.html)
+- [Migration Guide](V4_MIGRATION_GUIDE.md)
+
+**Skill for Coding Agents:** If you use coding agents such as Claude Code or Cursor, add the Auth0.Android migration skill to automate the upgrade: `npx skills add auth0/agent-skills --skill auth0-android-major-migration`
 
 
 ## Getting Started

--- a/V4_MIGRATION_GUIDE.md
+++ b/V4_MIGRATION_GUIDE.md
@@ -1,5 +1,9 @@
 # Migration Guide from SDK v3 to v4
 
+## Skill for Coding Agents
+
+If you use coding agents such as Claude Code or Cursor, we highly recommend adding the Auth0.Android migration skill to your repository: `npx skills add auth0/agent-skills --skill auth0-android-major-migration`
+
 > **Note:** This guide is actively maintained during the v4 development phase. As new changes are merged, this document will be updated to reflect the latest breaking changes and migration steps.
 
 v4 of the Auth0 Android SDK includes significant build toolchain updates, updated default values for better out-of-the-box behavior, and behavior changes to simplify credential management. This guide documents the changes required when migrating from v3 to v4.


### PR DESCRIPTION
 ## Summary

  Adds discovery points for the `auth0-android-major-migration` coding agent skill to help developers using Claude Code or Cursor automate their v3 →
  v4 upgrade.

  - `V4_MIGRATION_GUIDE.md`: adds a "Skill for Coding Agents" section at the top of the guide
  - `README.md`: adds a Migration Guide link to the Documentation section and a one-liner pointing to the skill


  ## Testing

Tested it does work perfectly

  - [x] Verified skill name `auth0-android-major-migration` exists in [auth0/agent-skills](https://github.com/auth0/agent-skills)

