### PR TITLE
docs: reference consolidated auth0 skill in migration section

### DIFF
--- a/V4_MIGRATION_GUIDE.md
+++ b/V4_MIGRATION_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Skill for Coding Agents
 
-If you use coding agents such as Claude Code or Cursor, we highly recommend adding the [Auth0 skill](https://github.com/auth0/agent-skills/blob/main/plugins/auth0/skills/auth0/SKILL.md) to your repository: `npx skills add auth0/agent-skills --skill auth0`
+If you use coding agents such as Claude Code or Cursor, we highly recommend adding the [Auth0 skill](https://github.com/auth0/agent-skills/blob/main/plugins/auth0/skills/auth0/SKILL.md) to your repository: `npx skills add auth0/agent-skills --skill auth0`. Using this skill, your agent will automatically upgrade your project from v3 to v4.
 
 > **Note:** This guide is actively maintained during the v4 development phase. As new changes are merged, this document will be updated to reflect the latest breaking changes and migration steps.
 

--- a/V4_MIGRATION_GUIDE.md
+++ b/V4_MIGRATION_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Skill for Coding Agents
 
-If you use coding agents such as Claude Code or Cursor, we highly recommend adding the Auth0.Android migration skill to your repository: `npx skills add auth0/agent-skills --skill auth0-android-major-migration`
+If you use coding agents such as Claude Code or Cursor, we highly recommend adding the [Auth0 skill](https://github.com/auth0/agent-skills/blob/main/plugins/auth0/skills/auth0/SKILL.md) to your repository: `npx skills add auth0/agent-skills --skill auth0`
 
 > **Note:** This guide is actively maintained during the v4 development phase. As new changes are merged, this document will be updated to reflect the latest breaking changes and migration steps.
 


### PR DESCRIPTION
## Summary
Updates the coding-agent migration instructions in the README to point at the unified `auth0` skill instead of the migration-specific `auth0-android-major-migration` skill. Mirrors the change made in [Auth0.swift#1259](https://github.com/auth0/Auth0.swift/pull/1259).

- Install command: `--skill auth0-android-major-migration` → `--skill auth0`
- Links "Auth0 skill" text to the consolidated [SKILL.md](https://github.com/auth0/agent-skills/blob/main/plugins/auth0/skills/auth0/SKILL.md)

## Test plan
- Documentation-only change; verified rendered markdown links resolve correctly.