### PR TITLE
doc: minor doc updates

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -12,8 +12,8 @@
   - [Changing the Return To URL scheme](#changing-the-return-to-url-scheme)
   - [Specify a Custom Logout URL](#specify-a-custom-logout-url)
   - [Trusted Web Activity](#trusted-web-activity)
-  - [Ephemeral Browsing [Experimental]](#ephemeral-browsing-experimental)
-  - [Auth Tab [Experimental]](#auth-tab-experimental)
+  - [Ephemeral Browsing](#ephemeral-browsing)
+  - [Auth Tab](#auth-tab)
   - [DPoP](#dpop)
   - [Authentication API](#authentication-api)
     - [Login with database connection](#login-with-database-connection)
@@ -304,11 +304,8 @@ WebAuthProvider.login(account)
 > [!NOTE]
 > `withTrustedWebActivity()` and `withAuthTab()` are mutually exclusive. If both are set on the same builder, TWA takes precedence and Auth Tab will not be used. They rely on different underlying launch mechanisms and cannot be combined. For standard OAuth flows against Auth0, prefer [Auth Tab](#auth-tab-experimental) — it requires no server-side setup and works with any domain.
 
-## Ephemeral Browsing [Experimental]
+## Ephemeral Browsing
 
-> **WARNING**
-> Ephemeral browsing support in Auth0.Android is still experimental and can change in the future. Please test it thoroughly in all the targeted browsers
-> and OS variants and let us know your feedback.
 
 Ephemeral browsing launches the Chrome Custom Tab in a fully isolated session — cookies, cache, history, and credentials are deleted when the tab closes. This is equivalent to incognito/private mode for Custom Tabs, useful for privacy-focused authentication flows.
 
@@ -340,10 +337,8 @@ WebAuthProvider.login(account)
 ```
 </details>
 
-## Auth Tab [Experimental]
+## Auth Tab
 
-> **WARNING**
-> Auth Tab support in Auth0.Android is still experimental and can change in the future. Please test it thoroughly on all targeted devices and OS variants and let us know your feedback.
 
 Auth Tab uses [`AuthTabIntent`](https://developer.android.com/reference/androidx/browser/auth/AuthTabIntent) from `androidx.browser` to open the authentication flow in a dedicated browser tab that verifies the redirect URI scheme before delivering the result back to your app. This provides an additional layer of security by ensuring only your app — whose redirect URI scheme is verified at registration time — can receive the authentication callback, preventing other apps from intercepting it.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 ![Auth0.Android](https://cdn.auth0.com/website/sdks/banners/auth0-android-banner.png)
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.auth0.android/auth0.svg?style=flat-square)](https://search.maven.org/artifact/com.auth0.android/auth0)
-[![Coverage Status](https://img.shields.io/codecov/c/github/auth0/Auth0.Android/master.svg?style=flat-square)](https://codecov.io/github/auth0/Auth0.Android)
-[![CircleCI](https://img.shields.io/circleci/project/github/auth0/Auth0.Android.svg?style=flat-square)](https://circleci.com/gh/auth0/Auth0.Android/tree/master)
+[![Coverage Status](https://img.shields.io/codecov/c/github/auth0/Auth0.Android/master.svg?style=flat-square)](https://app.codecov.io/github/auth0/Auth0.Android)
 [![License](https://img.shields.io/:license-mit-blue.svg?style=flat-square)](https://doge.mit-license.org/)
 [![javadoc](https://javadoc.io/badge2/com.auth0.android/auth0/javadoc.svg)](https://javadoc.io/doc/com.auth0.android/auth0)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/Auth0.Android)
@@ -15,7 +14,7 @@
 📚 [Documentation](#documentation) • 🚀 [Getting Started](#getting-started) • 💬 [Feedback](#feedback)
 
 ## Documentation
-- [Quickstart](https://auth0.com/docs/quickstart/native/android/interactive)
+- [Quickstart](https://auth0.com/docs/quickstart/native/android)
 - [Sample App](https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt)
 - [FAQs](https://github.com/auth0/auth0.android/blob/main/FAQ.md)
 - [Examples](https://github.com/auth0/auth0.android/blob/main/EXAMPLES.md)

--- a/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
+++ b/auth0/src/main/java/com/auth0/android/provider/WebAuthProvider.kt
@@ -451,7 +451,10 @@ public object WebAuthProvider {
             startInternal(context, effectiveCallback)
         }
 
-        private fun startInternal(context: Context, callback: Callback<Void?, AuthenticationException>) {
+        private fun startInternal(
+            context: Context,
+            callback: Callback<Void?, AuthenticationException>
+        ) {
             resetManagerInstance()
             val effectiveCtOptions = if (authTab) ctOptions.copyWithAuthTab() else ctOptions
             if (!effectiveCtOptions.hasCompatibleBrowser(context.packageManager)) {
@@ -750,13 +753,9 @@ public object WebAuthProvider {
          * Requires Chrome 136+ or a compatible browser. On unsupported browsers,
          * a warning is logged and a regular Custom Tab is used instead.
          *
-         * **Warning:** Ephemeral browsing support in Auth0.Android is still experimental
-         * and can change in the future. Please test it thoroughly in all the targeted browsers
-         * and OS variants and let us know your feedback.
          *
          * @return the current builder instance
          */
-        @ExperimentalAuth0Api
         public fun withEphemeralBrowsing(): Builder {
             ephemeralBrowsing = true
             return this
@@ -767,8 +766,6 @@ public object WebAuthProvider {
          * Auth Tab provides a dedicated, security-focused UI for OAuth flows with no address bar
          * or share button. Falls back to a regular Custom Tab on browsers that do not support it.
          *
-         * **Warning:** Auth Tab support in Auth0.Android is still experimental and can change in
-         * the future.
          *
          * Note: [withAuthTab] and [withTrustedWebActivity] are mutually exclusive. If both are set,
          * TWA takes precedence and Auth Tab will not be used. They rely on different underlying
@@ -776,7 +773,6 @@ public object WebAuthProvider {
          *
          * @return the current builder instance
          */
-        @ExperimentalAuth0Api
         public fun withAuthTab(): Builder {
             authTab = true
             return this
@@ -837,9 +833,13 @@ public object WebAuthProvider {
                     onDetached = { success: Credentials?, error: AuthenticationException? ->
                         if (callbacks.isNotEmpty()) {
                             if (success != null) {
-                                for (cb in callbacks) { cb.onSuccess(success) }
+                                for (cb in callbacks) {
+                                    cb.onSuccess(success)
+                                }
                             } else if (error != null) {
-                                for (cb in callbacks) { cb.onFailure(error) }
+                                for (cb in callbacks) {
+                                    cb.onFailure(error)
+                                }
                             }
                         } else {
                             if (success != null) {
@@ -886,7 +886,8 @@ public object WebAuthProvider {
             }
 
             var effectiveCtOptions = ctOptions
-            if (ephemeralBrowsing) effectiveCtOptions = effectiveCtOptions.copyWithEphemeralBrowsing()
+            if (ephemeralBrowsing) effectiveCtOptions =
+                effectiveCtOptions.copyWithEphemeralBrowsing()
             if (authTab) effectiveCtOptions = effectiveCtOptions.copyWithAuthTab()
 
             val manager = OAuthManager(


### PR DESCRIPTION
This PR updates minor doc changes. Removes the `@Experimental` tag from the Ephemeral and Auth Tab APIs for login


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Ephemeral Browsing and Auth Tab documentation to remove experimental labels and warnings.
  * Refreshed README badges and updated the Quickstart documentation link.
* **Style**
  * Improved code formatting and readability without changing login or logout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->