### PR TITLE
docs: fix stale SDK version values in manifestPlaceholders example

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ Next, define the Manifest Placeholders for the Auth0 Domain and Scheme which are
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 34
     defaultConfig {
         applicationId "com.auth0.samples"
-        minSdkVersion 21
-        targetSdkVersion 30
+        minSdkVersion 31
+        targetSdkVersion 34
         //...
 
         //---> Add the next line


### PR DESCRIPTION
## Summary

Fixed stale API version values in the build.gradle manifest placeholders example — they showed compileSdkVersion/targetSdkVersion 30 and minSdkVersion 21, contradicting the Requirements section which states API 31+ is required.

## Changes

- README.md — updated compileSdkVersion 30 → 34, targetSdkVersion 30 → 34, minSdkVersion 21 → 31

---
Generated with syncing-sdk-docs skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android SDK configuration requirements in setup instructions to reflect newer build targets: compileSdkVersion updated to 34, minSdkVersion updated to 31, and targetSdkVersion updated to 34.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->