### PR TITLE
chore: pin codeql-action to SHA and remove release trigger for v4_development

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,15 +45,15 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   release:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.base.ref == 'v4_development')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     environment: release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types:
       - closed
-    branches:
-      - v4_development
   workflow_dispatch:
 
 permissions:
@@ -18,7 +16,7 @@ permissions:
 
 jobs:
   rl-scanner:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.base.ref == 'v4_development')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   rl-scanner:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.base.ref == 'v4_development')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

Two CI fixes on `v4_development` so the 4.0.0 release PR doesn't regress `main`'s hardening:

1. **Pin `github/codeql-action/*` to a commit SHA.** v4 used bare `@v4` tags for `init` / `autobuild` / `analyze`, which would have replaced `main`'s SHA-pinned versions on merge. Now pinned to `8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2` (matching `main`), consistent with the other SHA-pinned actions in this workflow.

2. **Remove the release  trigger for `v4_development`.** Removed `github.event.pull_request.base.ref == 'v4_development'` from release the job's .
