### PR TITLE
docs: remove stale Early Access note from MFA Flexible Factors doc

### DIFF
--- a/examples/authentication-api/mfa-flexible-factors.md
+++ b/examples/authentication-api/mfa-flexible-factors.md
@@ -1,8 +1,5 @@
 ### MFA Flexible Factors Grant
 
-> [!IMPORTANT]
-> Multi Factor Authentication support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative.
-
 The MFA Flexible Factors Grant allows you to handle MFA challenges during the authentication flow when users sign in to MFA-enabled connections. This feature requires your Application to have the *MFA* grant type enabled. Check [this article](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
 
 #### Understanding the mfa_required Error Payload


### PR DESCRIPTION
## Summary

Removes a stale "Early Access — contact your Auth0 representative" banner from the MFA Flexible Factors Grant example doc. The MFA client API it warns about (`MfaApiClient`, `MfaEnrollmentType`, `MfaVerificationType`, `MfaRequiredErrorPayload`, `MfaRequirements`, etc.) is GA and has been for a while:

- Old MFA APIs deprecated in #932, removed in #947 (breaking) — the current `MfaApiClient` surface is the replacement, not a preview of it.
- Actively maintained since: DPoP support added for MFA APIs (#992), `getAuthenticators` filtering fix (#998), `MfaRequiredErrorPayload` optionality fix (#1272).
- Confirmed against the published `com.auth0.android:auth0:4.0.1` Maven artifact — every class/method this doc references (`MfaApiClient.getAuthenticators/enroll/challenge/verify`, `MfaEnrollmentType.Otp`, `MfaVerificationType.Oob`/`.Otp`, `MfaException.MfaChallengeException`/`MfaVerifyException`, `TotpEnrollmentChallenge.barcodeUri`) is compiled into the jar with matching signatures.

The banner appears to be leftover copy from before the feature graduated to GA, and it survived the most recent edit to this file (`docs: correct MFA getAuthenticators snippet for enroll flow`, 2026-08-28).

## Why this matters beyond docs accuracy

This file is the canonical MFA reference an AI coding-agent skill (`auth0/agent-skills`) points at for Auth0.Android MFA integration tasks. Running two different LLMs (`gpt-5.6-terra` via Codex, `claude-sonnet-5` via Claude Code) against an eval that uses this exact doc showed the stale banner actively causing problems downstream:

- Both models, on reading "Early Access, contact your representative," independently distrusted the doc and spent significant extra tool calls re-verifying the API against the real SDK before writing code (one decompiled the published `.aar` and ran `javap`; the other made ~20 separate `curl` calls fetching individual `.kt` source files from GitHub, plus the CHANGELOG and a GitHub code-search query, to confirm each class/method actually shipped).
- An LLM-as-judge grader evaluating the resulting code took the banner's implication at face value and flagged the (correct, real, decompiled-and-confirmed) API surface as "fabricated" / "predates the MFA client API" — a false failure, since every symbol is genuinely present in the 4.0.1 release.

Removing the stale banner removes the ambiguity that triggers this distrust-and-reverify behavior, for both AI agents and human readers who might otherwise assume the feature is gated when it isn't.

## Test plan

- [ ] Docs-only change; no code/build impact.
- [ ] Confirmed via `javap` against `com.auth0.android:auth0:4.0.1` that all referenced classes/methods exist with matching signatures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MFA Flexible Factors Grant documentation by removing the Early Access notice and related contact instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->