### PR TITLE
ci: run Build and Test + CodeQL on release/3.x branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - release/3.x
   schedule:
     - cron: "37 10 * * 2"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches:
       - main
+      - release/3.x
   push:
     branches:
       - main
+      - release/3.x
 
 permissions:
   contents: read


### PR DESCRIPTION
## Changes

Enables CI on the new `release/3.x` maintenance branch. The existing workflows only triggered on `main`, so PRs targeting `release/3.x` ran no checks.

- `.github/workflows/test.yml` — add `release/3.x` to the `pull_request` and `push` branch filters (Build and Test / unit tests + lint).
- `.github/workflows/codeql.yml` — add `release/3.x` to the `push` branch filter (CodeQL scan).

No code, endpoints, classes, methods, or public API changes — CI configuration only.

### Testing

This is a CI configuration change only — no application code, so there is no unit/integration test to add. It is validated by the CI system itself: once this merges into `release/3.x`, subsequent PRs targeting `release/3.x` will run the "Build and Test" (unit tests + lint) and CodeQL checks.

Note: the checks may **not** appear on this PR. For `pull_request` events GitHub reads the workflow definition from the base branch (`release/3.x`), which does not yet contain these triggers — so they take effect only after merge. This is expected, not a failure.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
