### PR TITLE
docs(examples): add Experiment Center override example

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -11,6 +11,7 @@ Each topic lives in its own file under [`examples/`](examples).
 - [Ephemeral Browsing](examples/ephemeral-browsing.md)
 - [Auth Tab](examples/auth-tab.md)
 - [DPoP](examples/dpop.md)
+- [Experiment Center](examples/experiment-center.md)
 - [Handling Configuration Changes During Authentication](examples/configuration-changes.md)
 
 ## Authentication API

--- a/examples/experiment-center.md
+++ b/examples/experiment-center.md
@@ -1,0 +1,89 @@
+# Experiment Center
+
+[Experiment Center](https://auth0.com/docs/customize/experiment-center/overview) is Auth0's A/B testing platform for authentication flows. It lets you split traffic across variants, measure results, and promote the winner — all inside Auth0.
+
+Pass `experiment_id` and `variation_id` via `withParameters()` to force a user into a specific variation for the login request, bypassing the server-side deterministic assignment. Both IDs are obtained from your Auth0 Dashboard or the Management API.
+
+```kotlin
+WebAuthProvider.login(account)
+    .withParameters(mapOf(
+        "experiment_id" to "<EXPERIMENT_ID>",
+        "variation_id" to "<VARIATION_ID>"
+    ))
+    .start(this, callback)
+```
+
+<details>
+  <summary>Using coroutines</summary>
+
+```kotlin
+WebAuthProvider.login(account)
+    .withParameters(mapOf(
+        "experiment_id" to "<EXPERIMENT_ID>",
+        "variation_id" to "<VARIATION_ID>"
+    ))
+    .await(this)
+```
+
+</details>
+
+<details>
+  <summary>Using Java</summary>
+
+```java
+WebAuthProvider.login(account)
+    .withParameters(new HashMap<String, Object>() {{
+        put("experiment_id", "<EXPERIMENT_ID>");
+        put("variation_id", "<VARIATION_ID>");
+    }})
+    .start(this, callback);
+```
+
+</details>
+
+When the experiment uses segment targeting, also pass `segment_id`:
+
+```kotlin
+WebAuthProvider.login(account)
+    .withParameters(mapOf(
+        "experiment_id" to "<EXPERIMENT_ID>",
+        "variation_id" to "<VARIATION_ID>",
+        "segment_id" to "<SEGMENT_ID>"
+    ))
+    .start(this, callback)
+```
+
+<details>
+  <summary>Using coroutines</summary>
+
+```kotlin
+WebAuthProvider.login(account)
+    .withParameters(mapOf(
+        "experiment_id" to "<EXPERIMENT_ID>",
+        "variation_id" to "<VARIATION_ID>",
+        "segment_id" to "<SEGMENT_ID>"
+    ))
+    .await(this)
+```
+
+</details>
+
+<details>
+  <summary>Using Java</summary>
+
+```java
+WebAuthProvider.login(account)
+    .withParameters(new HashMap<String, Object>() {{
+        put("experiment_id", "<EXPERIMENT_ID>");
+        put("variation_id", "<VARIATION_ID>");
+        put("segment_id", "<SEGMENT_ID>");
+    }})
+    .start(this, callback);
+```
+
+</details>
+
+> [!NOTE]
+> Experiment Center is an Enterprise feature. The override only applies to the current request — the next login without these parameters reverts to server-side deterministic assignment. Refer to the [Experiment Center documentation](https://auth0.com/docs/customize/experiment-center/overview) for setup instructions.
+>
+> Only `WebAuthProvider` login reaches Experiment Center. Embedded/native login and ROPG skip `/authorize` entirely and do not support experiment overrides.


### PR DESCRIPTION
### Changes

This is a **documentation-only** change adding usage guidance for [Experiment Center](https://auth0.com/docs/customize/experiment-center/overview), Auth0's A/B testing platform for authentication flows, ahead of its Early Access release.

Experiment Center already works with this SDK today — Auth0 honors `experiment_id`, `variation_id`, and `segment_id` as `/authorize` query parameters, and the existing `WebAuthProvider.Builder.withParameters(Map<String, Any?>)` method already forwards arbitrary parameters to `/authorize`. This PR documents how developers pass these three parameters to **force a specific experiment variation** on a Web Auth login request, bypassing the server-side deterministic assignment (useful for QA/test automation and for driving assignment from a flag/rollout tool).

- **Endpoints:** none added/changed
- **Classes and methods:** none added, deleted, deprecated, or changed — no source code changes
- **Docs added:**
  - New `examples/experiment-center.md` — shows forcing a variation via `withParameters()` with `experiment_id` + `variation_id`, and optionally `segment_id` for segment-targeted experiments. Includes Kotlin (callback), Kotlin (coroutine), and Java samples, plus a note that this is an Enterprise feature and only applies to `WebAuthProvider` (Universal Login) flows — embedded/native and ROPG do not reach `/authorize` and are unaffected.
  - Updated `EXAMPLES.md` — added a link to the new example under the **Web Auth** section.

### Testing

No functional code changed, so there is nothing to unit- or integration-test. The change touches only Markdown files. Reviewers should:

- Verify `examples/experiment-center.md` renders correctly and the code samples are accurate against the current `withParameters()` API.
- Verify the new link in `EXAMPLES.md` resolves to the new file.

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

> N/A — documentation-only change with no source modifications; existing tests are unaffected.


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Experiment Center example to the Web Auth documentation.
  * Documented how to select experiment variations during Android SDK login, including optional segment targeting.
  * Clarified supported login flows and that overrides apply only to the current request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->