### PR TITLE
chore : Added java version in the sca_scan workflow

### DIFF
--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -2,11 +2,12 @@ name: SCA
 
 on:
   push:
-    branches: ["master", "main", "**"]
+    branches: [ "main", "**"]
 
 jobs:
   snyk-cli:
     uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
     with:
+      java-version: "17"
       additional-arguments: "--exclude=README.md,.jfrog"
     secrets: inherit


### PR DESCRIPTION
### Changes

This is a small PR updating the java version in the `sca_scan` workflow. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning to run on the `main` branch and all branches.
  * Configured security scans to use Java 17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->