### PR TITLE
Guard against all uncaught exceptions in the serial executor block

### DIFF
--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -325,4 +325,18 @@ public abstract class BaseCredentialsManager internal constructor(
         return "$audience::${sortedScope}"
 
     }
+
+    internal inline fun <T> runCatchingOnExecutor(
+        callback: Callback<T, CredentialsManagerException>,
+        block: () -> Unit
+    ) {
+        try {
+            block()
+        } catch (t: Throwable) {
+            Log.e("BaseCredentialsManager", "Unexpected error in executor block", t)
+            callback.onFailure(
+                CredentialsManagerException(CredentialsManagerException.Code.UNKNOWN_ERROR, t)
+            )
+        }
+    }
 }

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/BaseCredentialsManager.kt
@@ -333,6 +333,9 @@ public abstract class BaseCredentialsManager internal constructor(
         try {
             block()
         } catch (t: Throwable) {
+            if (t is VirtualMachineError || t is ThreadDeath || t is LinkageError) {
+                throw t
+            }
             Log.e("BaseCredentialsManager", "Unexpected error in executor block", t)
             callback.onFailure(
                 CredentialsManagerException(CredentialsManagerException.Code.UNKNOWN_ERROR, t)

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/CredentialsManager.kt
@@ -129,48 +129,39 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
         callback: Callback<SSOCredentials, CredentialsManagerException>
     ) {
         serialExecutor.execute {
-            val refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN)
-            if (refreshToken.isNullOrEmpty()) {
-                callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
-                return@execute
-            }
-
-            val tokenType = storage.retrieveString(KEY_TOKEN_TYPE)
-            validateDPoPState(tokenType)?.let { dpopError ->
-                callback.onFailure(dpopError)
-                return@execute
-            }
-
-            val request = authenticationClient.ssoExchange(refreshToken)
-            try {
-                if (parameters.isNotEmpty()) {
-                    request.addParameters(parameters)
+            runCatchingOnExecutor(callback) {
+                val refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN)
+                if (refreshToken.isNullOrEmpty()) {
+                    callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
+                    return@execute
                 }
-                val sessionTransferCredentials = request.execute()
-                saveSsoCredentials(sessionTransferCredentials)
-                callback.onSuccess(sessionTransferCredentials)
-            } catch (error: AuthenticationException) {
-                val exception = when {
-                    error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
-                    else -> CredentialsManagerException.Code.SSO_EXCHANGE_FAILED
+
+                val tokenType = storage.retrieveString(KEY_TOKEN_TYPE)
+                validateDPoPState(tokenType)?.let { dpopError ->
+                    callback.onFailure(dpopError)
+                    return@execute
                 }
-                callback.onFailure(
-                    CredentialsManagerException(
-                        exception,
-                        error
+
+                val request = authenticationClient.ssoExchange(refreshToken)
+                try {
+                    if (parameters.isNotEmpty()) {
+                        request.addParameters(parameters)
+                    }
+                    val sessionTransferCredentials = request.execute()
+                    saveSsoCredentials(sessionTransferCredentials)
+                    callback.onSuccess(sessionTransferCredentials)
+                } catch (error: AuthenticationException) {
+                    val exception = when {
+                        error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
+                        else -> CredentialsManagerException.Code.SSO_EXCHANGE_FAILED
+                    }
+                    callback.onFailure(
+                        CredentialsManagerException(
+                            exception,
+                            error
+                        )
                     )
-                )
-            } catch (exception: RuntimeException) {
-                Log.e(
-                    TAG,
-                    "Caught unexpected exceptions while fetching sso token ${exception.stackTraceToString()}"
-                )
-                callback.onFailure(
-                    CredentialsManagerException(
-                        CredentialsManagerException.Code.UNKNOWN_ERROR,
-                        exception
-                    )
-                )
+                }
             }
         }
     }
@@ -459,120 +450,108 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
         callback: Callback<Credentials, CredentialsManagerException>
     ) {
         serialExecutor.execute {
-            val accessToken = storage.retrieveString(KEY_ACCESS_TOKEN)
-            val refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN)
-            val idToken = storage.retrieveString(KEY_ID_TOKEN)
-            val tokenType = storage.retrieveString(KEY_TOKEN_TYPE)
-            val expiresAt = storage.retrieveLong(KEY_EXPIRES_AT)
-            val storedScope = storage.retrieveString(KEY_SCOPE)
-            val hasEmptyCredentials =
-                TextUtils.isEmpty(accessToken) && TextUtils.isEmpty(idToken) || expiresAt == null
-            if (hasEmptyCredentials) {
-                callback.onFailure(CredentialsManagerException.NO_CREDENTIALS)
-                return@execute
-            }
-            val willAccessTokenExpire = willExpire(expiresAt!!, minTtl.toLong())
-            val scopeChanged = hasScopeChanged(storedScope, scope)
-            if (!forceRefresh && !willAccessTokenExpire && !scopeChanged) {
-                callback.onSuccess(
-                    recreateCredentials(
-                        idToken.orEmpty(),
-                        accessToken.orEmpty(),
-                        tokenType.orEmpty(),
-                        refreshToken,
-                        Date(expiresAt),
-                        storedScope
-                    )
-                )
-                return@execute
-            }
-            if (refreshToken == null) {
-                callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
-                return@execute
-            }
-            validateDPoPState(tokenType)?.let { dpopError ->
-                callback.onFailure(dpopError)
-                return@execute
-            }
-            val request = authenticationClient.renewAuth(refreshToken)
-            request.addParameters(parameters)
-            if (scope != null) {
-                request.addParameter("scope", scope)
-            }
-
-            for (header in headers) {
-                request.addHeader(header.key, header.value)
-            }
-
-            try {
-                val fresh = request.execute()
-                val expiresAt = fresh.expiresAt.time
-                val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
-                if (willAccessTokenExpire) {
-                    val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000
-                    val wrongTtlException = CredentialsManagerException(
-                        CredentialsManagerException.Code.LARGE_MIN_TTL, String.format(
-                            Locale.getDefault(),
-                            "The lifetime of the renewed Access Token (%d) is less than the minTTL requested (%d). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard, or request a lower minTTL.",
-                            tokenLifetime,
-                            minTtl
-                        )
-                    )
-                    callback.onFailure(wrongTtlException)
+            runCatchingOnExecutor(callback) {
+                val accessToken = storage.retrieveString(KEY_ACCESS_TOKEN)
+                val refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN)
+                val idToken = storage.retrieveString(KEY_ID_TOKEN)
+                val tokenType = storage.retrieveString(KEY_TOKEN_TYPE)
+                val expiresAt = storage.retrieveLong(KEY_EXPIRES_AT)
+                val storedScope = storage.retrieveString(KEY_SCOPE)
+                val hasEmptyCredentials =
+                    TextUtils.isEmpty(accessToken) && TextUtils.isEmpty(idToken) || expiresAt == null
+                if (hasEmptyCredentials) {
+                    callback.onFailure(CredentialsManagerException.NO_CREDENTIALS)
                     return@execute
                 }
+                val willAccessTokenExpire = willExpire(expiresAt!!, minTtl.toLong())
+                val scopeChanged = hasScopeChanged(storedScope, scope)
+                if (!forceRefresh && !willAccessTokenExpire && !scopeChanged) {
+                    callback.onSuccess(
+                        recreateCredentials(
+                            idToken.orEmpty(),
+                            accessToken.orEmpty(),
+                            tokenType.orEmpty(),
+                            refreshToken,
+                            Date(expiresAt),
+                            storedScope
+                        )
+                    )
+                    return@execute
+                }
+                if (refreshToken == null) {
+                    callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
+                    return@execute
+                }
+                validateDPoPState(tokenType)?.let { dpopError ->
+                    callback.onFailure(dpopError)
+                    return@execute
+                }
+                val request = authenticationClient.renewAuth(refreshToken)
+                request.addParameters(parameters)
+                if (scope != null) {
+                    request.addParameter("scope", scope)
+                }
 
-                // non-empty refresh token for refresh token rotation scenarios
-                val updatedRefreshToken =
-                    if (TextUtils.isEmpty(fresh.refreshToken)) refreshToken else fresh.refreshToken
-                val credentials = Credentials(
-                    fresh.idToken,
-                    fresh.accessToken,
-                    fresh.type,
-                    updatedRefreshToken,
-                    fresh.expiresAt,
-                    fresh.scope
-                )
-                saveCredentials(credentials)
-                callback.onSuccess(credentials)
-            } catch (error: AuthenticationException) {
-                if (error.isMultifactorRequired) {
+                for (header in headers) {
+                    request.addHeader(header.key, header.value)
+                }
+
+                try {
+                    val fresh = request.execute()
+                    val expiresAt = fresh.expiresAt.time
+                    val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
+                    if (willAccessTokenExpire) {
+                        val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000
+                        val wrongTtlException = CredentialsManagerException(
+                            CredentialsManagerException.Code.LARGE_MIN_TTL, String.format(
+                                Locale.getDefault(),
+                                "The lifetime of the renewed Access Token (%d) is less than the minTTL requested (%d). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard, or request a lower minTTL.",
+                                tokenLifetime,
+                                minTtl
+                            )
+                        )
+                        callback.onFailure(wrongTtlException)
+                        return@execute
+                    }
+
+                    // non-empty refresh token for refresh token rotation scenarios
+                    val updatedRefreshToken =
+                        if (TextUtils.isEmpty(fresh.refreshToken)) refreshToken else fresh.refreshToken
+                    val credentials = Credentials(
+                        fresh.idToken,
+                        fresh.accessToken,
+                        fresh.type,
+                        updatedRefreshToken,
+                        fresh.expiresAt,
+                        fresh.scope
+                    )
+                    saveCredentials(credentials)
+                    callback.onSuccess(credentials)
+                } catch (error: AuthenticationException) {
+                    if (error.isMultifactorRequired) {
+                        callback.onFailure(
+                            CredentialsManagerException(
+                                CredentialsManagerException.Code.MFA_REQUIRED,
+                                error.message
+                                    ?: "Multi-factor authentication is required to complete the credential renewal.",
+                                error,
+                                error.mfaRequiredErrorPayload
+                            )
+                        )
+                        return@execute
+                    }
+                    val exception = when {
+                        error.isRefreshTokenDeleted || error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
+
+                        error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
+                        else -> CredentialsManagerException.Code.API_ERROR
+                    }
                     callback.onFailure(
                         CredentialsManagerException(
-                            CredentialsManagerException.Code.MFA_REQUIRED,
-                            error.message
-                                ?: "Multi-factor authentication is required to complete the credential renewal.",
-                            error,
-                            error.mfaRequiredErrorPayload
+                            exception, error
                         )
                     )
-                    return@execute
                 }
-                val exception = when {
-                    error.isRefreshTokenDeleted || error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
-
-                    error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
-                    else -> CredentialsManagerException.Code.API_ERROR
-                }
-                callback.onFailure(
-                    CredentialsManagerException(
-                        exception, error
-                    )
-                )
-            } catch (exception: RuntimeException) {
-                /**
-                 *  Catching any unexpected runtime errors in the token renewal flow
-                 */
-                Log.e(
-                    TAG,
-                    "Caught unexpected exceptions for token renewal ${exception.stackTraceToString()}"
-                )
-                callback.onFailure(
-                    CredentialsManagerException(
-                        CredentialsManagerException.Code.UNKNOWN_ERROR,
-                        exception
-                    )
-                )
             }
         }
     }
@@ -602,97 +581,99 @@ public class CredentialsManager @VisibleForTesting(otherwise = VisibleForTesting
     ) {
 
         serialExecutor.execute {
-            //Check if existing api credentials are present and valid
-            val key = getAPICredentialsKey(audience, scope)
-            val apiCredentialsJson = storage.retrieveString(key)
-            var apiCredentialType: String? = null
-            apiCredentialsJson?.let {
-                val apiCredentials = gson.fromJson(it, APICredentials::class.java)
-                apiCredentialType = apiCredentials.type
-                val willTokenExpire = willExpire(apiCredentials.expiresAt.time, minTtl.toLong())
+            runCatchingOnExecutor(callback) {
+                //Check if existing api credentials are present and valid
+                val key = getAPICredentialsKey(audience, scope)
+                val apiCredentialsJson = storage.retrieveString(key)
+                var apiCredentialType: String? = null
+                apiCredentialsJson?.let {
+                    val apiCredentials = gson.fromJson(it, APICredentials::class.java)
+                    apiCredentialType = apiCredentials.type
+                    val willTokenExpire = willExpire(apiCredentials.expiresAt.time, minTtl.toLong())
 
-                val scopeChanged = hasScopeChanged(
-                    apiCredentials.scope,
-                    scope,
-                    ignoreOpenid = scope?.contains("openid") == false
-                )
-
-                val hasExpired = hasExpired(apiCredentials.expiresAt.time)
-
-                if (!hasExpired && !willTokenExpire && !scopeChanged) {
-                    callback.onSuccess(apiCredentials)
-                    return@execute
-                }
-            }
-            //Check if refresh token exists or not
-            val refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN)
-            if (refreshToken == null) {
-                callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
-                return@execute
-            }
-
-            val tokenType = apiCredentialType ?: storage.retrieveString(KEY_TOKEN_TYPE)
-            validateDPoPState(tokenType)?.let { dpopError ->
-                callback.onFailure(dpopError)
-                return@execute
-            }
-
-            val request = authenticationClient.renewAuth(refreshToken, audience, scope)
-            request.addParameters(parameters)
-
-            for (header in headers) {
-                request.addHeader(header.key, header.value)
-            }
-
-            try {
-                val newCredentials = request.execute()
-                val expiresAt = newCredentials.expiresAt.time
-                val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
-                if (willAccessTokenExpire) {
-                    val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000
-                    val wrongTtlException = CredentialsManagerException(
-                        CredentialsManagerException.Code.LARGE_MIN_TTL, String.format(
-                            Locale.getDefault(),
-                            "The lifetime of the renewed Access Token (%d) is less than the minTTL requested (%d). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard, or request a lower minTTL.",
-                            tokenLifetime,
-                            minTtl
-                        )
+                    val scopeChanged = hasScopeChanged(
+                        apiCredentials.scope,
+                        scope,
+                        ignoreOpenid = scope?.contains("openid") == false
                     )
-                    callback.onFailure(wrongTtlException)
+
+                    val hasExpired = hasExpired(apiCredentials.expiresAt.time)
+
+                    if (!hasExpired && !willTokenExpire && !scopeChanged) {
+                        callback.onSuccess(apiCredentials)
+                        return@execute
+                    }
+                }
+                //Check if refresh token exists or not
+                val refreshToken = storage.retrieveString(KEY_REFRESH_TOKEN)
+                if (refreshToken == null) {
+                    callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
                     return@execute
                 }
 
-                // non-empty refresh token for refresh token rotation scenarios
-                val updatedRefreshToken =
-                    if (TextUtils.isEmpty(newCredentials.refreshToken)) refreshToken else newCredentials.refreshToken
-                val newApiCredentials = newCredentials.toAPICredentials()
-                storage.store(KEY_REFRESH_TOKEN, updatedRefreshToken)
-                storage.store(KEY_ID_TOKEN, newCredentials.idToken)
-                saveApiCredentials(newApiCredentials, audience, scope)
-                callback.onSuccess(newApiCredentials)
-            } catch (error: AuthenticationException) {
-                if (error.isMultifactorRequired) {
+                val tokenType = apiCredentialType ?: storage.retrieveString(KEY_TOKEN_TYPE)
+                validateDPoPState(tokenType)?.let { dpopError ->
+                    callback.onFailure(dpopError)
+                    return@execute
+                }
+
+                val request = authenticationClient.renewAuth(refreshToken, audience, scope)
+                request.addParameters(parameters)
+
+                for (header in headers) {
+                    request.addHeader(header.key, header.value)
+                }
+
+                try {
+                    val newCredentials = request.execute()
+                    val expiresAt = newCredentials.expiresAt.time
+                    val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
+                    if (willAccessTokenExpire) {
+                        val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000
+                        val wrongTtlException = CredentialsManagerException(
+                            CredentialsManagerException.Code.LARGE_MIN_TTL, String.format(
+                                Locale.getDefault(),
+                                "The lifetime of the renewed Access Token (%d) is less than the minTTL requested (%d). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard, or request a lower minTTL.",
+                                tokenLifetime,
+                                minTtl
+                            )
+                        )
+                        callback.onFailure(wrongTtlException)
+                        return@execute
+                    }
+
+                    // non-empty refresh token for refresh token rotation scenarios
+                    val updatedRefreshToken =
+                        if (TextUtils.isEmpty(newCredentials.refreshToken)) refreshToken else newCredentials.refreshToken
+                    val newApiCredentials = newCredentials.toAPICredentials()
+                    storage.store(KEY_REFRESH_TOKEN, updatedRefreshToken)
+                    storage.store(KEY_ID_TOKEN, newCredentials.idToken)
+                    saveApiCredentials(newApiCredentials, audience, scope)
+                    callback.onSuccess(newApiCredentials)
+                } catch (error: AuthenticationException) {
+                    if (error.isMultifactorRequired) {
+                        callback.onFailure(
+                            CredentialsManagerException(
+                                CredentialsManagerException.Code.MFA_REQUIRED,
+                                error.message
+                                    ?: "Multi-factor authentication is required to complete the credential renewal.",
+                                error,
+                                error.mfaRequiredErrorPayload
+                            )
+                        )
+                        return@execute
+                    }
+                    val exception = when {
+                        error.isRefreshTokenDeleted || error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
+                        error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
+                        else -> CredentialsManagerException.Code.API_ERROR
+                    }
                     callback.onFailure(
                         CredentialsManagerException(
-                            CredentialsManagerException.Code.MFA_REQUIRED,
-                            error.message
-                                ?: "Multi-factor authentication is required to complete the credential renewal.",
-                            error,
-                            error.mfaRequiredErrorPayload
+                            exception, error
                         )
                     )
-                    return@execute
                 }
-                val exception = when {
-                    error.isRefreshTokenDeleted || error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
-                    error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
-                    else -> CredentialsManagerException.Code.API_ERROR
-                }
-                callback.onFailure(
-                    CredentialsManagerException(
-                        exception, error
-                    )
-                )
             }
         }
 

--- a/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt
@@ -223,59 +223,50 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         callback: Callback<SSOCredentials, CredentialsManagerException>
     ) {
         serialExecutor.execute {
-            val existingCredentials: Credentials = try {
-                getExistingCredentials()
-            } catch (exception: CredentialsManagerException) {
-                Log.e(TAG, "Error while fetching existing credentials", exception)
-                callback.onFailure(exception)
-                return@execute
-            }
-            if (existingCredentials.refreshToken.isNullOrEmpty()) {
-                callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
-                return@execute
-            }
-
-            val tokenType = storage.retrieveString(KEY_TOKEN_TYPE) ?: existingCredentials.type
-            validateDPoPState(tokenType)?.let { dpopError ->
-                callback.onFailure(dpopError)
-                return@execute
-            }
-
-            val request =
-                authenticationClient.ssoExchange(existingCredentials.refreshToken)
-            try {
-                if (parameters.isNotEmpty()) {
-                    request.addParameters(parameters)
+            runCatchingOnExecutor(callback) {
+                val existingCredentials: Credentials = try {
+                    getExistingCredentials()
+                } catch (exception: CredentialsManagerException) {
+                    Log.e(TAG, "Error while fetching existing credentials", exception)
+                    callback.onFailure(exception)
+                    return@execute
                 }
-                val sessionCredentials = request.execute()
-                saveSsoCredentials(sessionCredentials)
-                callback.onSuccess(sessionCredentials)
-            } catch (error: AuthenticationException) {
-                val exception = when {
-                    error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
-                    else -> CredentialsManagerException.Code.SSO_EXCHANGE_FAILED
+                if (existingCredentials.refreshToken.isNullOrEmpty()) {
+                    callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
+                    return@execute
                 }
-                callback.onFailure(
-                    CredentialsManagerException(
-                        exception, error
+
+                val tokenType = storage.retrieveString(KEY_TOKEN_TYPE) ?: existingCredentials.type
+                validateDPoPState(tokenType)?.let { dpopError ->
+                    callback.onFailure(dpopError)
+                    return@execute
+                }
+
+                val request =
+                    authenticationClient.ssoExchange(existingCredentials.refreshToken)
+                try {
+                    if (parameters.isNotEmpty()) {
+                        request.addParameters(parameters)
+                    }
+                    val sessionCredentials = request.execute()
+                    saveSsoCredentials(sessionCredentials)
+                    callback.onSuccess(sessionCredentials)
+                } catch (error: AuthenticationException) {
+                    val exception = when {
+                        error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
+                        else -> CredentialsManagerException.Code.SSO_EXCHANGE_FAILED
+                    }
+                    callback.onFailure(
+                        CredentialsManagerException(
+                            exception, error
+                        )
                     )
-                )
-            } catch (error: CredentialsManagerException) {
-                val exception = CredentialsManagerException(
-                    CredentialsManagerException.Code.STORE_FAILED, error
-                )
-                callback.onFailure(exception)
-            } catch (exception: RuntimeException) {
-                Log.e(
-                    TAG,
-                    "Caught unexpected exceptions while fetching sso token ${exception.stackTraceToString()}"
-                )
-                callback.onFailure(
-                    CredentialsManagerException(
-                        CredentialsManagerException.Code.UNKNOWN_ERROR,
-                        exception
+                } catch (error: CredentialsManagerException) {
+                    val exception = CredentialsManagerException(
+                        CredentialsManagerException.Code.STORE_FAILED, error
                     )
-                )
+                    callback.onFailure(exception)
+                }
             }
         }
     }
@@ -763,163 +754,150 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         callback: Callback<Credentials, CredentialsManagerException>
     ) {
         serialExecutor.execute {
-            val encryptedEncoded = storage.retrieveString(KEY_CREDENTIALS)
-            if (encryptedEncoded.isNullOrBlank()) {
-                callback.onFailure(CredentialsManagerException.NO_CREDENTIALS)
-                return@execute
-            }
-            val encrypted = Base64.decode(encryptedEncoded, Base64.DEFAULT)
-            val json: String
-            try {
-                json = String(crypto.decrypt(encrypted))
-            } catch (e: IncompatibleDeviceException) {
-                callback.onFailure(
-                    CredentialsManagerException(
-                        CredentialsManagerException.Code.INCOMPATIBLE_DEVICE, e
-                    )
-                )
-                return@execute
-            } catch (e: CryptoException) {
-                //If keys were invalidated, existing credentials will not be recoverable.
-                clearCredentials()
-                callback.onFailure(
-                    CredentialsManagerException(
-                        CredentialsManagerException.Code.CRYPTO_EXCEPTION, e
-                    )
-                )
-                return@execute
-            }
-            val bridgeCredentials = gson.fromJson(json, OptionalCredentials::class.java)/* OPTIONAL CREDENTIALS
-             * This bridge is required to prevent users from being logged out when
-             * migrating from Credentials with optional Access Token and ID token
-             */
-            val credentials = Credentials(
-                bridgeCredentials.idToken.orEmpty(),
-                bridgeCredentials.accessToken.orEmpty(),
-                bridgeCredentials.type.orEmpty(),
-                bridgeCredentials.refreshToken,
-                bridgeCredentials.expiresAt ?: Date(),
-                bridgeCredentials.scope
-            )
-            val expiresAt = credentials.expiresAt.time
-            val hasEmptyCredentials =
-                TextUtils.isEmpty(credentials.accessToken) && TextUtils.isEmpty(credentials.idToken)
-            if (hasEmptyCredentials) {
-                callback.onFailure(CredentialsManagerException.NO_CREDENTIALS)
-                return@execute
-            }
-            val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
-            val scopeChanged = hasScopeChanged(credentials.scope, scope)
-            if (!forceRefresh && !willAccessTokenExpire && !scopeChanged) {
-                callback.onSuccess(credentials)
-                return@execute
-            }
-            if (credentials.refreshToken == null) {
-                callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
-                return@execute
-            }
-            val tokenType = storage.retrieveString(KEY_TOKEN_TYPE) ?: credentials.type
-            validateDPoPState(tokenType)?.let { dpopError ->
-                callback.onFailure(dpopError)
-                return@execute
-            }
-            Log.d(TAG, "Credentials have expired. Renewing them now...")
-            val request = authenticationClient.renewAuth(
-                credentials.refreshToken
-            )
-
-            request.addParameters(parameters)
-            if (scope != null) {
-                request.addParameter("scope", scope)
-            }
-
-            for (header in headers) {
-                request.addHeader(header.key, header.value)
-            }
-
-            val freshCredentials: Credentials
-            try {
-                val fresh = request.execute()
-                val expiresAt = fresh.expiresAt.time
-                val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
-                if (willAccessTokenExpire) {
-                    val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000
-                    val wrongTtlException = CredentialsManagerException(
-                        CredentialsManagerException.Code.LARGE_MIN_TTL, String.format(
-                            Locale.getDefault(),
-                            "The lifetime of the renewed Access Token (%d) is less than the minTTL requested (%d). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard, or request a lower minTTL.",
-                            tokenLifetime,
-                            minTtl
-                        )
-                    )
-                    callback.onFailure(wrongTtlException)
+            runCatchingOnExecutor(callback) {
+                val encryptedEncoded = storage.retrieveString(KEY_CREDENTIALS)
+                if (encryptedEncoded.isNullOrBlank()) {
+                    callback.onFailure(CredentialsManagerException.NO_CREDENTIALS)
                     return@execute
                 }
-
-                //non-empty refresh token for refresh token rotation scenarios
-                val updatedRefreshToken =
-                    if (TextUtils.isEmpty(fresh.refreshToken)) credentials.refreshToken else fresh.refreshToken
-                freshCredentials = Credentials(
-                    fresh.idToken,
-                    fresh.accessToken,
-                    fresh.type,
-                    updatedRefreshToken,
-                    fresh.expiresAt,
-                    fresh.scope
-                )
-            } catch (error: AuthenticationException) {
-                if (error.isMultifactorRequired) {
+                val encrypted = Base64.decode(encryptedEncoded, Base64.DEFAULT)
+                val json: String
+                try {
+                    json = String(crypto.decrypt(encrypted))
+                } catch (e: IncompatibleDeviceException) {
                     callback.onFailure(
                         CredentialsManagerException(
-                            CredentialsManagerException.Code.MFA_REQUIRED,
-                            error.message
-                                ?: "Multi-factor authentication is required to complete the credential renewal.",
-                            error,
-                            error.mfaRequiredErrorPayload
+                            CredentialsManagerException.Code.INCOMPATIBLE_DEVICE, e
+                        )
+                    )
+                    return@execute
+                } catch (e: CryptoException) {
+                    //If keys were invalidated, existing credentials will not be recoverable.
+                    clearCredentials()
+                    callback.onFailure(
+                        CredentialsManagerException(
+                            CredentialsManagerException.Code.CRYPTO_EXCEPTION, e
                         )
                     )
                     return@execute
                 }
-                val exception = when {
-                    error.isRefreshTokenDeleted || error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
-
-                    error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
-                    else -> CredentialsManagerException.Code.API_ERROR
-                }
-                callback.onFailure(
-                    CredentialsManagerException(
-                        exception, error
-                    )
-                )
-                return@execute
-            } catch (exception: RuntimeException) {
-                /**
-                 *  Catching any unexpected runtime errors in the token renewal flow
+                val bridgeCredentials = gson.fromJson(json, OptionalCredentials::class.java)/* OPTIONAL CREDENTIALS
+                 * This bridge is required to prevent users from being logged out when
+                 * migrating from Credentials with optional Access Token and ID token
                  */
-                Log.e(
-                    TAG,
-                    "Caught unexpected exceptions for token renewal ${exception.stackTraceToString()}"
+                val credentials = Credentials(
+                    bridgeCredentials.idToken.orEmpty(),
+                    bridgeCredentials.accessToken.orEmpty(),
+                    bridgeCredentials.type.orEmpty(),
+                    bridgeCredentials.refreshToken,
+                    bridgeCredentials.expiresAt ?: Date(),
+                    bridgeCredentials.scope
                 )
-                callback.onFailure(
-                    CredentialsManagerException(
-                        CredentialsManagerException.Code.UNKNOWN_ERROR,
-                        exception
-                    )
-                )
-                return@execute
-            }
-
-            try {
-                saveCredentials(freshCredentials)
-                callback.onSuccess(freshCredentials)
-            } catch (error: CredentialsManagerException) {
-                val exception = CredentialsManagerException(
-                    CredentialsManagerException.Code.STORE_FAILED, error
-                )
-                if (error.cause is IncompatibleDeviceException || error.cause is CryptoException) {
-                    exception.refreshedCredentials = freshCredentials
+                val expiresAt = credentials.expiresAt.time
+                val hasEmptyCredentials =
+                    TextUtils.isEmpty(credentials.accessToken) && TextUtils.isEmpty(credentials.idToken)
+                if (hasEmptyCredentials) {
+                    callback.onFailure(CredentialsManagerException.NO_CREDENTIALS)
+                    return@execute
                 }
-                callback.onFailure(exception)
+                val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
+                val scopeChanged = hasScopeChanged(credentials.scope, scope)
+                if (!forceRefresh && !willAccessTokenExpire && !scopeChanged) {
+                    callback.onSuccess(credentials)
+                    return@execute
+                }
+                if (credentials.refreshToken == null) {
+                    callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
+                    return@execute
+                }
+                val tokenType = storage.retrieveString(KEY_TOKEN_TYPE) ?: credentials.type
+                validateDPoPState(tokenType)?.let { dpopError ->
+                    callback.onFailure(dpopError)
+                    return@execute
+                }
+                Log.d(TAG, "Credentials have expired. Renewing them now...")
+                val request = authenticationClient.renewAuth(
+                    credentials.refreshToken
+                )
+
+                request.addParameters(parameters)
+                if (scope != null) {
+                    request.addParameter("scope", scope)
+                }
+
+                for (header in headers) {
+                    request.addHeader(header.key, header.value)
+                }
+
+                val freshCredentials: Credentials
+                try {
+                    val fresh = request.execute()
+                    val expiresAt = fresh.expiresAt.time
+                    val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
+                    if (willAccessTokenExpire) {
+                        val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000
+                        val wrongTtlException = CredentialsManagerException(
+                            CredentialsManagerException.Code.LARGE_MIN_TTL, String.format(
+                                Locale.getDefault(),
+                                "The lifetime of the renewed Access Token (%d) is less than the minTTL requested (%d). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard, or request a lower minTTL.",
+                                tokenLifetime,
+                                minTtl
+                            )
+                        )
+                        callback.onFailure(wrongTtlException)
+                        return@execute
+                    }
+
+                    //non-empty refresh token for refresh token rotation scenarios
+                    val updatedRefreshToken =
+                        if (TextUtils.isEmpty(fresh.refreshToken)) credentials.refreshToken else fresh.refreshToken
+                    freshCredentials = Credentials(
+                        fresh.idToken,
+                        fresh.accessToken,
+                        fresh.type,
+                        updatedRefreshToken,
+                        fresh.expiresAt,
+                        fresh.scope
+                    )
+                } catch (error: AuthenticationException) {
+                    if (error.isMultifactorRequired) {
+                        callback.onFailure(
+                            CredentialsManagerException(
+                                CredentialsManagerException.Code.MFA_REQUIRED,
+                                error.message
+                                    ?: "Multi-factor authentication is required to complete the credential renewal.",
+                                error,
+                                error.mfaRequiredErrorPayload
+                            )
+                        )
+                        return@execute
+                    }
+                    val exception = when {
+                        error.isRefreshTokenDeleted || error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
+
+                        error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
+                        else -> CredentialsManagerException.Code.API_ERROR
+                    }
+                    callback.onFailure(
+                        CredentialsManagerException(
+                            exception, error
+                        )
+                    )
+                    return@execute
+                }
+
+                try {
+                    saveCredentials(freshCredentials)
+                    callback.onSuccess(freshCredentials)
+                } catch (error: CredentialsManagerException) {
+                    val exception = CredentialsManagerException(
+                        CredentialsManagerException.Code.STORE_FAILED, error
+                    )
+                    if (error.cause is IncompatibleDeviceException || error.cause is CryptoException) {
+                        exception.refreshedCredentials = freshCredentials
+                    }
+                    callback.onFailure(exception)
+                }
             }
         }
     }
@@ -935,131 +913,140 @@ public class SecureCredentialsManager @VisibleForTesting(otherwise = VisibleForT
         callback: Callback<APICredentials, CredentialsManagerException>
     ) {
         serialExecutor.execute {
-            val encryptedEncodedJson = storage.retrieveString(getAPICredentialsKey(audience, scope))
-            //Check if existing api credentials are present and valid
+            runCatchingOnExecutor(callback) {
+                val encryptedEncodedJson = storage.retrieveString(getAPICredentialsKey(audience, scope))
+                //Check if existing api credentials are present and valid
 
-            var apiCredentialType: String? = null
-            encryptedEncodedJson?.let { encryptedEncoded ->
-                val encrypted = Base64.decode(encryptedEncoded, Base64.DEFAULT)
-                val json: String = try {
-                    String(crypto.decrypt(encrypted))
-                } catch (e: IncompatibleDeviceException) {
+                var apiCredentialType: String? = null
+                encryptedEncodedJson?.let { encryptedEncoded ->
+                    val encrypted = Base64.decode(encryptedEncoded, Base64.DEFAULT)
+                    val json: String = try {
+                        String(crypto.decrypt(encrypted))
+                    } catch (e: IncompatibleDeviceException) {
+                        callback.onFailure(
+                            CredentialsManagerException(
+                                CredentialsManagerException.Code.INCOMPATIBLE_DEVICE,
+                                e
+                            )
+                        )
+                        return@execute
+                    } catch (e: CryptoException) {
+                        clearApiCredentials(audience, scope)
+                        callback.onFailure(
+                            CredentialsManagerException(
+                                CredentialsManagerException.Code.CRYPTO_EXCEPTION,
+                                e
+                            )
+                        )
+                        return@execute
+                    }
+
+                    val apiCredentials = gson.fromJson(json, APICredentials::class.java)
+                    apiCredentialType = apiCredentials.type
+
+                    val expiresAt = apiCredentials.expiresAt.time
+                    val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
+                    val scopeChanged = hasScopeChanged(
+                        apiCredentials.scope, scope,
+                        ignoreOpenid = scope?.contains("openid") == false
+                    )
+                    val hasExpired = hasExpired(apiCredentials.expiresAt.time)
+                    if (!hasExpired && !willAccessTokenExpire && !scopeChanged) {
+                        callback.onSuccess(apiCredentials)
+                        return@execute
+                    }
+                }
+
+                //Check if refresh token exists or not
+                val existingCredentials: Credentials = try {
+                    getExistingCredentials()
+                } catch (exception: CredentialsManagerException) {
+                    callback.onFailure(exception)
+                    return@execute
+                }
+                val refreshToken = existingCredentials.refreshToken
+                if (refreshToken == null) {
+                    callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
+                    return@execute
+                }
+
+                val tokenType = apiCredentialType ?: storage.retrieveString(KEY_TOKEN_TYPE)
+                ?: existingCredentials.type
+                validateDPoPState(tokenType)?.let { dpopError ->
+                    callback.onFailure(dpopError)
+                    return@execute
+                }
+
+                val request = authenticationClient.renewAuth(refreshToken, audience, scope)
+                request.addParameters(parameters)
+                for (header in headers) {
+                    request.addHeader(header.key, header.value)
+                }
+
+                val newApiCredentials: APICredentials
+                try {
+                    val newCredentials = request.execute()
+                    val expiresAt = newCredentials.expiresAt.time
+                    val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
+                    if (willAccessTokenExpire) {
+                        val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000
+                        val wrongTtlException = CredentialsManagerException(
+                            CredentialsManagerException.Code.LARGE_MIN_TTL, String.format(
+                                Locale.getDefault(),
+                                "The lifetime of the renewed Access Token (%d) is less than the minTTL requested (%d). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard, or request a lower minTTL.",
+                                tokenLifetime,
+                                minTtl
+                            )
+                        )
+                        callback.onFailure(wrongTtlException)
+                        return@execute
+                    }
+
+                    // non-empty refresh token for refresh token rotation scenarios
+                    val updatedRefreshToken =
+                        if (TextUtils.isEmpty(newCredentials.refreshToken)) refreshToken else newCredentials.refreshToken
+                    newApiCredentials = newCredentials.toAPICredentials()
+                    saveCredentials(
+                        existingCredentials.copy(
+                            refreshToken = updatedRefreshToken,
+                            idToken = newCredentials.idToken
+                        )
+                    )
+                    saveApiCredentials(newApiCredentials, audience, scope)
+                } catch (error: AuthenticationException) {
+                    if (error.isMultifactorRequired) {
+                        callback.onFailure(
+                            CredentialsManagerException(
+                                CredentialsManagerException.Code.MFA_REQUIRED,
+                                error.message
+                                    ?: "Multi-factor authentication is required to complete the credential renewal.",
+                                error,
+                                error.mfaRequiredErrorPayload
+                            )
+                        )
+                        return@execute
+                    }
+                    val exception = when {
+                        error.isRefreshTokenDeleted || error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
+                        error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
+                        else -> CredentialsManagerException.Code.API_ERROR
+                    }
                     callback.onFailure(
                         CredentialsManagerException(
-                            CredentialsManagerException.Code.INCOMPATIBLE_DEVICE,
-                            e
+                            exception, error
                         )
                     )
                     return@execute
-                } catch (e: CryptoException) {
-                    clearApiCredentials(audience, scope)
-                    callback.onFailure(
-                        CredentialsManagerException(
-                            CredentialsManagerException.Code.CRYPTO_EXCEPTION,
-                            e
-                        )
+                } catch (error: CredentialsManagerException) {
+                    val storeException = CredentialsManagerException(
+                        CredentialsManagerException.Code.STORE_FAILED, error
                     )
+                    callback.onFailure(storeException)
                     return@execute
                 }
 
-                val apiCredentials = gson.fromJson(json, APICredentials::class.java)
-                apiCredentialType = apiCredentials.type
-
-                val expiresAt = apiCredentials.expiresAt.time
-                val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
-                val scopeChanged = hasScopeChanged(
-                    apiCredentials.scope, scope,
-                    ignoreOpenid = scope?.contains("openid") == false
-                )
-                val hasExpired = hasExpired(apiCredentials.expiresAt.time)
-                if (!hasExpired && !willAccessTokenExpire && !scopeChanged) {
-                    callback.onSuccess(apiCredentials)
-                    return@execute
-                }
-            }
-
-            //Check if refresh token exists or not
-            val existingCredentials: Credentials = try {
-                getExistingCredentials()
-            } catch (exception: CredentialsManagerException) {
-                callback.onFailure(exception)
-                return@execute
-            }
-            val refreshToken = existingCredentials.refreshToken
-            if (refreshToken == null) {
-                callback.onFailure(CredentialsManagerException.NO_REFRESH_TOKEN)
-                return@execute
-            }
-
-            val tokenType = apiCredentialType ?: storage.retrieveString(KEY_TOKEN_TYPE)
-            ?: existingCredentials.type
-            validateDPoPState(tokenType)?.let { dpopError ->
-                callback.onFailure(dpopError)
-                return@execute
-            }
-
-            val request = authenticationClient.renewAuth(refreshToken, audience, scope)
-            request.addParameters(parameters)
-            for (header in headers) {
-                request.addHeader(header.key, header.value)
-            }
-
-            try {
-                val newCredentials = request.execute()
-                val expiresAt = newCredentials.expiresAt.time
-                val willAccessTokenExpire = willExpire(expiresAt, minTtl.toLong())
-                if (willAccessTokenExpire) {
-                    val tokenLifetime = (expiresAt - currentTimeInMillis - minTtl * 1000) / -1000
-                    val wrongTtlException = CredentialsManagerException(
-                        CredentialsManagerException.Code.LARGE_MIN_TTL, String.format(
-                            Locale.getDefault(),
-                            "The lifetime of the renewed Access Token (%d) is less than the minTTL requested (%d). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard, or request a lower minTTL.",
-                            tokenLifetime,
-                            minTtl
-                        )
-                    )
-                    callback.onFailure(wrongTtlException)
-                    return@execute
-                }
-
-                // non-empty refresh token for refresh token rotation scenarios
-                val updatedRefreshToken =
-                    if (TextUtils.isEmpty(newCredentials.refreshToken)) refreshToken else newCredentials.refreshToken
-                val newApiCredentials = newCredentials.toAPICredentials()
-                saveCredentials(
-                    existingCredentials.copy(
-                        refreshToken = updatedRefreshToken,
-                        idToken = newCredentials.idToken
-                    )
-                )
-                saveApiCredentials(newApiCredentials, audience, scope)
                 callback.onSuccess(newApiCredentials)
-
-            } catch (error: AuthenticationException) {
-                if (error.isMultifactorRequired) {
-                    callback.onFailure(
-                        CredentialsManagerException(
-                            CredentialsManagerException.Code.MFA_REQUIRED,
-                            error.message
-                                ?: "Multi-factor authentication is required to complete the credential renewal.",
-                            error,
-                            error.mfaRequiredErrorPayload
-                        )
-                    )
-                    return@execute
-                }
-                val exception = when {
-                    error.isRefreshTokenDeleted || error.isInvalidRefreshToken -> CredentialsManagerException.Code.RENEW_FAILED
-                    error.isNetworkError -> CredentialsManagerException.Code.NO_NETWORK
-                    else -> CredentialsManagerException.Code.API_ERROR
-                }
-                callback.onFailure(
-                    CredentialsManagerException(
-                        exception, error
-                    )
-                )
             }
-
         }
     }
 

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/CredentialsManagerTest.kt
@@ -2551,6 +2551,84 @@ public class CredentialsManagerTest {
         MatcherAssert.assertThat(exception, Is.`is`(CredentialsManagerException.DPOP_KEY_MISSING))
     }
 
+    // Verifies the outer runCatchingOnExecutor safety net in getCredentials.
+    // The IllegalStateException is thrown from storage.retrieveString() which is outside any inner
+    // try/catch block — only the outer catch(Throwable) in runCatchingOnExecutor can handle it.
+    @Test
+    public fun shouldCatchUnexpectedExceptionFromStorageOnGetCredentials() {
+        val error = IllegalStateException("storage corrupted")
+        Mockito.`when`(storage.retrieveString("com.auth0.access_token")).thenThrow(error)
+        manager.getCredentials(callback)
+        verify(callback).onFailure(exceptionCaptor.capture())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception, Is.`is`(CredentialsManagerException.UNKNOWN_ERROR))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(error))
+    }
+
+    // Same as above but via the coroutine path (awaitCredentials -> suspendCancellableCoroutine).
+    // Verifies that the outer catch routes the error through callback.onFailure which then
+    // resumes the continuation with the exception.
+    @Test
+    @ExperimentalCoroutinesApi
+    public fun shouldCatchUnexpectedExceptionFromStorageOnAwaitCredentials(): Unit = runTest {
+        val error = IllegalStateException("storage corrupted")
+        Mockito.`when`(storage.retrieveString("com.auth0.access_token")).thenThrow(error)
+        val exception = assertThrows(CredentialsManagerException::class.java) {
+            runBlocking { manager.awaitCredentials() }
+        }
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception, Is.`is`(CredentialsManagerException.UNKNOWN_ERROR))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(error))
+    }
+
+    // Verifies the outer runCatchingOnExecutor safety net in getSsoCredentials.
+    // The exception is thrown from storage before any inner try/catch is reached.
+    @Test
+    public fun shouldCatchUnexpectedExceptionFromStorageOnGetSsoCredentials() {
+        val error = IllegalStateException("storage corrupted")
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token")).thenThrow(error)
+        manager.getSsoCredentials(ssoCallback)
+        verify(ssoCallback).onFailure(exceptionCaptor.capture())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception, Is.`is`(CredentialsManagerException.UNKNOWN_ERROR))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(error))
+    }
+
+    // Verifies the outer runCatchingOnExecutor safety net in getApiCredentials.
+    // The exception is thrown from storage before any inner try/catch is reached.
+    @Test
+    public fun shouldCatchUnexpectedExceptionFromStorageOnGetApiCredentials() {
+        val error = IllegalStateException("storage corrupted")
+        Mockito.`when`(storage.retrieveString("audience")).thenThrow(error)
+        manager.getApiCredentials("audience", callback = apiCredentialsCallback)
+        verify(apiCredentialsCallback).onFailure(exceptionCaptor.capture())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception, Is.`is`(CredentialsManagerException.UNKNOWN_ERROR))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(error))
+    }
+
+    // Verifies the outer runCatchingOnExecutor safety net during API credential renewal.
+    // NullPointerException from request.execute() is not an AuthenticationException, so it
+    // escapes the inner catch(AuthenticationException) block. Only the outer catch(Throwable)
+    // in runCatchingOnExecutor handles it.
+    @Test
+    public fun shouldCatchUnexpectedExceptionDuringApiCredentialRenewal() {
+        val error = NullPointerException("unexpected null")
+        Mockito.`when`(storage.retrieveString("audience")).thenReturn(null)
+        Mockito.`when`(storage.retrieveString("com.auth0.refresh_token")).thenReturn("refreshToken")
+        Mockito.`when`(client.renewAuth("refreshToken", "audience", null)).thenReturn(request)
+        Mockito.`when`(request.execute()).thenThrow(error)
+        manager.getApiCredentials("audience", callback = apiCredentialsCallback)
+        verify(apiCredentialsCallback).onFailure(exceptionCaptor.capture())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception, Is.`is`(CredentialsManagerException.UNKNOWN_ERROR))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(error))
+    }
+
     @After
     public fun tearDown() {
         DPoPUtil.keyStore = DPoPKeyStore()

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -4168,6 +4168,75 @@ public class SecureCredentialsManagerTest {
         MatcherAssert.assertThat(exception, Is.`is`(CredentialsManagerException.DPOP_KEY_MISSING))
     }
 
+    // Verifies the outer runCatchingOnExecutor safety net in continueGetCredentials.
+    // The IllegalStateException is thrown from storage.retrieveString() which is outside any inner
+    // try/catch block — only the outer catch(Throwable) in runCatchingOnExecutor can handle it.
+    @Test
+    public fun shouldCatchUnexpectedExceptionFromStorageOnGetCredentials() {
+        val error = IllegalStateException("storage corrupted")
+        Mockito.`when`(storage.retrieveString("com.auth0.credentials")).thenThrow(error)
+        manager.continueGetCredentials(null, 0, emptyMap(), emptyMap(), false, callback)
+        verify(callback).onFailure(exceptionCaptor.capture())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception, Is.`is`(CredentialsManagerException.UNKNOWN_ERROR))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(error))
+    }
+
+    // Verifies the outer runCatchingOnExecutor safety net in getSsoCredentials.
+    // The exception is thrown from getExistingCredentials() → storage.retrieveString()
+    // before any inner try/catch is reached.
+    @Test
+    public fun shouldCatchUnexpectedExceptionFromStorageOnGetSsoCredentials() {
+        val error = IllegalStateException("storage corrupted")
+        Mockito.`when`(storage.retrieveString("com.auth0.credentials")).thenThrow(error)
+        manager.getSsoCredentials(ssoCallback)
+        verify(ssoCallback).onFailure(exceptionCaptor.capture())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception, Is.`is`(CredentialsManagerException.UNKNOWN_ERROR))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(error))
+    }
+
+    // Verifies the outer runCatchingOnExecutor safety net in continueGetApiCredentials.
+    // The exception is thrown from storage before any inner try/catch is reached.
+    @Test
+    public fun shouldCatchUnexpectedExceptionFromStorageOnGetApiCredentials() {
+        val error = IllegalStateException("storage corrupted")
+        Mockito.`when`(storage.retrieveString("audience")).thenThrow(error)
+        manager.continueGetApiCredentials("audience", null, 0, emptyMap(), emptyMap(), apiCredentialsCallback)
+        verify(apiCredentialsCallback).onFailure(exceptionCaptor.capture())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception, Is.`is`(CredentialsManagerException.UNKNOWN_ERROR))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(error))
+    }
+
+    // Verifies the outer runCatchingOnExecutor safety net during API credential renewal.
+    // NullPointerException from request.execute() is not an AuthenticationException, so it
+    // escapes the inner catch(AuthenticationException) block. Only the outer catch(Throwable)
+    // in runCatchingOnExecutor handles it.
+    @Test
+    public fun shouldCatchUnexpectedExceptionDuringApiCredentialRenewal() {
+        val error = NullPointerException("unexpected null")
+        Mockito.`when`(storage.retrieveString("audience")).thenReturn(null)
+        insertTestCredentials(
+            hasIdToken = true,
+            hasAccessToken = true,
+            hasRefreshToken = true,
+            willExpireAt = Date(CredentialsMock.ONE_HOUR_AHEAD_MS),
+            scope = "scope"
+        )
+        Mockito.`when`(client.renewAuth("refreshToken", "audience", null)).thenReturn(request)
+        Mockito.`when`(request.execute()).thenThrow(error)
+        manager.continueGetApiCredentials("audience", null, 0, emptyMap(), emptyMap(), apiCredentialsCallback)
+        verify(apiCredentialsCallback).onFailure(exceptionCaptor.capture())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(exception, Is.`is`(CredentialsManagerException.UNKNOWN_ERROR))
+        MatcherAssert.assertThat(exception.cause, Is.`is`(error))
+    }
+
     @After
     public fun tearDown() {
         DPoPUtil.keyStore = DPoPKeyStore()

--- a/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/storage/SecureCredentialsManagerTest.kt
@@ -4237,6 +4237,46 @@ public class SecureCredentialsManagerTest {
         MatcherAssert.assertThat(exception.cause, Is.`is`(error))
     }
 
+    @Test
+    public fun shouldFailWithStoreFailedWhenSavingRenewedApiCredentialsThrows() {
+        Mockito.`when`(storage.retrieveString("audience")).thenReturn(null)
+        val expiresAt = Date(CredentialsMock.ONE_HOUR_AHEAD_MS)
+        insertTestCredentials(
+            hasIdToken = true,
+            hasAccessToken = true,
+            hasRefreshToken = true,
+            willExpireAt = expiresAt,
+            scope = "scope"
+        )
+        Mockito.`when`(
+            client.renewAuth("refreshToken", "audience", "newScope")
+        ).thenReturn(request)
+        val newDate = Date(CredentialsMock.ONE_HOUR_AHEAD_MS + ONE_HOUR_SECONDS * 1000)
+        val jwtMock = mock<Jwt>()
+        Mockito.`when`(jwtMock.expiresAt).thenReturn(newDate)
+        Mockito.`when`(jwtDecoder.decode("newId")).thenReturn(jwtMock)
+
+        // Renewal succeeds but persisting the credentials fails
+        val renewedCredentials =
+            Credentials("newId", "newAccess", "newType", null, newDate, "newScope")
+        Mockito.`when`(request.execute()).thenReturn(renewedCredentials)
+        Mockito.`when`(crypto.encrypt(any()))
+            .thenThrow(CryptoException("CryptoException is thrown"))
+
+        manager.continueGetApiCredentials(
+            "audience", "newScope", 0, emptyMap(), emptyMap(), apiCredentialsCallback
+        )
+
+        verify(apiCredentialsCallback).onFailure(exceptionCaptor.capture())
+        val exception = exceptionCaptor.firstValue
+        MatcherAssert.assertThat(exception, Is.`is`(Matchers.notNullValue()))
+        MatcherAssert.assertThat(
+            exception.message,
+            Is.`is`("An error occurred while saving the refreshed Credentials.")
+        )
+        Mockito.verify(apiCredentialsCallback, Mockito.never()).onSuccess(any())
+    }
+
     @After
     public fun tearDown() {
         DPoPUtil.keyStore = DPoPKeyStore()


### PR DESCRIPTION
## Summary
Ports the serial-executor exception guard (#970) onto the `v4_development` branch as its own feature.

- Adds `runCatchingOnExecutor` helper to `BaseCredentialsManager`, wrapping each `serialExecutor.execute { }` body in a `catch (Throwable) -> onFailure(UNKNOWN_ERROR)` safety net so unexpected errors surface as a failure callback instead of being swallowed on the executor thread.
- Wraps all 3 `CredentialsManager` and all 3 `SecureCredentialsManager` execute blocks; removes the now-redundant trailing `catch (RuntimeException)` blocks while keeping the domain-specific catches (`AuthenticationException`, `CredentialsManagerException`, `IncompatibleDeviceException`, `CryptoException`).
- Brings `SecureCredentialsManager.continueGetApiCredentials` to parity with the other two blocks by mapping a save failure to `STORE_FAILED` (rather than letting it fall through to the new `UNKNOWN_ERROR` net).

This is the v4 port of the change merged to `main` in #970; reconciled onto v4's restructured credentials managers and test imports (`org.mockito.kotlin.*`).

## Test plan
- [x] `./gradlew :auth0:compileDebugKotlin`
- [x] `./gradlew :auth0:testDebugUnitTest` — full suite green
- [x] 5 new tests in `CredentialsManagerTest` (98 total), 4 new in `SecureCredentialsManagerTest` (131 total), 0 failures
- [x] Verified wrap/catch parity against #970 (3+3 execute blocks wrapped, STORE_FAILED 3=3, domain catches match)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential retrieval so unexpected errors are now handled consistently and returned as a standard error response instead of causing unhandled failures.
  * Applied the same safer error handling across sign-in, SSO, and API credential renewal flows.
  * Preserved existing behavior for authentication-specific errors while making runtime failures more predictable.

* **Tests**
  * Added coverage for unexpected storage and renewal failures to verify they surface the expected error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->