### PR TITLE
fix: MFAClient getAuthenticators filtering based on Authenticator.type field

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -560,7 +560,7 @@ authentication
                 requirements?.enroll?.let { enrollTypes ->
                     println("User needs to enroll MFA")
                     println("Available enrollment types: ${enrollTypes.map { it.type }}")
-                    // Example output: ["otp", "sms", "push-notification"]
+                    // Example output: ["otp", "phone", "push-notification"]
                     // Proceed with MFA enrollment using one of these types
                 }
                 
@@ -568,7 +568,7 @@ authentication
                 requirements?.challenge?.let { challengeTypes ->
                     println("User has enrolled MFA factors")
                     println("Available challenge types: ${challengeTypes.map { it.type }}")
-                    // Example output: ["otp", "sms"]
+                    // Example output: ["otp", "phone"]
                     // Get authenticators and challenge one of them
                 }
                 
@@ -650,14 +650,14 @@ try {
         requirements?.enroll?.let { enrollTypes ->
             println("User needs to enroll MFA")
             println("Available enrollment types: ${enrollTypes.map { it.type }}")
-            // Example output: ["otp", "sms", "push-notification"]
+            // Example output: ["otp", "phone", "push-notification"]
         }
         
         // Check if challenge is available
         requirements?.challenge?.let { challengeTypes ->
             println("User has enrolled MFA factors")
             println("Available challenge types: ${challengeTypes.map { it.type }}")
-            // Example output: ["otp", "sms"]
+            // Example output: ["otp", "phone"]
         }
         
         // Proceed with MFA flow using mfaToken

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -868,10 +868,13 @@ mfaClient
         override fun onFailure(exception: MfaEnrollmentException) { }
 
         override fun onSuccess(enrollment: EnrollmentChallenge) {
-            // Display QR code or secret for user to scan/enter in authenticator app
+            // Display QR code or secret for user to scan/enter in authenticator app.
+            // The `/mfa/associate` endpoint returns the manual-entry key as `secret`
+            // (not `manualInputCode`, which is only populated by the My Account API).
             if (enrollment is TotpEnrollmentChallenge) {
-                val secret = enrollment.manualInputCode
+                val secret = enrollment.secret
                 val barcodeUri = enrollment.barcodeUri
+                val recoveryCodes = enrollment.recoveryCodes
             }
         }
     })
@@ -889,11 +892,14 @@ mfaClient
 
         @Override
         public void onSuccess(EnrollmentChallenge enrollment) {
-            // Display QR code or secret for user to scan/enter in authenticator app
+            // Display QR code or secret for user to scan/enter in authenticator app.
+            // The `/mfa/associate` endpoint returns the manual-entry key as `secret`
+            // (not `manualInputCode`, which is only populated by the My Account API).
             if (enrollment instanceof TotpEnrollmentChallenge) {
                 TotpEnrollmentChallenge totpEnrollment = (TotpEnrollmentChallenge) enrollment;
-                String secret = totpEnrollment.getManualInputCode();
+                String secret = totpEnrollment.getSecret();
                 String barcodeUri = totpEnrollment.getBarcodeUri();
+                List<String> recoveryCodes = totpEnrollment.getRecoveryCodes();
             }
         }
     });

--- a/auth0/src/main/java/com/auth0/android/authentication/mfa/MfaApiClient.kt
+++ b/auth0/src/main/java/com/auth0/android/authentication/mfa/MfaApiClient.kt
@@ -124,16 +124,19 @@ public class MfaApiClient @VisibleForTesting(otherwise = VisibleForTesting.PRIVA
      * ## Usage
      *
      * ```kotlin
-     * mfaClient.getAuthenticators(listOf("otp", "oob"))
+     * mfaClient.getAuthenticators(listOf("otp", "phone"))
      *     .start(object : Callback<List<Authenticator>, MfaListAuthenticatorsException> {
      *         override fun onSuccess(result: List<Authenticator>) {
-     *             // Only OTP and OOB authenticators returned
+     *             // Only authenticators whose `type` is "otp" or "phone" are returned
      *         }
      *         override fun onFailure(error: MfaListAuthenticatorsException) { }
      *     })
      * ```
      *
-     * @param factorsAllowed Array of factor types to filter the authenticators (e.g., `["otp", "oob", "recovery-code"]`).
+     * Filtering matches each authenticator's [Authenticator.type] field against the
+     * provided values using exact (case-sensitive) equality.
+     *
+     * @param factorsAllowed Array of factor types to filter the authenticators (e.g., `["otp", "phone", "email", "recovery-code"]`).
      *                       Must contain at least one factor type.
      * @return a request to configure and start that will yield a list of [Authenticator]
      *
@@ -307,11 +310,11 @@ public class MfaApiClient @VisibleForTesting(otherwise = VisibleForTesting.PRIVA
      * transparently by the SDK.
      *
      * **Filtering:**
-     * Authenticators are filtered by their effective type:
-     * - OOB authenticators: matched by their channel ("sms" or "email")
-     * - Other authenticators: matched by their type ("otp", "recovery-code", etc.)
+     * An authenticator is included when [Authenticator.type] exactly matches one of the
+     * provided [factorsAllowed] values (case-sensitive equality). This mirrors the
+     * filtering behavior of the Auth0.swift SDK.
      *
-     * @param factorsAllowed List of factor types to include (e.g., ["sms", "email", "otp"])
+     * @param factorsAllowed List of factor types to include (e.g., ["phone", "email", "otp"])
      * @return A JsonAdapter that produces a filtered list of authenticators
      */
     private fun createFilteringAuthenticatorsAdapter(factorsAllowed: List<String>): JsonAdapter<List<Authenticator>> {
@@ -321,63 +324,9 @@ public class MfaApiClient @VisibleForTesting(otherwise = VisibleForTesting.PRIVA
                 val allAuthenticators = baseAdapter.fromJson(reader, metadata)
 
                 return allAuthenticators.filter { authenticator ->
-                    matchesFactorType(authenticator, factorsAllowed)
+                    factorsAllowed.contains(authenticator.type)
                 }
             }
-        }
-    }
-
-    /**
-     * Checks if an authenticator matches any of the allowed factor types.
-     *
-     * The matching logic handles various factor type aliases:
-     * - "sms" or "phone": matches OOB authenticators with SMS channel
-     * - "email": matches OOB authenticators with email channel
-     * - "otp" or "totp": matches time-based one-time password authenticators
-     * - "oob": matches any out-of-band authenticator regardless of channel
-     * - "recovery-code": matches recovery code authenticators
-     * - "push-notification": matches push notification authenticators
-     *
-     * @param authenticator The authenticator to check
-     * @param factorsAllowed List of allowed factor types
-     * @return true if the authenticator matches any allowed factor type
-     */
-    private fun matchesFactorType(
-        authenticator: Authenticator,
-        factorsAllowed: List<String>
-    ): Boolean {
-        val effectiveType = getEffectiveType(authenticator)
-
-        return factorsAllowed.any { factor ->
-            val normalizedFactor = factor.lowercase(java.util.Locale.ROOT)
-            when (normalizedFactor) {
-                "sms", "phone" -> effectiveType == "sms" || effectiveType == "phone"
-                "email" -> effectiveType == "email"
-                "otp", "totp" -> effectiveType == "otp" || effectiveType == "totp"
-                "oob" -> authenticator.authenticatorType == "oob" || authenticator.type == "oob"
-                "recovery-code" -> effectiveType == "recovery-code"
-                "push-notification" -> effectiveType == "push-notification"
-                else -> effectiveType == normalizedFactor ||
-                        authenticator.authenticatorType?.lowercase(java.util.Locale.ROOT) == normalizedFactor ||
-                        authenticator.type.lowercase(java.util.Locale.ROOT) == normalizedFactor
-            }
-        }
-    }
-
-    /**
-     * Resolves the effective type of an authenticator for filtering purposes.
-     *
-     * OOB (out-of-band) authenticators use their channel ("sms" or "email") as the
-     * effective type, since users typically filter by delivery method rather than
-     * the generic "oob" type. Other authenticators use their authenticatorType directly.
-     *
-     * @param authenticator The authenticator to get the type for
-     * @return The effective type string used for filtering
-     */
-    private fun getEffectiveType(authenticator: Authenticator): String {
-        return when (authenticator.authenticatorType) {
-            "oob" -> authenticator.oobChannel ?: "oob"
-            else -> authenticator.authenticatorType ?: authenticator.type
         }
     }
 

--- a/auth0/src/main/java/com/auth0/android/result/EnrollmentChallenge.kt
+++ b/auth0/src/main/java/com/auth0/android/result/EnrollmentChallenge.kt
@@ -54,15 +54,36 @@ public data class OobEnrollmentChallenge(
     public val bindingMethod: String? = null
 ) : EnrollmentChallenge()
 
+/**
+ * Enrollment challenge for TOTP (authenticator app) and Push factors, returned by both
+ * the MFA `/mfa/associate` endpoint and the My Account `/authentication-methods` endpoint.
+ *
+ * The two endpoints return different field sets, so every field except [barcodeUri] is
+ * optional:
+ *  - `/mfa/associate` (ROPG MFA flow) returns [authenticatorType], [secret], [barcodeUri]
+ *    and [recoveryCodes]. It does NOT return `id`, `auth_session` or `manual_input_code`.
+ *  - `/authentication-methods` (My Account) returns [id], [authSession], [barcodeUri] and
+ *    [manualInputCode].
+ *
+ * [secret] and [manualInputCode] both carry the human-readable key for manual entry into an
+ * authenticator app; only one is populated depending on the endpoint. The [barcodeUri]
+ * (`otpauth://` URI) is always present and embeds the same secret.
+ */
 public data class TotpEnrollmentChallenge(
     @SerializedName("id")
-    override val id: String,
+    override val id: String? = null,
     @SerializedName("auth_session")
-    override val authSession: String,
+    override val authSession: String? = null,
     @SerializedName("barcode_uri")
     public val barcodeUri: String,
     @SerializedName("manual_input_code")
-    public val manualInputCode: String?
+    public val manualInputCode: String? = null,
+    @SerializedName("authenticator_type")
+    public val authenticatorType: String? = null,
+    @SerializedName("secret")
+    public val secret: String? = null,
+    @SerializedName("recovery_codes")
+    public val recoveryCodes: List<String>? = null
 ) : EnrollmentChallenge()
 
 public data class RecoveryCodeEnrollmentChallenge(

--- a/auth0/src/main/java/com/auth0/android/result/EnrollmentChallenge.kt
+++ b/auth0/src/main/java/com/auth0/android/result/EnrollmentChallenge.kt
@@ -69,6 +69,23 @@ public data class OobEnrollmentChallenge(
  * [secret] and [manualInputCode] both carry the human-readable key for manual entry into an
  * authenticator app; only one is populated depending on the endpoint. The [barcodeUri]
  * (`otpauth://` URI) is always present and embeds the same secret.
+ *
+ * @property id Identifier of the created authentication method. `null` on the `/mfa/associate`
+ * response (which does not return it); populated by the My Account `/authentication-methods`
+ * endpoint.
+ * @property authSession Authentication session for the enrollment. `null` on the
+ * `/mfa/associate` response; populated by the My Account `/authentication-methods` endpoint.
+ * @property barcodeUri The `otpauth://` URI to render as a QR code. Always present on both
+ * endpoints.
+ * @property manualInputCode Human-readable key for manual entry, returned only by the My Account
+ * `/authentication-methods` endpoint; `null` on the `/mfa/associate` response (which returns the
+ * key as [secret] instead).
+ * @property authenticatorType Low-level authenticator type (e.g. `otp`), returned only by the
+ * `/mfa/associate` endpoint; `null` on the My Account response.
+ * @property secret Human-readable key for manual entry, returned only by the `/mfa/associate`
+ * endpoint; `null` on the My Account response (which returns the key as [manualInputCode]).
+ * @property recoveryCodes Recovery codes generated during enrollment, returned only by the
+ * `/mfa/associate` endpoint; `null` on the My Account response.
  */
 public data class TotpEnrollmentChallenge(
     @SerializedName("id")

--- a/auth0/src/test/java/com/auth0/android/authentication/MfaApiClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/MfaApiClientTest.kt
@@ -190,9 +190,9 @@ public class MfaApiClientTest {
         whenever(mockKeyStore.hasKeyPair()).thenReturn(true)
         whenever(mockKeyStore.getKeyPair()).thenReturn(Pair(FakeECPrivateKey(), FakeECPublicKey()))
         val dpopClient = MfaApiClient(auth0, MFA_TOKEN).useDPoP(mockContext)
-        enqueueMockResponse("""[{"id": "sms|dev_123", "type": "oob", "active": true}]""")
+        enqueueMockResponse("""[{"id": "sms|dev_123", "type": "phone", "authenticator_type": "oob", "oob_channel": "sms", "active": true}]""")
 
-        dpopClient.getAuthenticators(listOf("oob")).await()
+        dpopClient.getAuthenticators(listOf("phone")).await()
 
         val request = mockServer.takeRequest()
         assertThat(request.path, `is`("/mfa/authenticators"))
@@ -255,10 +255,10 @@ public class MfaApiClientTest {
 
     @Test
     public fun shouldIncludeAuth0ClientHeaderInGetAuthenticators(): Unit = runTest {
-        val json = """[{"id": "sms|dev_123", "type": "oob", "active": true}]"""
+        val json = """[{"id": "sms|dev_123", "type": "phone", "authenticator_type": "oob", "oob_channel": "sms", "active": true}]"""
         enqueueMockResponse(json)
 
-        mfaClient.getAuthenticators(listOf("oob")).await()
+        mfaClient.getAuthenticators(listOf("phone")).await()
 
         val request = mockServer.takeRequest()
         assertThat(request.getHeader("Auth0-Client"), `is`(notNullValue()))
@@ -301,34 +301,38 @@ public class MfaApiClientTest {
     @Test
     public fun shouldGetAuthenticatorsSuccess(): Unit = runTest {
         val json = """[
-            {"id": "sms|dev_123", "type": "oob", "authenticator_type": "oob", "active": true, "oob_channel": "sms"},
-            {"id": "totp|dev_456", "type": "otp", "authenticator_type": "otp", "active": true}
+            {"id": "sms|dev_123", "type": "phone", "authenticator_type": "oob", "active": true, "oob_channel": "sms"},
+            {"id": "voice|dev_123", "type": "phone", "authenticator_type": "oob", "active": true, "oob_channel": "voice"},
+            {"id": "recovery|dev_789", "type": "recovery-code", "authenticator_type": "recovery-code", "active": true},
+            {"id": "email|dev_456", "type": "email", "authenticator_type": "oob", "active": true, "oob_channel": "email"}
         ]"""
         enqueueMockResponse(json)
 
-        val authenticators = mfaClient.getAuthenticators(listOf("oob", "otp")).await()
+        val authenticators = mfaClient.getAuthenticators(listOf("phone", "email")).await()
 
-        assertThat(authenticators, hasSize(2))
+        assertThat(authenticators, hasSize(3))
         assertThat(authenticators[0].id, `is`("sms|dev_123"))
-        assertThat(authenticators[0].type, `is`("oob"))
-        assertThat(authenticators[1].id, `is`("totp|dev_456"))
-        assertThat(authenticators[1].type, `is`("otp"))
+        assertThat(authenticators[0].type, `is`("phone"))
+        assertThat(authenticators[1].id, `is`("voice|dev_123"))
+        assertThat(authenticators[1].type, `is`("phone"))
+        assertThat(authenticators[2].id, `is`("email|dev_456"))
+        assertThat(authenticators[2].type, `is`("email"))
     }
 
     @Test
     public fun shouldFilterAuthenticatorsByFactorsAllowed(): Unit = runTest {
         val json = """[
-            {"id": "sms|dev_123", "type": "oob", "authenticator_type": "oob", "active": true, "oob_channel": "sms"},
-            {"id": "totp|dev_456", "type": "otp", "authenticator_type": "otp", "active": true},
+            {"id": "sms|dev_123", "type": "phone", "authenticator_type": "oob", "active": true, "oob_channel": "sms"},
+            {"id": "email|dev_456", "type": "email", "authenticator_type": "oob", "active": true, "oob_channel": "email"},
             {"id": "recovery|dev_789", "type": "recovery-code", "authenticator_type": "recovery-code", "active": true}
         ]"""
         enqueueMockResponse(json)
 
-        val authenticators = mfaClient.getAuthenticators(listOf("otp")).await()
+        val authenticators = mfaClient.getAuthenticators(listOf("recovery-code")).await()
 
         assertThat(authenticators, hasSize(1))
-        assertThat(authenticators[0].id, `is`("totp|dev_456"))
-        assertThat(authenticators[0].type, `is`("otp"))
+        assertThat(authenticators[0].id, `is`("recovery|dev_789"))
+        assertThat(authenticators[0].type, `is`("recovery-code"))
     }
 
     @Test
@@ -344,10 +348,10 @@ public class MfaApiClientTest {
 
     @Test
     public fun shouldIncludeAuthorizationHeaderInGetAuthenticators(): Unit = runTest {
-        val json = """[{"id": "sms|dev_123", "type": "oob", "active": true}]"""
+        val json = """[{"id": "sms|dev_123", "type": "phone", "authenticator_type": "oob", "oob_channel": "sms", "active": true}]"""
         enqueueMockResponse(json)
 
-        mfaClient.getAuthenticators(listOf("oob")).await()
+        mfaClient.getAuthenticators(listOf("phone")).await()
 
         val request = mockServer.takeRequest()
         assertThat(request.getHeader("Authorization"), `is`("Bearer $MFA_TOKEN"))
@@ -361,7 +365,7 @@ public class MfaApiClientTest {
 
         val exception = assertThrows(MfaListAuthenticatorsException::class.java) {
             runTest {
-                mfaClient.getAuthenticators(listOf("oob")).await()
+                mfaClient.getAuthenticators(listOf("phone")).await()
             }
         }
         assertThat(exception.getCode(), `is`("access_denied"))
@@ -372,7 +376,7 @@ public class MfaApiClientTest {
     @Test
     public fun shouldReturnEmptyListWhenNoMatchingFactors(): Unit = runTest {
         val json = """[
-            {"id": "sms|dev_123", "type": "oob", "active": true}
+            {"id": "sms|dev_123", "type": "phone", "authenticator_type": "oob", "oob_channel": "sms", "active": true}
         ]"""
         enqueueMockResponse(json)
 
@@ -477,11 +481,13 @@ public class MfaApiClientTest {
 
     @Test
     public fun shouldEnrollOtpSuccess(): Unit = runTest {
+        // Real /mfa/associate TOTP response shape: authenticator_type + secret + barcode_uri
+        // + recovery_codes. It does NOT contain id, auth_session or manual_input_code.
         val json = """{
-            "id": "totp|dev_789",
-            "auth_session": "session_ghi",
+            "authenticator_type": "otp",
+            "secret": "JBSWY3DPEHPK3PXP",
             "barcode_uri": "otpauth://totp/Example:user@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example",
-            "manual_input_code": "JBSWY3DPEHPK3PXP"
+            "recovery_codes": ["ABCD1234EFGH5678"]
         }"""
         enqueueMockResponse(json)
 
@@ -489,10 +495,14 @@ public class MfaApiClientTest {
 
         assertThat(challenge, `is`(instanceOf(TotpEnrollmentChallenge::class.java)))
         val totpChallenge = challenge as TotpEnrollmentChallenge
-        assertThat(totpChallenge.id, `is`("totp|dev_789"))
-        assertThat(totpChallenge.authSession, `is`("session_ghi"))
+        assertThat(totpChallenge.authenticatorType, `is`("otp"))
+        assertThat(totpChallenge.secret, `is`("JBSWY3DPEHPK3PXP"))
         assertThat(totpChallenge.barcodeUri, containsString("otpauth://"))
-        assertThat(totpChallenge.manualInputCode, `is`("JBSWY3DPEHPK3PXP"))
+        assertThat(totpChallenge.recoveryCodes, `is`(listOf("ABCD1234EFGH5678")))
+        // Fields not returned by /mfa/associate must be null (not force-unwrapped non-null).
+        assertThat(totpChallenge.id, `is`(nullValue()))
+        assertThat(totpChallenge.authSession, `is`(nullValue()))
+        assertThat(totpChallenge.manualInputCode, `is`(nullValue()))
     }
 
     @Test
@@ -839,12 +849,12 @@ public class MfaApiClientTest {
 
     @Test
     public fun shouldGetAuthenticatorsWithCallback(): Unit {
-        val json = """[{"id": "sms|dev_123", "type": "oob", "authenticator_type": "oob", "active": true}]"""
+        val json = """[{"id": "sms|dev_123", "type": "phone", "authenticator_type": "oob", "oob_channel": "sms", "active": true}]"""
         enqueueMockResponse(json)
 
         val callback = MockCallback<List<Authenticator>, MfaListAuthenticatorsException>()
 
-        mfaClient.getAuthenticators(listOf("oob"))
+        mfaClient.getAuthenticators(listOf("phone"))
             .start(callback)
 
         ShadowLooper.idleMainLooper()

--- a/auth0/src/test/java/com/auth0/android/authentication/MfaApiClientTest.kt
+++ b/auth0/src/test/java/com/auth0/android/authentication/MfaApiClientTest.kt
@@ -839,7 +839,7 @@ public class MfaApiClientTest {
 
     @Test
     public fun shouldGetAuthenticatorsWithCallback(): Unit {
-        val json = """[{"id": "sms|dev_123", "authenticator_type": "oob", "active": true}]"""
+        val json = """[{"id": "sms|dev_123", "type": "oob", "authenticator_type": "oob", "active": true}]"""
         enqueueMockResponse(json)
 
         val callback = MockCallback<List<Authenticator>, MfaListAuthenticatorsException>()


### PR DESCRIPTION
### Changes

This PR contains two related MFA fixes.

#### 1. `getAuthenticators` — filter on `Authenticator.type` (exact match)

Updates how `MfaApiClient.getAuthenticators(factorsAllowed)` filters the authenticators returned by `GET /mfa/authenticators`.

**What changed**

- **Filtering logic** — Authenticators are now filtered by comparing each `Authenticator.type` value directly against the `factorsAllowed` list using exact (case-sensitive) equality. Previously the SDK derived an "effective type" by inspecting `oob_channel` and `authenticator_type` (with aliasing, e.g. `sms`/`phone`, `otp`/`totp`, and treating `oob` as a wildcard). That derivation and its helpers have been removed.
- **Methods removed** — the private helpers `matchesFactorType(...)` and `getEffectiveType(...)` in `MfaApiClient`.
- **No endpoint or public method signature changes** — `getAuthenticators(factorsAllowed: List<String>)` keeps the same signature; only its internal filtering behavior changed.
- **Documentation** — `MfaApiClient` KDoc and `EXAMPLES.md` updated so the `factorsAllowed` examples use the same factor values as the `type` field (e.g. `phone`, `email`, `otp`, `recovery-code`) instead of channel-level values like `sms`/`oob`.

**Why it matters**

The `factorsAllowed` values now map one-to-one to the `Authenticator.type` field, so filtering is predictable and matches the values a caller gets from `MfaRequirements` (`MfaFactor.type`). This is a **behavioral change**: callers passing channel-level or wildcard values such as `sms` or `oob` will no longer match — they should pass the resolved `type` value (e.g. `phone`). Confirmed against live FGS that a TOTP factor has `type: "totp"` (`authenticator_type: "otp"`), so callers must pass `totp` to surface it.

#### 2. `TotpEnrollmentChallenge` — correct field mapping for `/mfa/associate`

`TotpEnrollmentChallenge` is shared by two endpoints with different response shapes, but was modeled only on the My Account `/authentication-methods` shape. Used against the ROPG `/mfa/associate` endpoint (which `MfaApiClient.enroll(Otp)` calls), this caused:

- `id` and `authSession` declared non-null but populated as `null` by Gson (null-safety bypass / latent NPE hazard),
- `manualInputCode` always `null` (the endpoint returns the key as `secret`, not `manual_input_code`),
- `secret` and `recovery_codes` silently dropped.

**What changed**

- Made `id` and `authSession` nullable (`manualInputCode` was already nullable) and added `authenticatorType`, `secret`, `recoveryCodes`, so a single class deserializes both endpoints correctly. This matches Auth0.swift's `OTPMFAEnrollmentChallenge` (the only cross-SDK peer that implements `/mfa/associate`).
- **My Account flow unaffected** — its fields (`id`/`authSession`/`manualInputCode`/`barcodeUri`) still map identically; the change only loosens nullability and adds fields. No runtime break for existing users; recompiling My Account consumers may need a null check on `id`/`authSession` (the safe direction).
- **Documentation** — `EXAMPLES.md` MFA `enroll(Otp)` snippet corrected to read `secret` (not `manualInputCode`) and now shows `recoveryCodes`.

**Usage**

```kotlin
// factorsAllowed values map directly to Authenticator.type
val factorTypes = requirements?.challenge?.map { it.type } ?: emptyList()

mfaClient
    .getAuthenticators(factorsAllowed = factorTypes) // e.g. ["otp", "phone", "email", "recovery-code"]
    .start(object : Callback<List<Authenticator>, MfaListAuthenticatorsException> {
        override fun onSuccess(result: List<Authenticator>) {
            // Only authenticators whose `type` matches one of factorsAllowed are returned
        }
        override fun onFailure(error: MfaListAuthenticatorsException) { }
    })

// Enrolling TOTP via /mfa/associate
mfaClient
    .enroll(MfaEnrollmentType.Otp)
    .start(object : Callback<EnrollmentChallenge, MfaEnrollmentException> {
        override fun onSuccess(enrollment: EnrollmentChallenge) {
            if (enrollment is TotpEnrollmentChallenge) {
                val secret = enrollment.secret          // manual-entry key
                val barcodeUri = enrollment.barcodeUri  // otpauth:// URI for QR
                val recoveryCodes = enrollment.recoveryCodes
            }
        }
        override fun onFailure(error: MfaEnrollmentException) { }
    })
```

### References



### Testing

- **getAuthenticators** unit tests in `MfaApiClientTest` exercise exact-type matching: fixtures include a top-level `type` field and assert only authenticators whose `type` is in `factorsAllowed` are returned.
- **TOTP enroll** test updated to use the real `/mfa/associate` response shape, asserting `secret`/`recoveryCodes`/`authenticatorType` populate.
- `MyAccountAPIClientTest` re-run to confirm the shared-class change does not affect the My Account TOTP/push flows.
- Verified end-to-end on a physical device (Pixel 7a) against live FGS: login → enroll OTP → verify OTP → verify recovery code, all succeeded; `secret`/`recovery_codes` populate correctly.

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MFA authenticator filtering to use the exact factor type you request, resulting in more consistent authenticator lists and smoother enrollment.
  * Updated TOTP enrollment handling to correctly capture and expose the latest response fields (including secret and recovery codes), improving setup details.
* **Documentation**
  * Refreshed MFA Kotlin/Java examples to use the correct factor names and updated TOTP enrollment fields to match current responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->