### PR TITLE
chore: Grouping codeql dependabot updates together to avoid PR failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      codeql:
+        patterns:
+          - 'github/codeql-action*'
+      setup-java:
+        patterns:
+          - 'actions/setup-java*'


### PR DESCRIPTION
### Changes

This PR updates the dependabot PR update for codeql and java actions so that all the related versions are updated together in a single PR rather than individual PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped CodeQL and Java setup action updates to simplify dependency update management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->