### PR TITLE
fix(provider): fall back to returnTo for Auth Tab logout scheme

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java
@@ -175,6 +175,9 @@ class CustomTabsController extends CustomTabsServiceConnection {
         }
         String redirectUri = uri.getQueryParameter("redirect_uri");
         if (redirectUri == null) {
+            redirectUri = uri.getQueryParameter("returnTo");
+        }
+        if (redirectUri == null) {
             Log.e(TAG, "Could not determine redirect URI from authorize URL. This is likely a configuration error.");
             if (failureCallback != null) {
                 AuthenticationException e = new AuthenticationException(

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsControllerTest.java
@@ -386,6 +386,33 @@ public class CustomTabsControllerTest {
     }
 
     @Test
+    public void shouldLaunchAsAuthTabUsingReturnToWhenRedirectUriIsAbsent() throws Exception {
+        customTabsClientMock = Mockito.mockStatic(CustomTabsClient.class);
+        customTabsClientMock.when(() ->
+                CustomTabsClient.isAuthTabSupported(any(), eq(DEFAULT_BROWSER_PACKAGE))
+        ).thenReturn(true);
+
+        @SuppressWarnings("unchecked")
+        ActivityResultLauncher<Intent> mockAuthTabLauncher = mock(ActivityResultLauncher.class);
+
+        BrowserPicker browserPicker = mock(BrowserPicker.class);
+        when(browserPicker.getBestBrowserPackage(context.getPackageManager())).thenReturn(DEFAULT_BROWSER_PACKAGE);
+        CustomTabsOptions ctOptions = CustomTabsOptions.newBuilder()
+                .withBrowserPicker(browserPicker)
+                .withAuthTab()
+                .build();
+
+        CustomTabsController authTabController =
+                new CustomTabsController(context, ctOptions, twaLauncher, mockAuthTabLauncher);
+
+        Uri logoutUri = Uri.parse("https://example.auth0.com/v2/logout?returnTo=myapp%3A%2F%2Fcallback");
+        authTabController.launchUri(logoutUri, false, mockThreadSwitcher, null);
+
+        verify(mockAuthTabLauncher, timeout(MAX_TEST_WAIT_TIME_MS)).launch(any(Intent.class));
+        verify(context, never()).startActivity(any(Intent.class));
+    }
+
+    @Test
     public void shouldFallbackToCustomTabWhenAuthTabNotSupportedByBrowser() {
         customTabsClientMock = Mockito.mockStatic(CustomTabsClient.class);
         customTabsClientMock.when(() ->


### PR DESCRIPTION
### Changes

`WebAuthProvider.logout(account).withAuthTab()` could never succeed. When Auth Tab is used, `CustomTabsController.launchAsAuthTab` derives the redirect scheme from the `redirect_uri` query parameter of the URL. The login flow always sets `redirect_uri`, but the **logout** flow only sets `returnTo` — so the lookup returned `null` and the SDK failed with `a0.invalid_authorize_url` before the browser ever opened.

**Fix:** In `launchAsAuthTab`, fall back to the `returnTo` query parameter when `redirect_uri` is absent, so the Auth Tab logout flow can resolve a scheme. Login behavior is unchanged (it always has `redirect_uri`).

- **Classes/methods changed:** `CustomTabsController.launchAsAuthTab(...)` (package-private, internal) — added a `returnTo` fallback for scheme resolution.
- **Endpoints:** none added, deleted, deprecated, or changed.
- **Public API:** no public API changes. This restores the intended behavior of the existing `LogoutBuilder.withAuthTab()` option; no new usage patterns are introduced.

> Security note: this touches redirect/scheme handling. The change only broadens where the scheme is read from (`redirect_uri` → `returnTo`) for the logout flow; exact scheme resolution and validation are otherwise unchanged.


### References

SDK-9834

### Testing

Added a unit test covering the logout case where only `returnTo` is present, verifying the Auth Tab is launched (rather than failing with `a0.invalid_authorize_url`). The existing `CustomTabsControllerTest` suite continues to pass (19/19). Also verified end-to-end on a physical device (Pixel 7a) against a real Auth0 tenant: tapping "Log out (Auth Tab)" launched the browser and returned `onSuccess` with no error.

**Reviewers can verify by:**
- Running `./gradlew :auth0:testReleaseUnitTest` and confirming `CustomTabsControllerTest` passes, including `shouldLaunchAsAuthTabUsingReturnToWhenRedirectUriIsAbsent`.
- Optionally, wiring `WebAuthProvider.logout(account).withScheme(...).withAuthTab().start(...)` in a sample app on a device with an Auth Tab–capable browser and confirming logout completes.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Auth Tab handling for authorization links that omit `redirect_uri` but provide a `returnTo` parameter.
  * Such links now launch through the Auth Tab flow as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->