### PR TITLE
feat: allow enabling EXTRA_SEND_TO_EXTERNAL_DEFAULT_HANDLER on the Custom Tab intent

### DIFF
--- a/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
+++ b/auth0/src/main/java/com/auth0/android/provider/CustomTabsOptions.java
@@ -56,6 +56,8 @@ public class CustomTabsOptions implements Parcelable {
     // Partial Custom Tabs - Background Interaction
     private final boolean backgroundInteractionEnabled;
 
+    private final boolean sendToExternalDefaultHandlerEnabled;
+
     private final boolean authTab;
 
     private CustomTabsOptions(boolean showTitle, @ColorRes int toolbarColor, @NonNull BrowserPicker browserPicker,
@@ -63,7 +65,7 @@ public class CustomTabsOptions implements Parcelable {
                               int initialHeight, int activityHeightResizeBehavior, int toolbarCornerRadius,
                               int initialWidth, int sideSheetBreakpoint,
                               boolean backgroundInteractionEnabled, boolean ephemeralBrowsing,
-                              boolean authTab) {
+                              boolean sendToExternalDefaultHandlerEnabled, boolean authTab) {
         this.showTitle = showTitle;
         this.toolbarColor = toolbarColor;
         this.browserPicker = browserPicker;
@@ -75,6 +77,7 @@ public class CustomTabsOptions implements Parcelable {
         this.initialWidth = initialWidth;
         this.sideSheetBreakpoint = sideSheetBreakpoint;
         this.backgroundInteractionEnabled = backgroundInteractionEnabled;
+        this.sendToExternalDefaultHandlerEnabled = sendToExternalDefaultHandlerEnabled;
         this.authTab = authTab;
     }
 
@@ -114,6 +117,7 @@ public class CustomTabsOptions implements Parcelable {
         builder.initialWidth = this.initialWidth;
         builder.sideSheetBreakpoint = this.sideSheetBreakpoint;
         builder.backgroundInteractionEnabled = this.backgroundInteractionEnabled;
+        builder.sendToExternalDefaultHandlerEnabled = this.sendToExternalDefaultHandlerEnabled;
         builder.ephemeralBrowsing = this.ephemeralBrowsing;
         builder.authTab = this.authTab;
         return builder;
@@ -191,6 +195,14 @@ public class CustomTabsOptions implements Parcelable {
             builder.setBackgroundInteractionEnabled(true);
         }
 
+        // Allow the initial navigation chain (e.g. /authorize redirecting straight to an https
+        // callback URL) to leave the browser and launch this app. Without this, Chrome versions
+        // prior to 120 keep such redirects inside the Custom Tab because the launching intent
+        // explicitly targets the browser package.
+        if (sendToExternalDefaultHandlerEnabled) {
+            builder.setSendToExternalDefaultHandlerEnabled(true);
+        }
+
         return builder.build().intent;
     }
 
@@ -241,6 +253,7 @@ public class CustomTabsOptions implements Parcelable {
         initialWidth = in.readInt();
         sideSheetBreakpoint = in.readInt();
         backgroundInteractionEnabled = in.readByte() != 0;
+        sendToExternalDefaultHandlerEnabled = in.readByte() != 0;
         authTab = in.readByte() != 0;
     }
 
@@ -257,6 +270,7 @@ public class CustomTabsOptions implements Parcelable {
         dest.writeInt(initialWidth);
         dest.writeInt(sideSheetBreakpoint);
         dest.writeByte((byte) (backgroundInteractionEnabled ? 1 : 0));
+        dest.writeByte((byte) (sendToExternalDefaultHandlerEnabled ? 1 : 0));
         dest.writeByte((byte) (authTab ? 1 : 0));
     }
 
@@ -298,6 +312,7 @@ public class CustomTabsOptions implements Parcelable {
         private int initialWidth;
         private int sideSheetBreakpoint;
         private boolean backgroundInteractionEnabled;
+        private boolean sendToExternalDefaultHandlerEnabled;
 
         Builder() {
             this.showTitle = false;
@@ -312,6 +327,7 @@ public class CustomTabsOptions implements Parcelable {
             this.initialWidth = 0;
             this.sideSheetBreakpoint = 0;
             this.backgroundInteractionEnabled = false;
+            this.sendToExternalDefaultHandlerEnabled = false;
         }
 
         /**
@@ -495,6 +511,33 @@ public class CustomTabsOptions implements Parcelable {
         }
 
         /**
+         * Allows the initial navigation chain of the Custom Tab to leave the browser and launch
+         * an external app, by setting {@link CustomTabsIntent#EXTRA_SEND_TO_EXTERNAL_DEFAULT_HANDLER}
+         * on the Custom Tab intent.
+         * <p>
+         * This is relevant when the redirect scheme is {@code https} (Android App Links). A Custom
+         * Tab intent created from a Custom Tabs session always targets the browser package
+         * explicitly, and Chrome versions prior to 120 interpret that as a request to keep the
+         * initial navigation chain inside the browser. When the {@code /authorize} request redirects
+         * straight to the callback URL without any user interaction, for example because the user
+         * already has a session or {@code prompt=none} is used, those Chrome versions load the
+         * callback URL in the Custom Tab instead of launching the app, and the user sees a
+         * "Not found." page. Enabling this option lets the redirect launch the app instead.
+         * <p>
+         * It has no effect on flows that already require user interaction, on Chrome 120 and
+         * later for redirects back to the calling app, or on the Auth Tab flow.
+         * By default, this option is disabled.
+         *
+         * @param enabled whether to allow the initial navigation chain to launch an external app.
+         * @return this same builder instance.
+         */
+        @NonNull
+        public Builder withSendToExternalDefaultHandlerEnabled(boolean enabled) {
+            this.sendToExternalDefaultHandlerEnabled = enabled;
+            return this;
+        }
+
+        /**
          * Create a new CustomTabsOptions instance with the customization settings.
          *
          * @return an instance of CustomTabsOptions with the customization settings.
@@ -504,7 +547,7 @@ public class CustomTabsOptions implements Parcelable {
             return new CustomTabsOptions(showTitle, toolbarColor, browserPicker, disabledCustomTabsPackages,
                     initialHeight, activityHeightResizeBehavior, toolbarCornerRadius,
                     initialWidth, sideSheetBreakpoint, backgroundInteractionEnabled, ephemeralBrowsing,
-                    authTab);
+                    sendToExternalDefaultHandlerEnabled, authTab);
         }
     }
 

--- a/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
+++ b/auth0/src/test/java/com/auth0/android/provider/CustomTabsOptionsTest.java
@@ -745,6 +745,51 @@ public class CustomTabsOptionsTest {
         assertEquals(intentNoExtras.getAction(), "android.intent.action.VIEW");
     }
 
+    // --- Send To External Default Handler ---
+
+    @Test
+    public void shouldSetSendToExternalDefaultHandlerEnabled() {
+        CustomTabsOptions options = CustomTabsOptions.newBuilder()
+                .withSendToExternalDefaultHandlerEnabled(true)
+                .build();
+        assertThat(options, is(notNullValue()));
+
+        Intent intent = options.toIntent(context, null);
+        assertThat(intent, is(notNullValue()));
+        assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_SEND_TO_EXTERNAL_DEFAULT_HANDLER), is(true));
+        assertThat(CustomTabsIntent.isSendToExternalDefaultHandlerEnabled(intent), is(true));
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        CustomTabsOptions parceledOptions = CustomTabsOptions.CREATOR.createFromParcel(parcel);
+        Intent parceledIntent = parceledOptions.toIntent(context, null);
+        assertThat(CustomTabsIntent.isSendToExternalDefaultHandlerEnabled(parceledIntent), is(true));
+    }
+
+    @Test
+    public void shouldNotSetSendToExternalDefaultHandlerByDefault() {
+        CustomTabsOptions options = CustomTabsOptions.newBuilder()
+                .build();
+        assertThat(options, is(notNullValue()));
+
+        Intent intent = options.toIntent(context, null);
+        assertThat(intent, is(notNullValue()));
+        assertThat(intent.hasExtra(CustomTabsIntent.EXTRA_SEND_TO_EXTERNAL_DEFAULT_HANDLER), is(false));
+        assertThat(CustomTabsIntent.isSendToExternalDefaultHandlerEnabled(intent), is(false));
+    }
+
+    @Test
+    public void shouldKeepSendToExternalDefaultHandlerWhenCopied() {
+        CustomTabsOptions options = CustomTabsOptions.newBuilder()
+                .withSendToExternalDefaultHandlerEnabled(true)
+                .build();
+
+        CustomTabsOptions copy = options.copyWithEphemeralBrowsing();
+        Intent intent = copy.toIntent(context, null);
+        assertThat(CustomTabsIntent.isSendToExternalDefaultHandlerEnabled(intent), is(true));
+    }
+
     // --- Auth Tab ---
 
     @Test


### PR DESCRIPTION
### Changes

When `WebAuthProvider` opens Universal Login in a Custom Tab, the Custom Tabs intent always targets the browser package explicitly (a Custom Tabs session implies it). Chrome interprets an intent that explicitly targets the browser as "the app wants to stay in the browser" and refuses to hand off redirects that happen in the *initial navigation chain* to another app, unless it trusts the calling app.

Until Chrome 120 (December 2023) that trust was only granted to Google-signed apps. On Chrome <= 119, when `/authorize` immediately 302-redirects to an `https` callback URL (Android App Links) — for example because the user already has an Auth0 session, or `prompt=none` is used — Chrome loads the callback URL inside the Custom Tab instead of launching the app. The tenant answers `404 Not found.`, which is what the user sees. Flows that involve user input (typing credentials) are not affected, because the input starts a new navigation chain with a user gesture.

Chrome has provided an opt-in escape hatch for exactly this case since Chrome 84: `CustomTabsIntent.EXTRA_SEND_TO_EXTERNAL_DEFAULT_HANDLER`. The androidx.browser javadoc describes it as: *"A Custom Tab Intent from a Custom Tab session will always have the package set, so the Intent will always be to the browser. This extra can be used to allow the initial Intent navigation chain to leave the browser."* `CustomTabsOptions` currently offers no way to set it.

This PR adds:

- `CustomTabsOptions.Builder#withSendToExternalDefaultHandlerEnabled(boolean)` (public API, default `false`, opt-in).
- When enabled, `CustomTabsOptions#toIntent` calls `CustomTabsIntent.Builder#setSendToExternalDefaultHandlerEnabled(true)`.
- Parcelable and `toBuilder()` round-trip support for the new flag.

Behavior is unchanged unless the option is enabled. The Auth Tab and TWA paths are not touched (Auth Tab handles the redirect itself; TWA is out of scope). The androidx.browser API used is available in the version already declared by the library (1.10.0).

Usage:

```kotlin
val ctOptions = CustomTabsOptions.newBuilder()
    .withSendToExternalDefaultHandlerEnabled(true)
    .build()

WebAuthProvider.login(account)
    .withCustomTabsOptions(ctOptions)
    .start(this, callback)
```

### References

- androidx.browser: `CustomTabsIntent#EXTRA_SEND_TO_EXTERNAL_DEFAULT_HANDLER`, `CustomTabsIntent.Builder#setSendToExternalDefaultHandlerEnabled`
- Chromium `components/external_intents/.../RedirectHandler.java`: `if (isCustomTabIntent && sendToExternalApps) preferToStayInChrome = false;` (present since Chrome 84)
- Chromium `ExternalNavigationHandler.java`: the "Launching intent explicitly targeted the browser." branch keeps http(s) redirects inside the browser
- Chromium `chrome/.../customtabs/CustomTabDelegateFactory.java`: `isForTrustedCallingApp` required `isGoogleSigned(mClientPackageName)` up to Chrome 119; gated by `TrustedClientGestureBypass` (enabled by default) from Chrome 120; unconditional from Chrome 136
- Community reports of the same symptom: https://community.auth0.com/t/android-not-found-error-when-using-social-login/82070 , https://community.auth0.com/t/auth0-android-authentication-does-not-work-properly-if-user-has-a-session/36606 , https://github.com/openid/AppAuth-Android/issues/248

### Testing

Unit tests added to `CustomTabsOptionsTest`:

- the extra is present when the option is enabled, and survives a Parcel round-trip
- the extra is absent by default
- the flag is preserved through `toBuilder()` (`copyWithEphemeralBrowsing()`)

I could not run the Gradle test suite locally (no Android SDK on the machine used for this change), so I am relying on this repository's CI for the unit tests and lint. The androidx.browser APIs used (`Builder#setSendToExternalDefaultHandlerEnabled`, `CustomTabsIntent#isSendToExternalDefaultHandlerEnabled`, `EXTRA_SEND_TO_EXTERNAL_DEFAULT_HANDLER`) were verified to exist in the `browser:1.10.0` artifact the library already depends on.

How to reproduce the underlying problem and verify the fix on a device:

1. App with `auth0Scheme = "https"` and verified Android App Links, on a device running Chrome <= 119.
2. Make sure an Auth0 session exists in Chrome (e.g. log in once on the web in Chrome on the same device), or use `prompt=none`.
3. Start `WebAuthProvider.login(...)`. Without the option, `/authorize` redirects straight to the callback URL and the Custom Tab shows `Not found.`. With `withSendToExternalDefaultHandlerEnabled(true)`, the app receives the callback.
4. On Chrome 120+ both variants behave the same (the app receives the callback).

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not — see above: unit tests are expected to run in CI; device verification of the Chrome <= 119 scenario is still pending on my side.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors (to be confirmed by CI on this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to allow Custom Tab navigation to open the device’s default handler when enabled.
  - The setting is available through the Custom Tabs configuration builder and remains preserved when configurations are copied or restored.
  - The option is disabled by default, maintaining existing navigation behavior unless explicitly enabled.

- **Bug Fixes**
  - Improved handling of authorization flows that redirect directly to an app callback URL on supported browser versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->