### PR TITLE
feat : Added passwordless API for DB-Connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ version.txt
 
 # Internal planning docs
 plans/
+docs/

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1504,20 +1504,23 @@ Obtain a `PasswordlessClient` from the `AuthenticationAPIClient`:
 val passwordless = AuthenticationAPIClient(account).passwordlessClient()
 ```
 
-The flow has two steps: request an OTP challenge, then exchange the code for credentials.
+The flow has two steps: first issue an OTP challenge, then — after the user enters the code they received — exchange it for credentials. **Save the `PasswordlessChallenge` from step 1**, as you pass that same object into `loginWithOTP` in step 2.
 
 #### Step 1: Issue an OTP challenge
 
-Send a one-time code to the user's email. For privacy, the server **always responds successfully regardless of whether the user exists**. On success you receive a `PasswordlessChallenge` containing an opaque `auth_session` that you must keep for step 2.
+Send a one-time code to the user's email. For privacy, the server **always responds successfully regardless of whether the user exists**. On success, save the returned `PasswordlessChallenge` for step 2.
 
 ```kotlin
+// keep this reference until the user enters the code
+var challenge: PasswordlessChallenge? = null
+
 passwordless
     .challengeWithEmail("info@auth0.com", "my-database-connection")
     .start(object: Callback<PasswordlessChallenge, AuthenticationException> {
         override fun onFailure(exception: AuthenticationException) { }
 
         override fun onSuccess(result: PasswordlessChallenge) {
-            val challenge = result
+            challenge = result
         }
     })
 ```
@@ -1531,50 +1534,16 @@ passwordless
         override fun onFailure(exception: AuthenticationException) { }
 
         override fun onSuccess(result: PasswordlessChallenge) {
-            val challenge = result
+            challenge = result
         }
     })
 ```
 
 Both challenge methods accept an optional `allowSignup` parameter (defaults to `false`) that controls whether a new user is created if one does not yet exist.
 
-<details>
-  <summary>Using coroutines</summary>
-
-```kotlin
-try {
-    val challenge = passwordless
-        .challengeWithEmail("info@auth0.com", "my-database-connection")
-        .await()
-} catch (e: AuthenticationException) {
-    e.printStackTrace()
-}
-```
-</details>
-
-<details>
-  <summary>Using Java</summary>
-
-```java
-passwordless
-    .challengeWithEmail("info@auth0.com", "my-database-connection", false)
-    .start(new Callback<PasswordlessChallenge, AuthenticationException>() {
-        @Override
-        public void onSuccess(PasswordlessChallenge result) {
-            PasswordlessChallenge challenge = result;
-        }
-
-        @Override
-        public void onFailure(@NonNull AuthenticationException error) {
-            //Error!
-        }
-    });
-```
-</details>
-
 #### Step 2: Verify the code and log in
 
-Exchange the `PasswordlessChallenge` from step 1 together with the code the user received for `Credentials`. If DPoP is enabled on the originating `AuthenticationAPIClient`, a DPoP proof is attached automatically to this token request.
+Once the user enters the code, pass the saved `challenge` together with that code to `loginWithOTP` to obtain `Credentials`. If DPoP is enabled on the originating `AuthenticationAPIClient`, a DPoP proof is attached automatically to this token request.
 
 ```kotlin
 passwordless
@@ -1590,14 +1559,15 @@ passwordless
   <summary>Using coroutines</summary>
 
 ```kotlin
-try {
-    val credentials = passwordless
-        .loginWithOTP(challenge, "123456")
-        .await()
-    println(credentials)
-} catch (e: AuthenticationException) {
-    e.printStackTrace()
-}
+// Step 1: issue the challenge and keep it
+val challenge = passwordless
+    .challengeWithEmail("info@auth0.com", "my-database-connection")
+    .await()
+
+// Step 2: once the user enters the code, pass the saved challenge back to log in
+val credentials = passwordless
+    .loginWithOTP(challenge, "123456")
+    .await()
 ```
 </details>
 
@@ -1605,6 +1575,22 @@ try {
   <summary>Using Java</summary>
 
 ```java
+// Step 1: issue the challenge and keep it
+passwordless
+    .challengeWithEmail("info@auth0.com", "my-database-connection", false)
+    .start(new Callback<PasswordlessChallenge, AuthenticationException>() {
+        @Override
+        public void onSuccess(PasswordlessChallenge result) {
+            challenge = result;
+        }
+
+        @Override
+        public void onFailure(@NonNull AuthenticationException error) {
+            //Error!
+        }
+    });
+
+// Step 2: once the user enters the code, pass the saved challenge back to log in
 passwordless
     .loginWithOTP(challenge, "123456")
     .start(new Callback<Credentials, AuthenticationException>() {

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -27,6 +27,9 @@
     - [Passwordless Login](#passwordless-login)
       - [Step 1: Request the code](#step-1-request-the-code)
       - [Step 2: Input the code](#step-2-input-the-code)
+    - [Passwordless Login with a Database Connection (EA)](#passwordless-login-with-a-database-connection-ea)
+      - [Step 1: Issue an OTP challenge](#step-1-issue-an-otp-challenge)
+      - [Step 2: Verify the code and log in](#step-2-verify-the-code-and-log-in)
     - [Sign Up with a database connection](#sign-up-with-a-database-connection)
     - [Get user information](#get-user-information)
     - [Custom Token Exchange](#custom-token-exchange)
@@ -1472,6 +1475,139 @@ try {
 authentication
     .loginWithEmail("info@auth0.com", "123456", "my-passwordless-connection")
     .validateClaims() //mandatory
+    .start(new Callback<Credentials, AuthenticationException>() {
+        @Override
+        public void onSuccess(@Nullable Credentials payload) {
+            //Logged in!
+        }
+
+        @Override
+        public void onFailure(@NonNull AuthenticationException error) {
+            //Error!
+        }
+    });
+```
+</details>
+
+> The default scope used is `openid profile email`. Regardless of the scopes set to the request, the `openid` scope is always enforced.
+
+### Passwordless Login with a Database Connection (EA)
+
+> [!IMPORTANT]
+> Passwordless Login for database connections is currently in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). Please reach out to Auth0 support to get it enabled for your tenant.
+
+This flow lets users authenticate with a one-time code sent over email or SMS/voice against a **database connection** that has `email_otp` or `phone_otp` enabled. It is distinct from the `/passwordless/start` flow described above, which uses dedicated passwordless connections.
+
+Obtain a `PasswordlessClient` from the `AuthenticationAPIClient`:
+
+```kotlin
+val passwordless = AuthenticationAPIClient(account).passwordlessClient()
+```
+
+The flow has two steps: request an OTP challenge, then exchange the code for credentials.
+
+#### Step 1: Issue an OTP challenge
+
+Send a one-time code to the user's email. For privacy, the server **always responds successfully regardless of whether the user exists**. On success you receive an opaque `auth_session` that you must keep for step 2.
+
+```kotlin
+passwordless
+    .challengeWithEmail("info@auth0.com", "my-database-connection")
+    .start(object: Callback<PasswordlessChallenge, AuthenticationException> {
+        override fun onFailure(exception: AuthenticationException) { }
+
+        override fun onSuccess(result: PasswordlessChallenge) {
+            val authSession = result.authSession
+        }
+    })
+```
+
+To send the code over SMS or voice instead, use `challengeWithPhoneNumber` against a connection with `phone_otp` enabled, choosing the `DeliveryMethod`:
+
+```kotlin
+passwordless
+    .challengeWithPhoneNumber("+15555550123", "my-database-connection", DeliveryMethod.TEXT)
+    .start(object: Callback<PasswordlessChallenge, AuthenticationException> {
+        override fun onFailure(exception: AuthenticationException) { }
+
+        override fun onSuccess(result: PasswordlessChallenge) {
+            val authSession = result.authSession
+        }
+    })
+```
+
+Both challenge methods accept an optional `allowSignup` parameter (defaults to `false`) that controls whether a new user is created if one does not yet exist.
+
+<details>
+  <summary>Using coroutines</summary>
+
+```kotlin
+try {
+    val challenge = passwordless
+        .challengeWithEmail("info@auth0.com", "my-database-connection")
+        .await()
+    val authSession = challenge.authSession
+} catch (e: AuthenticationException) {
+    e.printStackTrace()
+}
+```
+</details>
+
+<details>
+  <summary>Using Java</summary>
+
+```java
+passwordless
+    .challengeWithEmail("info@auth0.com", "my-database-connection", false)
+    .start(new Callback<PasswordlessChallenge, AuthenticationException>() {
+        @Override
+        public void onSuccess(PasswordlessChallenge result) {
+            String authSession = result.getAuthSession();
+        }
+
+        @Override
+        public void onFailure(@NonNull AuthenticationException error) {
+            //Error!
+        }
+    });
+```
+</details>
+
+#### Step 2: Verify the code and log in
+
+Exchange the `auth_session` from step 1 together with the code the user received for `Credentials`. If DPoP is enabled on the originating `AuthenticationAPIClient`, a DPoP proof is attached automatically to this token request.
+
+```kotlin
+passwordless
+    .loginWithOTP(authSession, "123456")
+    .start(object: Callback<Credentials, AuthenticationException> {
+        override fun onFailure(exception: AuthenticationException) { }
+
+        override fun onSuccess(credentials: Credentials) { }
+    })
+```
+
+<details>
+  <summary>Using coroutines</summary>
+
+```kotlin
+try {
+    val credentials = passwordless
+        .loginWithOTP(authSession, "123456")
+        .await()
+    println(credentials)
+} catch (e: AuthenticationException) {
+    e.printStackTrace()
+}
+```
+</details>
+
+<details>
+  <summary>Using Java</summary>
+
+```java
+passwordless
+    .loginWithOTP(authSession, "123456")
     .start(new Callback<Credentials, AuthenticationException>() {
         @Override
         public void onSuccess(@Nullable Credentials payload) {

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1508,7 +1508,7 @@ The flow has two steps: request an OTP challenge, then exchange the code for cre
 
 #### Step 1: Issue an OTP challenge
 
-Send a one-time code to the user's email. For privacy, the server **always responds successfully regardless of whether the user exists**. On success you receive an opaque `auth_session` that you must keep for step 2.
+Send a one-time code to the user's email. For privacy, the server **always responds successfully regardless of whether the user exists**. On success you receive a `PasswordlessChallenge` containing an opaque `auth_session` that you must keep for step 2.
 
 ```kotlin
 passwordless
@@ -1517,7 +1517,7 @@ passwordless
         override fun onFailure(exception: AuthenticationException) { }
 
         override fun onSuccess(result: PasswordlessChallenge) {
-            val authSession = result.authSession
+            val challenge = result
         }
     })
 ```
@@ -1531,7 +1531,7 @@ passwordless
         override fun onFailure(exception: AuthenticationException) { }
 
         override fun onSuccess(result: PasswordlessChallenge) {
-            val authSession = result.authSession
+            val challenge = result
         }
     })
 ```
@@ -1546,7 +1546,6 @@ try {
     val challenge = passwordless
         .challengeWithEmail("info@auth0.com", "my-database-connection")
         .await()
-    val authSession = challenge.authSession
 } catch (e: AuthenticationException) {
     e.printStackTrace()
 }
@@ -1562,7 +1561,7 @@ passwordless
     .start(new Callback<PasswordlessChallenge, AuthenticationException>() {
         @Override
         public void onSuccess(PasswordlessChallenge result) {
-            String authSession = result.getAuthSession();
+            PasswordlessChallenge challenge = result;
         }
 
         @Override
@@ -1575,11 +1574,11 @@ passwordless
 
 #### Step 2: Verify the code and log in
 
-Exchange the `auth_session` from step 1 together with the code the user received for `Credentials`. If DPoP is enabled on the originating `AuthenticationAPIClient`, a DPoP proof is attached automatically to this token request.
+Exchange the `PasswordlessChallenge` from step 1 together with the code the user received for `Credentials`. If DPoP is enabled on the originating `AuthenticationAPIClient`, a DPoP proof is attached automatically to this token request.
 
 ```kotlin
 passwordless
-    .loginWithOTP(authSession, "123456")
+    .loginWithOTP(challenge, "123456")
     .start(object: Callback<Credentials, AuthenticationException> {
         override fun onFailure(exception: AuthenticationException) { }
 
@@ -1593,7 +1592,7 @@ passwordless
 ```kotlin
 try {
     val credentials = passwordless
-        .loginWithOTP(authSession, "123456")
+        .loginWithOTP(challenge, "123456")
         .await()
     println(credentials)
 } catch (e: AuthenticationException) {
@@ -1607,7 +1606,7 @@ try {
 
 ```java
 passwordless
-    .loginWithOTP(authSession, "123456")
+    .loginWithOTP(challenge, "123456")
     .start(new Callback<Credentials, AuthenticationException>() {
         @Override
         public void onSuccess(@Nullable Credentials payload) {

--- a/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt
@@ -6,6 +6,7 @@ import com.auth0.android.Auth0
 import com.auth0.android.Auth0Exception
 import com.auth0.android.NetworkErrorException
 import com.auth0.android.authentication.mfa.MfaApiClient
+import com.auth0.android.authentication.passwordless.PasswordlessClient
 import com.auth0.android.authentication.request.ActorToken
 import com.auth0.android.dpop.DPoP
 import com.auth0.android.dpop.DPoPException
@@ -116,6 +117,27 @@ public class AuthenticationAPIClient @VisibleForTesting(otherwise = VisibleForTe
      */
     public fun mfaClient(mfaToken: String): MfaApiClient {
         return MfaApiClient(this.auth0, mfaToken)
+    }
+
+    /**
+     * Creates a [PasswordlessClient] for the database-connection passwordless flow.
+     *
+     * ## Availability
+     *
+     * This feature is currently available in
+     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
+     * Please reach out to Auth0 support to get it enabled for your tenant.
+     *
+     * ## Usage
+     *
+     * ```kotlin
+     * val passwordless = authClient.passwordlessClient()
+     * ```
+     *
+     * @return a new [PasswordlessClient] instance bound to this client's Auth0 account.
+     */
+    public fun passwordlessClient(): PasswordlessClient {
+        return PasswordlessClient(this.auth0, gson, this.dPoP)
     }
 
     /**

--- a/auth0/src/main/java/com/auth0/android/authentication/passwordless/DeliveryMethod.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/passwordless/DeliveryMethod.kt
@@ -1,0 +1,17 @@
+package com.auth0.android.authentication.passwordless
+
+/**
+ * Delivery method for a phone-number OTP challenge.
+ *
+ * Maps to the `delivery_method` request parameter of `POST /otp/challenge`. [TEXT] sends the
+ * one-time code via SMS (the server default); [VOICE] delivers it through a voice call.
+ *
+ * @property value the wire value sent to the server.
+ */
+public enum class DeliveryMethod(public val value: String) {
+    /** Deliver the one-time code via SMS. */
+    TEXT("text"),
+
+    /** Deliver the one-time code via a voice call. */
+    VOICE("voice")
+}

--- a/auth0/src/main/java/com/auth0/android/authentication/passwordless/PasswordlessClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/passwordless/PasswordlessClient.kt
@@ -92,6 +92,7 @@ public class PasswordlessClient @VisibleForTesting(otherwise = VisibleForTesting
      * @return a request that, when started, yields a [PasswordlessChallenge] containing the `auth_session`.
      * @see loginWithOTP
      */
+    @JvmOverloads
     public fun challengeWithEmail(
         email: String,
         connection: String,
@@ -143,6 +144,7 @@ public class PasswordlessClient @VisibleForTesting(otherwise = VisibleForTesting
      * @return a request that, when started, yields a [PasswordlessChallenge] containing the `auth_session`.
      * @see loginWithOTP
      */
+    @JvmOverloads
     public fun challengeWithPhoneNumber(
         phoneNumber: String,
         connection: String,

--- a/auth0/src/main/java/com/auth0/android/authentication/passwordless/PasswordlessClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/passwordless/PasswordlessClient.kt
@@ -82,7 +82,7 @@ public class PasswordlessClient @VisibleForTesting(otherwise = VisibleForTesting
      * passwordless.challengeWithEmail("user@example.com", "Username-Password-Authentication")
      *     .start(object : Callback<PasswordlessChallenge, AuthenticationException> {
      *         override fun onSuccess(result: PasswordlessChallenge) {
-     *             val authSession = result.authSession
+     *             val challenge = result
      *         }
      *         override fun onFailure(error: AuthenticationException) { }
      *     })
@@ -133,7 +133,7 @@ public class PasswordlessClient @VisibleForTesting(otherwise = VisibleForTesting
      * passwordless.challengeWithPhoneNumber("+15555550123", "Username-Password-Authentication", DeliveryMethod.TEXT)
      *     .start(object : Callback<PasswordlessChallenge, AuthenticationException> {
      *         override fun onSuccess(result: PasswordlessChallenge) {
-     *             val authSession = result.authSession
+     *             val challenge = result
      *         }
      *         override fun onFailure(error: AuthenticationException) { }
      *     })
@@ -185,21 +185,21 @@ public class PasswordlessClient @VisibleForTesting(otherwise = VisibleForTesting
      * ## Usage
      *
      * ```kotlin
-     * passwordless.loginWithOTP(authSession, "123456")
+     * passwordless.loginWithOTP(challenge, "123456")
      *     .start(object : Callback<Credentials, AuthenticationException> {
      *         override fun onSuccess(result: Credentials) { }
      *         override fun onFailure(error: AuthenticationException) { }
      *     })
      * ```
      *
-     * @param authSession the opaque session token from a prior challenge (see [PasswordlessChallenge.authSession]).
+     * @param passwordlessChallenge the challenge from a prior challenge (see [PasswordlessChallenge]).
      * @param otp the one-time code the user received via email, SMS, or voice call.
      * @return a request that, when started, yields [Credentials] on success.
      * @see challengeWithEmail
      * @see challengeWithPhoneNumber
      */
     public fun loginWithOTP(
-        authSession: String,
+        passwordlessChallenge: PasswordlessChallenge,
         otp: String
     ): AuthenticationRequest {
         val url = baseURL.toHttpUrl().newBuilder()
@@ -210,7 +210,7 @@ public class PasswordlessClient @VisibleForTesting(otherwise = VisibleForTesting
         val parameters = ParameterBuilder.newAuthenticationBuilder()
             .setClientId(clientId)
             .setGrantType(ParameterBuilder.GRANT_TYPE_PASSWORDLESS_OTP)
-            .set(AUTH_SESSION_KEY, authSession)
+            .set(AUTH_SESSION_KEY, passwordlessChallenge.authSession)
             .set(ONE_TIME_PASSWORD_KEY, otp)
             .asDictionary()
 
@@ -223,7 +223,6 @@ public class PasswordlessClient @VisibleForTesting(otherwise = VisibleForTesting
             addParameters(parameters)
             addValidator(object : RequestValidator {
                 override fun validate(options: RequestOptions) {
-                    requireNotBlank(authSession, AUTH_SESSION_KEY)
                     requireNotBlank(otp, ONE_TIME_PASSWORD_KEY)
                 }
             })

--- a/auth0/src/main/java/com/auth0/android/authentication/passwordless/PasswordlessClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/passwordless/PasswordlessClient.kt
@@ -8,11 +8,13 @@ import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.authentication.ParameterBuilder
 import com.auth0.android.dpop.DPoP
 import com.auth0.android.dpop.DPoPException
+import com.auth0.android.request.AuthenticationRequest
 import com.auth0.android.request.ErrorAdapter
 import com.auth0.android.request.JsonAdapter
 import com.auth0.android.request.Request
 import com.auth0.android.request.RequestOptions
 import com.auth0.android.request.RequestValidator
+import com.auth0.android.request.internal.BaseAuthenticationRequest
 import com.auth0.android.request.internal.GsonAdapter
 import com.auth0.android.request.internal.GsonProvider
 import com.auth0.android.request.internal.RequestFactory
@@ -199,13 +201,13 @@ public class PasswordlessClient @VisibleForTesting(otherwise = VisibleForTesting
     public fun loginWithOTP(
         authSession: String,
         otp: String
-    ): Request<Credentials, AuthenticationException> {
+    ): AuthenticationRequest {
         val url = baseURL.toHttpUrl().newBuilder()
             .addPathSegment(OAUTH_PATH)
             .addPathSegment(TOKEN_PATH)
             .build()
 
-        val parameters = ParameterBuilder.newBuilder()
+        val parameters = ParameterBuilder.newAuthenticationBuilder()
             .setClientId(clientId)
             .setGrantType(ParameterBuilder.GRANT_TYPE_PASSWORDLESS_OTP)
             .set(AUTH_SESSION_KEY, authSession)
@@ -215,14 +217,18 @@ public class PasswordlessClient @VisibleForTesting(otherwise = VisibleForTesting
         val credentialsAdapter: JsonAdapter<Credentials> =
             GsonAdapter(Credentials::class.java, gson)
 
-        return requestFactory.post(url.toString(), credentialsAdapter, dPoP)
-            .addParameters(parameters)
-            .addValidator(object : RequestValidator {
+        val request = BaseAuthenticationRequest(
+            requestFactory.post(url.toString(), credentialsAdapter, dPoP), clientId, baseURL
+        ).apply {
+            addParameters(parameters)
+            addValidator(object : RequestValidator {
                 override fun validate(options: RequestOptions) {
                     requireNotBlank(authSession, AUTH_SESSION_KEY)
                     requireNotBlank(otp, ONE_TIME_PASSWORD_KEY)
                 }
             })
+        }
+        return request
     }
 
     private fun challengeRequest(
@@ -254,7 +260,10 @@ public class PasswordlessClient @VisibleForTesting(otherwise = VisibleForTesting
             ): AuthenticationException = AuthenticationException(bodyText, statusCode)
 
             @Throws(IOException::class)
-            override fun fromJsonResponse(statusCode: Int, reader: Reader): AuthenticationException {
+            override fun fromJsonResponse(
+                statusCode: Int,
+                reader: Reader
+            ): AuthenticationException {
                 val values = mapAdapter.fromJson(reader)
                 return AuthenticationException(values, statusCode)
             }

--- a/auth0/src/main/java/com/auth0/android/authentication/passwordless/PasswordlessClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/passwordless/PasswordlessClient.kt
@@ -1,0 +1,292 @@
+package com.auth0.android.authentication.passwordless
+
+import androidx.annotation.VisibleForTesting
+import com.auth0.android.Auth0
+import com.auth0.android.Auth0Exception
+import com.auth0.android.NetworkErrorException
+import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.ParameterBuilder
+import com.auth0.android.dpop.DPoP
+import com.auth0.android.dpop.DPoPException
+import com.auth0.android.request.ErrorAdapter
+import com.auth0.android.request.JsonAdapter
+import com.auth0.android.request.Request
+import com.auth0.android.request.RequestOptions
+import com.auth0.android.request.RequestValidator
+import com.auth0.android.request.internal.GsonAdapter
+import com.auth0.android.request.internal.GsonProvider
+import com.auth0.android.request.internal.RequestFactory
+import com.auth0.android.request.internal.ResponseUtils.isNetworkError
+import com.auth0.android.result.Credentials
+import com.auth0.android.result.PasswordlessChallenge
+import com.google.gson.Gson
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import java.io.IOException
+import java.io.Reader
+
+/**
+ * API client for the database-connection passwordless authentication flow.
+ *
+ * Obtain an instance from
+ * [com.auth0.android.authentication.AuthenticationAPIClient.passwordlessClient].
+ *
+ * ## Availability
+ *
+ * This feature is currently available in
+ * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
+ * Please reach out to Auth0 support to get it enabled for your tenant.
+ *
+ * @see com.auth0.android.authentication.AuthenticationAPIClient.passwordlessClient
+ */
+public class PasswordlessClient @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) internal constructor(
+    private val auth0: Auth0,
+    private val gson: Gson,
+    private val dPoP: DPoP?
+) {
+
+    private val requestFactory: RequestFactory<AuthenticationException> by lazy {
+        RequestFactory(auth0.networkingClient, createErrorAdapter()).apply {
+            setAuth0ClientInfo(auth0.auth0UserAgent.value)
+        }
+    }
+
+    /**
+     * Creates a new PasswordlessClient instance.
+     *
+     * @param auth0 the Auth0 account information.
+     */
+    public constructor(auth0: Auth0) : this(auth0, GsonProvider.gson, null)
+
+    private val clientId: String = auth0.clientId
+    private val baseURL: String = auth0.getDomainUrl()
+
+    /**
+     * Issues an OTP challenge to an email address for a database connection.
+     *
+     * Sends a one-time code to the given email for a connection that has `email_otp` enabled.
+     * For privacy, the server **always responds successfully regardless of whether the user
+     * exists** (user-enumeration prevention). On success an opaque [PasswordlessChallenge.authSession]
+     * is returned — pass it to [loginWithOTP] together with the code the user receives.
+     *
+     * ## Availability
+     *
+     * This feature is currently available in
+     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
+     * Please reach out to Auth0 support to get it enabled for your tenant.
+     *
+     * ## Usage
+     *
+     * ```kotlin
+     * passwordless.challengeWithEmail("user@example.com", "Username-Password-Authentication")
+     *     .start(object : Callback<PasswordlessChallenge, AuthenticationException> {
+     *         override fun onSuccess(result: PasswordlessChallenge) {
+     *             val authSession = result.authSession
+     *         }
+     *         override fun onFailure(error: AuthenticationException) { }
+     *     })
+     * ```
+     *
+     * @param email the email address to send the one-time code to.
+     * @param connection the name of the database connection; it must have `email_otp` enabled.
+     * @param allowSignup whether to allow sign-up if the user does not yet exist. Defaults to `false`.
+     * @return a request that, when started, yields a [PasswordlessChallenge] containing the `auth_session`.
+     * @see loginWithOTP
+     */
+    public fun challengeWithEmail(
+        email: String,
+        connection: String,
+        allowSignup: Boolean = false
+    ): Request<PasswordlessChallenge, AuthenticationException> {
+        val parameters = ParameterBuilder.newBuilder()
+            .setClientId(clientId)
+            .setConnection(connection)
+            .set(ALLOW_SIGNUP_KEY, allowSignup.toString())
+            .set(EMAIL_KEY, email)
+            .asDictionary()
+        return challengeRequest(parameters).addValidator(object : RequestValidator {
+            override fun validate(options: RequestOptions) {
+                requireNotBlank(email, EMAIL_KEY)
+                requireNotBlank(connection, CONNECTION_KEY)
+            }
+        })
+    }
+
+    /**
+     * Issues an OTP challenge to a phone number for a database connection.
+     *
+     * Sends a one-time code to the given phone number for a connection that has `phone_otp`
+     * enabled, delivered either by SMS or voice call per [deliveryMethod]. For privacy, the server
+     * **always responds successfully regardless of whether the user exists**.
+     *
+     * ## Availability
+     *
+     * This feature is currently available in
+     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
+     * Please reach out to Auth0 support to get it enabled for your tenant.
+     *
+     * ## Usage
+     *
+     * ```kotlin
+     * passwordless.challengeWithPhoneNumber("+15555550123", "Username-Password-Authentication", DeliveryMethod.TEXT)
+     *     .start(object : Callback<PasswordlessChallenge, AuthenticationException> {
+     *         override fun onSuccess(result: PasswordlessChallenge) {
+     *             val authSession = result.authSession
+     *         }
+     *         override fun onFailure(error: AuthenticationException) { }
+     *     })
+     * ```
+     *
+     * @param phoneNumber the E.164 phone number to send the one-time code to (e.g. `"+15555550123"`).
+     * @param connection the name of the database connection; it must have `phone_otp` enabled.
+     * @param deliveryMethod how to deliver the code. Defaults to [DeliveryMethod.TEXT].
+     * @param allowSignup whether to allow sign-up if the user does not yet exist. Defaults to `false`.
+     * @return a request that, when started, yields a [PasswordlessChallenge] containing the `auth_session`.
+     * @see loginWithOTP
+     */
+    public fun challengeWithPhoneNumber(
+        phoneNumber: String,
+        connection: String,
+        deliveryMethod: DeliveryMethod = DeliveryMethod.TEXT,
+        allowSignup: Boolean = false
+    ): Request<PasswordlessChallenge, AuthenticationException> {
+        val parameters = ParameterBuilder.newBuilder()
+            .setClientId(clientId)
+            .setConnection(connection)
+            .set(ALLOW_SIGNUP_KEY, allowSignup.toString())
+            .set(PHONE_NUMBER_KEY, phoneNumber)
+            .set(DELIVERY_METHOD_KEY, deliveryMethod.value)
+            .asDictionary()
+        return challengeRequest(parameters).addValidator(object : RequestValidator {
+            override fun validate(options: RequestOptions) {
+                requireNotBlank(phoneNumber, PHONE_NUMBER_KEY)
+                requireNotBlank(connection, CONNECTION_KEY)
+            }
+        })
+    }
+
+    /**
+     * Completes the OTP flow by verifying the one-time code and obtaining credentials.
+     *
+     * Exchanges the opaque `auth_session` returned by [challengeWithEmail] or
+     * [challengeWithPhoneNumber], together with the code the user received, for [Credentials] using
+     * the passwordless OTP grant on `POST /oauth/token`. When DPoP is enabled on the originating
+     * [com.auth0.android.authentication.AuthenticationAPIClient], a DPoP proof is attached.
+     *
+     * ## Availability
+     *
+     * This feature is currently available in
+     * [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
+     * Please reach out to Auth0 support to get it enabled for your tenant.
+     *
+     * ## Usage
+     *
+     * ```kotlin
+     * passwordless.loginWithOTP(authSession, "123456")
+     *     .start(object : Callback<Credentials, AuthenticationException> {
+     *         override fun onSuccess(result: Credentials) { }
+     *         override fun onFailure(error: AuthenticationException) { }
+     *     })
+     * ```
+     *
+     * @param authSession the opaque session token from a prior challenge (see [PasswordlessChallenge.authSession]).
+     * @param otp the one-time code the user received via email, SMS, or voice call.
+     * @return a request that, when started, yields [Credentials] on success.
+     * @see challengeWithEmail
+     * @see challengeWithPhoneNumber
+     */
+    public fun loginWithOTP(
+        authSession: String,
+        otp: String
+    ): Request<Credentials, AuthenticationException> {
+        val url = baseURL.toHttpUrl().newBuilder()
+            .addPathSegment(OAUTH_PATH)
+            .addPathSegment(TOKEN_PATH)
+            .build()
+
+        val parameters = ParameterBuilder.newBuilder()
+            .setClientId(clientId)
+            .setGrantType(ParameterBuilder.GRANT_TYPE_PASSWORDLESS_OTP)
+            .set(AUTH_SESSION_KEY, authSession)
+            .set(ONE_TIME_PASSWORD_KEY, otp)
+            .asDictionary()
+
+        val credentialsAdapter: JsonAdapter<Credentials> =
+            GsonAdapter(Credentials::class.java, gson)
+
+        return requestFactory.post(url.toString(), credentialsAdapter, dPoP)
+            .addParameters(parameters)
+            .addValidator(object : RequestValidator {
+                override fun validate(options: RequestOptions) {
+                    requireNotBlank(authSession, AUTH_SESSION_KEY)
+                    requireNotBlank(otp, ONE_TIME_PASSWORD_KEY)
+                }
+            })
+    }
+
+    private fun challengeRequest(
+        parameters: Map<String, String>
+    ): Request<PasswordlessChallenge, AuthenticationException> {
+        val url = baseURL.toHttpUrl().newBuilder()
+            .addPathSegment(OTP_PATH)
+            .addPathSegment(CHALLENGE_PATH)
+            .build()
+
+        val challengeAdapter: JsonAdapter<PasswordlessChallenge> =
+            GsonAdapter(PasswordlessChallenge::class.java, gson)
+
+        return requestFactory.post(url.toString(), challengeAdapter)
+            .addParameters(parameters)
+    }
+
+    private fun requireNotBlank(value: String, name: String) {
+        if (value.isBlank()) {
+            throw AuthenticationException(INVALID_REQUEST, "$name is required")
+        }
+    }
+
+    private fun createErrorAdapter(): ErrorAdapter<AuthenticationException> {
+        val mapAdapter = GsonAdapter.forMap(gson)
+        return object : ErrorAdapter<AuthenticationException> {
+            override fun fromRawResponse(
+                statusCode: Int, bodyText: String, headers: Map<String, List<String>>
+            ): AuthenticationException = AuthenticationException(bodyText, statusCode)
+
+            @Throws(IOException::class)
+            override fun fromJsonResponse(statusCode: Int, reader: Reader): AuthenticationException {
+                val values = mapAdapter.fromJson(reader)
+                return AuthenticationException(values, statusCode)
+            }
+
+            override fun fromException(cause: Throwable): AuthenticationException {
+                if (isNetworkError(cause)) {
+                    return AuthenticationException(
+                        "Failed to execute the network request", NetworkErrorException(cause)
+                    )
+                }
+                if (cause is DPoPException) {
+                    return AuthenticationException(
+                        cause.message ?: "Error while attaching DPoP proof", cause
+                    )
+                }
+                return AuthenticationException(
+                    "Something went wrong", Auth0Exception("Something went wrong", cause)
+                )
+            }
+        }
+    }
+
+    private companion object {
+        private const val OTP_PATH = "otp"
+        private const val CHALLENGE_PATH = "challenge"
+        private const val OAUTH_PATH = "oauth"
+        private const val TOKEN_PATH = "token"
+        private const val EMAIL_KEY = "email"
+        private const val PHONE_NUMBER_KEY = "phone_number"
+        private const val DELIVERY_METHOD_KEY = "delivery_method"
+        private const val ALLOW_SIGNUP_KEY = "allow_signup"
+        private const val CONNECTION_KEY = "connection"
+        private const val AUTH_SESSION_KEY = "auth_session"
+        private const val ONE_TIME_PASSWORD_KEY = "otp"
+        private const val INVALID_REQUEST = "invalid_request"
+    }
+}

--- a/auth0/src/main/java/com/auth0/android/result/PasswordlessChallenge.kt
+++ b/auth0/src/main/java/com/auth0/android/result/PasswordlessChallenge.kt
@@ -1,0 +1,17 @@
+package com.auth0.android.result
+
+import com.auth0.android.request.internal.JsonRequired
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Result of a passwordless challenge.
+ *
+ * Holds the opaque `auth_session` token returned when a passwordless challenge is issued.
+ *
+ * @see [com.auth0.android.authentication.passwordless.PasswordlessClient.challengeWithEmail]
+ * @see [com.auth0.android.authentication.passwordless.PasswordlessClient.challengeWithPhoneNumber]
+ */
+public class PasswordlessChallenge(
+    @field:JsonRequired @field:SerializedName("auth_session")
+    public val authSession: String
+)

--- a/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/AuthenticationAPIClientTest.kt
@@ -142,6 +142,12 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
+    public fun shouldCreatePasswordlessClient() {
+        val client = AuthenticationAPIClient(Auth0.getInstance(CLIENT_ID, DOMAIN))
+        assertThat(client.passwordlessClient(), Matchers.`is`(Matchers.notNullValue()))
+    }
+
+    @Test
     public fun shouldCreateClientWithContextInfo() {
         val context: Context = mock()
         val resources: Resources = mock()

--- a/auth0/src/test/java/com/auth0/android/authentication/PasswordlessClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/PasswordlessClientTest.kt
@@ -204,7 +204,7 @@ public class PasswordlessClientTest {
             """{"access_token": "$ACCESS_TOKEN", "id_token": "$ID_TOKEN", "token_type": "Bearer", "expires_in": 86400}"""
         )
 
-        passwordlessClient.loginWithOTP("session_abc", "123456").await()
+        passwordlessClient.loginWithOTP(PasswordlessChallenge("session_abc"), "123456").await()
 
         val request = mockServer.takeRequest()
         assertThat(request.path, `is`("/oauth/token"))
@@ -222,7 +222,7 @@ public class PasswordlessClientTest {
             """{"access_token": "$ACCESS_TOKEN", "id_token": "$ID_TOKEN", "token_type": "Bearer", "expires_in": 86400}"""
         )
 
-        val credentials = passwordlessClient.loginWithOTP("session_abc", "123456").await()
+        val credentials = passwordlessClient.loginWithOTP(PasswordlessChallenge("session_abc"), "123456").await()
 
         assertThat(credentials.accessToken, `is`(ACCESS_TOKEN))
     }
@@ -232,25 +232,15 @@ public class PasswordlessClientTest {
         enqueueErrorResponse("invalid_grant", "Invalid or expired code", 403)
 
         val exception = assertThrows(AuthenticationException::class.java) {
-            runTest { passwordlessClient.loginWithOTP("session_abc", "000000").await() }
+            runTest { passwordlessClient.loginWithOTP(PasswordlessChallenge("session_abc"), "000000").await() }
         }
         assertThat(exception.getCode(), `is`("invalid_grant"))
     }
 
     @Test
-    public fun shouldFailLoginWithBlankAuthSessionWithoutNetworkCall() {
-        val exception = assertThrows(AuthenticationException::class.java) {
-            runTest { passwordlessClient.loginWithOTP("", "123456").await() }
-        }
-        assertThat(exception.getCode(), `is`("invalid_request"))
-        assertThat(exception.getDescription(), containsString("auth_session is required"))
-        assertThat(mockServer.requestCount, `is`(0))
-    }
-
-    @Test
     public fun shouldFailLoginWithBlankOtpWithoutNetworkCall() {
         val exception = assertThrows(AuthenticationException::class.java) {
-            runTest { passwordlessClient.loginWithOTP("session_abc", "").await() }
+            runTest { passwordlessClient.loginWithOTP(PasswordlessChallenge("session_abc"), "").await() }
         }
         assertThat(exception.getCode(), `is`("invalid_request"))
         assertThat(exception.getDescription(), containsString("otp is required"))
@@ -266,7 +256,7 @@ public class PasswordlessClientTest {
             """{"access_token": "$ACCESS_TOKEN", "id_token": "$ID_TOKEN", "token_type": "Bearer", "expires_in": 86400}"""
         )
 
-        dpopClient.loginWithOTP("session_abc", "123456").await()
+        dpopClient.loginWithOTP(PasswordlessChallenge("session_abc"), "123456").await()
 
         val request = mockServer.takeRequest()
         assertThat(request.getHeader("DPoP"), `is`(notNullValue()))

--- a/auth0/src/test/java/com/auth0/android/authentication/PasswordlessClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/PasswordlessClientTest.kt
@@ -1,0 +1,294 @@
+package com.auth0.android.authentication
+
+import android.content.Context
+import com.auth0.android.Auth0
+import com.auth0.android.authentication.passwordless.DeliveryMethod
+import com.auth0.android.authentication.passwordless.PasswordlessClient
+import com.auth0.android.dpop.DPoPKeyStore
+import com.auth0.android.dpop.DPoPUtil
+import com.auth0.android.dpop.FakeECPrivateKey
+import com.auth0.android.dpop.FakeECPublicKey
+import com.auth0.android.request.internal.ThreadSwitcherShadow
+import com.auth0.android.result.Credentials
+import com.auth0.android.result.PasswordlessChallenge
+import com.auth0.android.util.SSLTestUtils
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.hasEntry
+import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
+import org.junit.After
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ThreadSwitcherShadow::class])
+@OptIn(ExperimentalCoroutinesApi::class)
+public class PasswordlessClientTest {
+
+    private lateinit var mockServer: MockWebServer
+    private lateinit var auth0: Auth0
+    private lateinit var passwordlessClient: PasswordlessClient
+    private lateinit var gson: Gson
+    private lateinit var mockKeyStore: DPoPKeyStore
+    private lateinit var mockContext: Context
+
+    @Before
+    public fun setUp() {
+        mockServer = SSLTestUtils.createMockWebServer()
+        mockServer.start()
+        val domain = mockServer.url("/").toString()
+        auth0 = Auth0.getInstance(CLIENT_ID, domain, domain)
+        auth0.networkingClient = SSLTestUtils.testClient
+        passwordlessClient = PasswordlessClient(auth0)
+        gson = GsonBuilder().serializeNulls().create()
+        mockKeyStore = mock()
+        mockContext = mock()
+        whenever(mockContext.applicationContext).thenReturn(mockContext)
+        DPoPUtil.keyStore = mockKeyStore
+    }
+
+    @After
+    public fun tearDown() {
+        mockServer.shutdown()
+    }
+
+    private fun enqueueMockResponse(json: String, statusCode: Int = 200) {
+        mockServer.enqueue(
+            MockResponse()
+                .setResponseCode(statusCode)
+                .addHeader("Content-Type", "application/json")
+                .setBody(json)
+        )
+    }
+
+    private fun enqueueErrorResponse(error: String, description: String, statusCode: Int = 400) {
+        enqueueMockResponse("""{"error": "$error", "error_description": "$description"}""", statusCode)
+    }
+
+    private inline fun <reified T> bodyFromRequest(request: RecordedRequest): Map<String, T> {
+        val mapType = object : TypeToken<Map<String, T>>() {}.type
+        return gson.fromJson(request.body.readUtf8(), mapType)
+    }
+
+    @Test
+    public fun shouldCreateClient() {
+        assertThat(PasswordlessClient(auth0), `is`(notNullValue()))
+    }
+
+    @Test
+    public fun shouldChallengeWithEmailHitOtpChallengeWithCorrectParams(): Unit = runTest {
+        enqueueMockResponse("""{"auth_session": "session_abc"}""")
+
+        val challenge = passwordlessClient
+            .challengeWithEmail("user@example.com", CONNECTION, allowSignup = true)
+            .await()
+
+        val request = mockServer.takeRequest()
+        assertThat(request.path, `is`("/otp/challenge"))
+        assertThat(request.method, `is`("POST"))
+        val body = bodyFromRequest<String>(request)
+        assertThat(body, hasEntry("client_id", CLIENT_ID))
+        assertThat(body, hasEntry("connection", CONNECTION))
+        assertThat(body, hasEntry("email", "user@example.com"))
+        assertThat(body, hasEntry("allow_signup", "true"))
+        assertThat(challenge.authSession, `is`("session_abc"))
+    }
+
+    @Test
+    public fun shouldChallengeWithEmailDefaultAllowSignupFalse(): Unit = runTest {
+        enqueueMockResponse("""{"auth_session": "session_abc"}""")
+
+        passwordlessClient.challengeWithEmail("user@example.com", CONNECTION).await()
+
+        val body = bodyFromRequest<String>(mockServer.takeRequest())
+        assertThat(body, hasEntry("allow_signup", "false"))
+    }
+
+    @Test
+    public fun shouldChallengeWithPhoneNumberHitOtpChallengeWithCorrectParams(): Unit = runTest {
+        enqueueMockResponse("""{"auth_session": "session_abc"}""")
+
+        val challenge = passwordlessClient.challengeWithPhoneNumber(
+            "+15555550123", CONNECTION, DeliveryMethod.VOICE, allowSignup = true
+        ).await()
+
+        val request = mockServer.takeRequest()
+        assertThat(request.path, `is`("/otp/challenge"))
+        val body = bodyFromRequest<String>(request)
+        assertThat(body, hasEntry("client_id", CLIENT_ID))
+        assertThat(body, hasEntry("connection", CONNECTION))
+        assertThat(body, hasEntry("phone_number", "+15555550123"))
+        assertThat(body, hasEntry("delivery_method", "voice"))
+        assertThat(body, hasEntry("allow_signup", "true"))
+        assertThat(challenge.authSession, `is`("session_abc"))
+    }
+
+    @Test
+    public fun shouldChallengeWithPhoneNumberDefaultDeliveryMethodText(): Unit = runTest {
+        enqueueMockResponse("""{"auth_session": "session_abc"}""")
+
+        passwordlessClient.challengeWithPhoneNumber("+15555550123", CONNECTION).await()
+
+        val body = bodyFromRequest<String>(mockServer.takeRequest())
+        assertThat(body, hasEntry("delivery_method", "text"))
+    }
+
+    @Test
+    public fun shouldIncludeAuth0ClientHeaderInChallenge(): Unit = runTest {
+        enqueueMockResponse("""{"auth_session": "session_abc"}""")
+
+        passwordlessClient.challengeWithEmail("user@example.com", CONNECTION).await()
+
+        assertThat(mockServer.takeRequest().getHeader("Auth0-Client"), `is`(notNullValue()))
+    }
+
+    @Test
+    public fun shouldPropagateChallengeApiError() {
+        enqueueErrorResponse("invalid_connection", "Connection does not exist", 400)
+
+        val exception = assertThrows(AuthenticationException::class.java) {
+            runTest { passwordlessClient.challengeWithEmail("user@example.com", CONNECTION).await() }
+        }
+        assertThat(exception.getCode(), `is`("invalid_connection"))
+    }
+
+    @Test
+    public fun shouldFailChallengeWithBlankEmailWithoutNetworkCall() {
+        val exception = assertThrows(AuthenticationException::class.java) {
+            runTest { passwordlessClient.challengeWithEmail("", CONNECTION).await() }
+        }
+        assertThat(exception.getCode(), `is`("invalid_request"))
+        assertThat(exception.getDescription(), containsString("email is required"))
+        assertThat(mockServer.requestCount, `is`(0))
+    }
+
+    @Test
+    public fun shouldFailChallengeWithBlankConnectionWithoutNetworkCall() {
+        val exception = assertThrows(AuthenticationException::class.java) {
+            runTest { passwordlessClient.challengeWithEmail("user@example.com", "").await() }
+        }
+        assertThat(exception.getCode(), `is`("invalid_request"))
+        assertThat(exception.getDescription(), containsString("connection is required"))
+        assertThat(mockServer.requestCount, `is`(0))
+    }
+
+    @Test
+    public fun shouldFailChallengeWithBlankPhoneWithoutNetworkCall() {
+        val exception = assertThrows(AuthenticationException::class.java) {
+            runTest { passwordlessClient.challengeWithPhoneNumber("", CONNECTION).await() }
+        }
+        assertThat(exception.getCode(), `is`("invalid_request"))
+        assertThat(exception.getDescription(), containsString("phone_number is required"))
+        assertThat(mockServer.requestCount, `is`(0))
+    }
+
+    @Test
+    public fun shouldLoginWithOtpHitOauthTokenWithCorrectParams(): Unit = runTest {
+        enqueueMockResponse(
+            """{"access_token": "$ACCESS_TOKEN", "id_token": "$ID_TOKEN", "token_type": "Bearer", "expires_in": 86400}"""
+        )
+
+        passwordlessClient.loginWithOTP("session_abc", "123456").await()
+
+        val request = mockServer.takeRequest()
+        assertThat(request.path, `is`("/oauth/token"))
+        assertThat(request.method, `is`("POST"))
+        val body = bodyFromRequest<String>(request)
+        assertThat(body, hasEntry("client_id", CLIENT_ID))
+        assertThat(body, hasEntry("grant_type", "http://auth0.com/oauth/grant-type/passwordless/otp"))
+        assertThat(body, hasEntry("auth_session", "session_abc"))
+        assertThat(body, hasEntry("otp", "123456"))
+    }
+
+    @Test
+    public fun shouldLoginWithOtpReturnCredentials(): Unit = runTest {
+        enqueueMockResponse(
+            """{"access_token": "$ACCESS_TOKEN", "id_token": "$ID_TOKEN", "token_type": "Bearer", "expires_in": 86400}"""
+        )
+
+        val credentials = passwordlessClient.loginWithOTP("session_abc", "123456").await()
+
+        assertThat(credentials.accessToken, `is`(ACCESS_TOKEN))
+    }
+
+    @Test
+    public fun shouldPropagateLoginWithOtpApiError() {
+        enqueueErrorResponse("invalid_grant", "Invalid or expired code", 403)
+
+        val exception = assertThrows(AuthenticationException::class.java) {
+            runTest { passwordlessClient.loginWithOTP("session_abc", "000000").await() }
+        }
+        assertThat(exception.getCode(), `is`("invalid_grant"))
+    }
+
+    @Test
+    public fun shouldFailLoginWithBlankAuthSessionWithoutNetworkCall() {
+        val exception = assertThrows(AuthenticationException::class.java) {
+            runTest { passwordlessClient.loginWithOTP("", "123456").await() }
+        }
+        assertThat(exception.getCode(), `is`("invalid_request"))
+        assertThat(exception.getDescription(), containsString("auth_session is required"))
+        assertThat(mockServer.requestCount, `is`(0))
+    }
+
+    @Test
+    public fun shouldFailLoginWithBlankOtpWithoutNetworkCall() {
+        val exception = assertThrows(AuthenticationException::class.java) {
+            runTest { passwordlessClient.loginWithOTP("session_abc", "").await() }
+        }
+        assertThat(exception.getCode(), `is`("invalid_request"))
+        assertThat(exception.getDescription(), containsString("otp is required"))
+        assertThat(mockServer.requestCount, `is`(0))
+    }
+
+    @Test
+    public fun shouldAttachDpopHeaderOnLoginWhenDpopEnabled(): Unit = runTest {
+        whenever(mockKeyStore.hasKeyPair()).thenReturn(true)
+        whenever(mockKeyStore.getKeyPair()).thenReturn(Pair(FakeECPrivateKey(), FakeECPublicKey()))
+        val dpopClient = AuthenticationAPIClient(auth0).useDPoP(mockContext).passwordlessClient()
+        enqueueMockResponse(
+            """{"access_token": "$ACCESS_TOKEN", "id_token": "$ID_TOKEN", "token_type": "Bearer", "expires_in": 86400}"""
+        )
+
+        dpopClient.loginWithOTP("session_abc", "123456").await()
+
+        val request = mockServer.takeRequest()
+        assertThat(request.getHeader("DPoP"), `is`(notNullValue()))
+    }
+
+    @Test
+    public fun shouldNotAttachDpopHeaderOnChallengeWhenDpopEnabled(): Unit = runTest {
+        whenever(mockKeyStore.hasKeyPair()).thenReturn(true)
+        whenever(mockKeyStore.getKeyPair()).thenReturn(Pair(FakeECPrivateKey(), FakeECPublicKey()))
+        val dpopClient = AuthenticationAPIClient(auth0).useDPoP(mockContext).passwordlessClient()
+        enqueueMockResponse("""{"auth_session": "session_abc"}""")
+
+        dpopClient.challengeWithEmail("user@example.com", CONNECTION).await()
+
+        val request = mockServer.takeRequest()
+        assertThat(request.getHeader("DPoP"), `is`(nullValue()))
+    }
+
+    private companion object {
+        private const val CLIENT_ID = "CLIENT_ID"
+        private const val CONNECTION = "Username-Password-Authentication"
+        private const val ACCESS_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0In0.sig"
+        private const val ID_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0In0.sig"
+    }
+}


### PR DESCRIPTION
### Changes
  
  Adds support for the database-connection passwordless (OTP) authentication flow via a new `PasswordlessClient`

  This drives a two-step flow against a database connection that has email_otp or phone_otp enabled:

  1. Challenge — `challengeWithEmail(...)` / `challengeWithPhoneNumber(...)` issue a one-time code (`POST /otp/challenge`) and return an opaque `PasswordlessChallenge` containing an auth_session.
  2. Login — `loginWithOTP(authSession, otp)` exchanges the session and code for `Credentials` using the passwordless-OTP grant (`POST /oauth/token`).

  This is distinct from the SDK's existing `/passwordless/start` flow.

  ### What's included
  
  - `PasswordlessClient` — new sub-client obtained from AuthenticationAPIClient.passwordlessClient().
  - `PasswordlessChallenge` — result type wrapping the opaque auth_session.
  - `DeliveryMethod` — TEXT / VOICE enum for phone challenges.
  - `AuthenticationAPIClient.passwordlessClient()` — factory method that forwards the client's private dPoP instance.

  ### Testing

  - PasswordlessClientTest — 17 tests covering challenge request params/defaults, loginWithOTP params and credentials, API error propagation, blank-input validation (no network call), and wire-level DPoP behavior (proof present
  on /oauth/token, absent on /otp/challenge).
  - AuthenticationAPIClientTest — wiring test for passwordlessClient().


### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added passwordless OTP support for database-connection flows, including an API to request OTP challenges (email/phone) and exchange `auth_session` plus OTP for credentials.
  * Added selectable phone delivery method (text/voice).
* **Tests**
  * Added unit/Robolectric tests covering challenge and login requests, input validation, error propagation, and DPoP request behavior.
* **Chores**
  * Updated ignore rules to exclude the `docs/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->