### PR TITLE
feat: enable ephemeral browsing for Auth Tab

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -340,6 +340,10 @@ WebAuthProvider.login(account)
 ```
 </details>
 
+
+> [!NOTE]
+> Ephemeral browsing is not supported with Trusted Web Activity. When `withTrustedWebActivity()` is used, `withEphemeralBrowsing()` has no effect and the flow launches as a Trusted Web Activity using the browser's normal (non-isolated) session. This is a platform limitation — a TWA shares the user's browser profile by design, so it cannot run in an isolated ephemeral session.
+
 ## Auth Tab
 
 
@@ -402,7 +406,7 @@ When `withAuthTab()` is combined with `withCustomTabsOptions()`, only a subset o
 |---|---|
 | `withToolbarColor()` | ✅ Applied to the Auth Tab toolbar |
 | `showTitle()` | ❌ Ignored — Auth Tab has no title-visibility option |
-| `withEphemeralBrowsing()` | ❌ Ignored — Auth Tab does not support ephemeral sessions. Use a regular Custom Tab if session isolation is required |
+| `withEphemeralBrowsing()` | ✅ Honored — the Auth Tab runs in an isolated ephemeral session when the browser supports it (requires Chrome 136+ or a compatible browser); otherwise a warning is logged and it falls back to a regular Auth Tab |
 | `withInitialHeight()` / `withInitialWidth()` | ❌ Ignored — Auth Tab is always full-screen |
 | `withToolbarCornerRadius()` | ❌ Ignored |
 | `withSideSheetBreakpoint()` | ❌ Ignored |

--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
@@ -197,6 +197,17 @@ public class CustomTabsOptions implements Parcelable {
     @SuppressLint("ResourceType")
     AuthTabIntent.Builder toAuthTabIntentBuilder(@NonNull Context context) {
         AuthTabIntent.Builder builder = new AuthTabIntent.Builder();
+        if (ephemeralBrowsing) {
+            String preferredPackage = this.getPreferredPackage(context.getPackageManager());
+            if (preferredPackage != null
+                    && CustomTabsClient.isEphemeralBrowsingSupported(context, preferredPackage)) {
+                builder.setEphemeralBrowsingEnabled(true);
+            } else {
+                Log.w(TAG, "Ephemeral browsing was requested but is not supported by the "
+                        + "current browser (" + preferredPackage + "). "
+                        + "Falling back to a regular Auth Tab.");
+            }
+        }
         if (toolbarColor > 0) {
             final AuthTabColorSchemeParams params = new AuthTabColorSchemeParams.Builder()
                     .setToolbarColor(ContextCompat.getColor(context, toolbarColor))

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Parcel;
 
+import androidx.browser.auth.AuthTabIntent;
 import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.core.content.ContextCompat;
@@ -397,6 +398,86 @@ public class CustomTabsOptionsTest {
         assertEquals(intent.getAction(), "android.intent.action.VIEW");
 
         // No warning should be logged since the entire Custom Tab path is skipped
+        assertThat(hasLogWithMessage("Ephemeral browsing was requested"), is(false));
+    }
+
+    @Test
+    public void shouldSetEphemeralBrowsingOnAuthTabWhenSupported() {
+        Activity activity = spy(Robolectric.setupActivity(Activity.class));
+        BrowserPickerTest.setupBrowserContext(activity, Collections.singletonList("com.android.chrome"), null, null);
+
+        customTabsClientMock = Mockito.mockStatic(CustomTabsClient.class);
+        customTabsClientMock.when(() ->
+                CustomTabsClient.isEphemeralBrowsingSupported(any(), eq("com.android.chrome"))
+        ).thenReturn(true);
+
+        BrowserPicker browserPicker = BrowserPicker.newBuilder().build();
+        CustomTabsOptions options = CustomTabsOptions.newBuilder()
+                .withBrowserPicker(browserPicker)
+                .withEphemeralBrowsing()
+                .withAuthTab()
+                .build();
+        assertThat(options, is(notNullValue()));
+
+        AuthTabIntent authTabIntent = options.toAuthTabIntentBuilder(activity).build();
+        assertThat(authTabIntent, is(notNullValue()));
+
+        // Verify ephemeral browsing extra is set on the Auth Tab intent
+        assertThat(authTabIntent.intent.getBooleanExtra(CustomTabsIntent.EXTRA_ENABLE_EPHEMERAL_BROWSING, false), is(true));
+
+        // Verify isEphemeralBrowsingSupported was called
+        customTabsClientMock.verify(() ->
+                CustomTabsClient.isEphemeralBrowsingSupported(any(), eq("com.android.chrome"))
+        );
+
+        // Verify no warning was logged
+        assertThat(hasLogWithMessage("Ephemeral browsing was requested"), is(false));
+    }
+
+    @Test
+    public void shouldFallbackWithWarningWhenEphemeralNotSupportedOnAuthTab() {
+        Activity activity = spy(Robolectric.setupActivity(Activity.class));
+        BrowserPickerTest.setupBrowserContext(activity, Collections.singletonList("com.android.chrome"), null, null);
+
+        customTabsClientMock = Mockito.mockStatic(CustomTabsClient.class);
+        customTabsClientMock.when(() ->
+                CustomTabsClient.isEphemeralBrowsingSupported(any(), eq("com.android.chrome"))
+        ).thenReturn(false);
+
+        BrowserPicker browserPicker = BrowserPicker.newBuilder().build();
+        CustomTabsOptions options = CustomTabsOptions.newBuilder()
+                .withBrowserPicker(browserPicker)
+                .withEphemeralBrowsing()
+                .withAuthTab()
+                .build();
+
+        AuthTabIntent authTabIntent = options.toAuthTabIntentBuilder(activity).build();
+        assertThat(authTabIntent, is(notNullValue()));
+
+        assertThat(hasLogWithMessage("Ephemeral browsing was requested but is not supported"), is(true));
+
+        // Verify ephemeral browsing extra is not set (fallback to a regular Auth Tab)
+        assertThat(authTabIntent.intent.getBooleanExtra(CustomTabsIntent.EXTRA_ENABLE_EPHEMERAL_BROWSING, false), is(false));
+    }
+
+    @Test
+    public void shouldNotSetEphemeralBrowsingOnAuthTabByDefault() {
+        customTabsClientMock = Mockito.mockStatic(CustomTabsClient.class);
+
+        CustomTabsOptions options = CustomTabsOptions.newBuilder()
+                .withAuthTab()
+                .build();
+        assertThat(options, is(notNullValue()));
+
+        AuthTabIntent authTabIntent = options.toAuthTabIntentBuilder(context).build();
+        assertThat(authTabIntent, is(notNullValue()));
+
+        // Ephemeral support should not be queried when ephemeral browsing was not requested
+        customTabsClientMock.verifyNoInteractions();
+
+        // Verify ephemeral browsing extra is not set
+        assertThat(authTabIntent.intent.getBooleanExtra(CustomTabsIntent.EXTRA_ENABLE_EPHEMERAL_BROWSING, false), is(false));
+
         assertThat(hasLogWithMessage("Ephemeral browsing was requested"), is(false));
     }
 


### PR DESCRIPTION
## Description

When an Auth Tab and an ephemeral session were requested together (`withEphemeralBrowsing()` + Auth Tab), the ephemeral flag was silently dropped. `CustomTabsOptions.toAuthTabIntentBuilder()` only set the toolbar color and never propagated the ephemeral preference, so the Auth Tab launched in the browser's normal (non-isolated) session.

This change makes `toAuthTabIntentBuilder()` honor ephemeral browsing, mirroring the existing behavior in `toIntent()`:

- If ephemeral is requested and the resolved browser advertises `isEphemeralBrowsingSupported`, the Auth Tab is built with `setEphemeralBrowsingEnabled(true)`.
- Otherwise a warning is logged and the flow falls back to a regular Auth Tab.



## Testing

- Added 3 unit tests in `CustomTabsOptionsTest`: ephemeral set when supported, warning + fallback when unsupported, and off by default.
- EXAMPLES.md updated: the `withEphemeralBrowsing()` limitations row now reflects Auth Tab support, plus a TWA note.

## Checklist

- [x] Unit tests added for success and fallback paths
- [x] EXAMPLES.md updated for the changed behavior
- [x] No public API change
